### PR TITLE
Readme markdown fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,3 @@ trim_trailing_whitespace = true
 
 [*.md]
 insert_final_newline = false
-trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -3,16 +3,14 @@
 </p>
 
 <p align="center">
-  <a href="https://modus-web-components.netlify.app/" target="_blank">
-    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg">
+  <a href="https://modus-web-components.trimble.com/" target="_blank">
+    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg" alt>
   </a>
-
-  <a href="https://github.com/trimble-oss/modus-web-components/releases/tag/v0.0.19">
-    <img src="https://img.shields.io/badge/latest%20version-v0.0.20-%230063a3" />
+  <a href="https://github.com/trimble-oss/modus-web-components/releases">
+    <img src="https://img.shields.io/badge/latest%20version-v0.0.20-%230063a3" alt/>
   </a>
-  
-  <a href="https://app.netlify.com/sites/modus-web-components/deploys"> 
-  <img src="https://api.netlify.com/api/v1/badges/c9f1de7d-daf8-4dd4-876d-4aa36a077213/deploy-status" />
+  <a href="https://app.netlify.com/sites/modus-web-components/deploys">
+    <img src="https://api.netlify.com/api/v1/badges/c9f1de7d-daf8-4dd4-876d-4aa36a077213/deploy-status" alt/>
   </a>
 </p>
 

--- a/storybook/public/storybook-styles.css
+++ b/storybook/public/storybook-styles.css
@@ -1,8 +1,15 @@
 /* https://storybook.js.org/docs/react/configure/theming */
 
 body,
-.sbdocs {
-  color: #252a2e !important;
+#docs-root,
+#docs-root p,
+.sbdocs,
+.sbdocs-h1,
+.sbdocs-h2,
+.sbdocs-li,
+.sbdocs-p,
+.sbdocs-ul {
+  color: #252a2e;
 }
 
 .sbdocs-table thead tr th {
@@ -28,4 +35,8 @@ body,
 
 .token.comment {
   opacity: 0.8;
+}
+
+body .sbdocs a {
+  color: #217cbb;
 }


### PR DESCRIPTION
- Fix for links not appearing in blue (fixes: #328 )
- change URL on README to production URL rather than Netlify.app one
- Add alt tags to images (accessibility)
- `.editorconfig` minor fix so trailing spaces are trimmed in markdown files