### PR TITLE
Table formatting fixes

### DIFF
--- a/storybook/public/storybook-styles.css
+++ b/storybook/public/storybook-styles.css
@@ -12,6 +12,10 @@ body,
   color: #252a2e;
 }
 
+.sbdocs-table {
+  width: 100%;
+}
+
 .sbdocs-table thead tr th {
   color: #252a2e;
   background-color: #f1f1f6;
@@ -23,6 +27,11 @@ body,
 
 .sbdocs-table tbody tr td {
   border: 1px solid #b7b9c3;
+}
+
+.sbdocs-table tbody tr td:first-of-type {
+  max-width: 160px;
+  width: 160px;
 }
 
 .docblock-source {

--- a/storybook/stories/components/modus-progress-bar/modus-progress-bar-storybook-docs.mdx
+++ b/storybook/stories/components/modus-progress-bar/modus-progress-bar-storybook-docs.mdx
@@ -16,86 +16,16 @@
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The progress bar's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>background-color</td>
-        <td>The bar's background color</td>
-        <td>string</td>
-        <td></td>
-        <td>'#FFFFFF' (Trimble White)</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>color</td>
-        <td>The bar's color</td>
-        <td>string</td>
-        <td></td>
-        <td>'#005F9E' (Trimble Blue Mid)</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>max-value</td>
-        <td>The maximum value</td>
-        <td>number</td>
-        <td></td>
-        <td>100</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>min-value</td>
-        <td>The minimum value</td>
-        <td>number</td>
-        <td></td>
-        <td>0</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>text</td>
-        <td>The text displayed on the bar</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>text-color</td>
-        <td>The text color</td>
-        <td>string</td>
-        <td></td>
-        <td>'#FFFFFF' (Trimble White)</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>value</td>
-        <td>The progress value</td>
-        <td>number</td>
-        <td></td>
-        <td>0</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name               | Description                   | Type     | Options | Default Value                | Required |
+| ------------------ | ----------------------------- | -------- | ------- | ---------------------------- | -------- |
+| `aria-label`       | The progress bar's aria-label | `string` |         |                              |          |
+| `background-color` | The bar's background color    | `string` |         | `#FFFFFF` (Trimble White)    |          |
+| `color`            | The bar's color               | `string` |         | `#005F9E` (Trimble Blue Mid) |          |
+| `max-value`        | The maximum value             | `number` |         | 100                          |          |
+| `min-value `       | The minimum value             | `number` |         | 0                            |          |
+| `text`             | The text displayed on the bar | `string` |         |                              |          |
+| `text-color`       | The text color                | `string` |         | `#FFFFFF` (Trimble White)    |          |
+| `value`            | The progress value            | `number` |         | 0                            |          |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-radio-group/modus-radio-group-storybook-docs.mdx
+++ b/storybook/stories/components/modus-radio-group/modus-radio-group-storybook-docs.mdx
@@ -46,81 +46,18 @@ A new TypeScript typing has been provided named RadioButton defined as:
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>checked-id</td>
-        <td>The id of the checked radio button</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td>
-          <span class="material-icons">&#10004;</span>
-        </td>
-      </tr>
-      <tr>
-        <td>name</td>
-        <td>The name of the radio group</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td>
-          <span class="material-icons">&#10004;</span>
-        </td>
-      </tr>
-      <tr>
-        <td>radioButtons</td>
-        <td>The radio buttons</td>
-        <td>RadioButton[]</td>
-        <td></td>
-        <td></td>
-        <td>
-          <span class="material-icons">&#10004;</span>
-        </td>
-      </tr>
-      <tr>
-        <td>aria-label</td>
-        <td>The radio group's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name           | Description                        | Type            | Options | Default Value | Required |
+| -------------- | ---------------------------------- | --------------- | ------- | ------------- | -------- |
+| `checked-id`   | The id of the checked radio button | `string`        |         |               | ✔        |
+| `name`         | The name of the radio group        | `string`        |         |               | ✔        |
+| `radioButtons` | The radio buttons                  | `RadioButton[]` |         |               | ✔        |
+| `aria-label`   | The radio group's aria-label       | `string`        |         |               |          |
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>buttonClick</td>
-        <td>Fires on radio button click</td>
-        <td>The currently checked radio button</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name          | Description                 | Emits                              |
+| ------------- | --------------------------- | ---------------------------------- |
+| `buttonClick` | Fires on radio button click | The currently checked radio button |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
+++ b/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
@@ -145,24 +145,9 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>valueChange</td>
-        <td>Fires on value change</td>
-        <td>The value of the selected option</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name          | Description           | Emits                            |
+| ------------- | --------------------- | -------------------------------- |
+| `valueChange` | Fires on value change | The value of the selected option |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-slider/modus-slider-storybook-docs.mdx
+++ b/storybook/stories/components/modus-slider/modus-slider-storybook-docs.mdx
@@ -16,96 +16,21 @@
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The slider's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>disabled</td>
-        <td>Whether the slider is disabled</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>label</td>
-        <td>The slider's label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>max-value</td>
-        <td>The slider's maximum value</td>
-        <td>number</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>min-value</td>
-        <td>The slider's minimum value</td>
-        <td>number</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>value</td>
-        <td>The slider's value</td>
-        <td>number</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name         | Description                    | Type      | Options | Default Value | Required |
+| ------------ | ------------------------------ | --------- | ------- | ------------- | -------- |
+| `aria-label` | The slider's aria-label        | `string`  |         |               |          |
+| `disabled`   | Whether the slider is disabled | `boolean` |         | false         |          |
+| `label`      | The slider's label             | `string`  |         |               |          |
+| `max-value`  | The slider's maximum value     | `number`  |         |               |          |
+| `min-value`  | The slider's minimum value     | `number`  |         |               |          |
+| `value`      | The slider's value             | `number`  |         |               |          |
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>valueChange</td>
-        <td>Fires on value change</td>
-        <td>The slider's value</td>
-      </tr>
-      <tr>
-        <td>valueInput</td>
-        <td>Fires on value input</td>
-        <td>The input value</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name          | Description           | Emits              |
+| ------------- | --------------------- | ------------------ |
+| `valueChange` | Fires on value change | The slider's value |
+| `valueInput`  | Fires on value input  | The input value    |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-spinner/modus-spinner-storybook-docs.mdx
+++ b/storybook/stories/components/modus-spinner/modus-spinner-storybook-docs.mdx
@@ -26,38 +26,10 @@
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>color</td>
-        <td>The color of the spinner</td>
-        <td>string</td>
-        <td></td>
-        <td>'#005F9E' (Trimble Blue Mid)</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>size</td>
-        <td>The size of the spinner</td>
-        <td>string</td>
-        <td></td>
-        <td>'2rem'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name    | Description              | Type     | Options | Default Value                | Required |
+| ------- | ------------------------ | -------- | ------- | ---------------------------- | -------- |
+| `color` | The color of the spinner | `string` |         | `#005F9E` (Trimble Blue Mid) |          |
+| `size`  | The size of the spinner  | `string` |         | '2rem'                       |          |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-tabs/modus-tabs-storybook-docs.mdx
+++ b/storybook/stories/components/modus-tabs/modus-tabs-storybook-docs.mdx
@@ -41,69 +41,17 @@ A new TypeScript typing has been provided named Tab defined as:
 
 ### Properties
 
-<section class="properties">
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>tabs</td>
-        <td>The tabs' tabs</td>
-        <td>Tab[]</td>
-        <td></td>
-        <td></td>
-        <td>
-          <span class="material-icons">&#10004;</span>
-        </td>
-      </tr>
-      <tr>
-        <td>aria-label</td>
-        <td>The tabs' aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>size</td>
-        <td>The tabs' size</td>
-        <td>string</td>
-        <td>'medium', 'small</td>
-        <td>'medium'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name         | Description          | Type     | Options          | Default Value | Required |
+| ------------ | -------------------- | -------- | ---------------- | ------------- | -------- |
+| `tabs`       | The tabs' tabs       | `Tab[]`  |                  |               | ✔        |
+| `aria-label` | The tabs' aria-label | `string` |                  |               |          |
+| `size`       | The tabs' size       | `string` | 'medium', 'small | 'medium'      |          |
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>tabChange</td>
-        <td>Fires on tab change</td>
-        <td>The current tab</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name        | Description         | Emits           |
+| ----------- | ------------------- | --------------- |
+| `tabChange` | Fires on tab change | The current tab |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -26,163 +26,29 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The input's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>clearable</td>
-        <td>Whether the text input can be cleared</td>
-        <td>boolean</td>
-        <td></td>
-        <td>true</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>disabled</td>
-        <td>Whether the text input is disabled</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>error-text</td>
-        <td>The error text</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>helper-text</td>
-        <td>The helper text</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>include-search-icon</td>
-        <td>Whether to include the search icon</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>label</td>
-        <td>The text input label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>max-length</td>
-        <td>The maximum length of the value</td>
-        <td>number</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>min-length</td>
-        <td>The minimum length of the value</td>
-        <td>number</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>placeholder</td>
-        <td>The placeholder text</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>read-only</td>
-        <td>Whether the text input is read-only</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>required</td>
-        <td>Whether the text input is required</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>size</td>
-        <td>The size of the input</td>
-        <td>string</td>
-        <td>'medium', 'large'</td>
-        <td>'medium'</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>valid-text</td>
-        <td>The valid text</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>value</td>
-        <td>The text input string value</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name                  | Description                           | Type      | Options           | Default Value | Required |
+| --------------------- | ------------------------------------- | --------- | ----------------- | ------------- | -------- |
+| `aria-label`          | The input's aria-label                | `string`  |                   |               |          |
+| `clearable`           | Whether the text input can be cleared | `boolean` |                   | true          |          |
+| `disabled`            | Whether the text input is disabled    | `boolean` |                   | false         |          |
+| `error-text`          | The error text                        | `string`  |                   |               |          |
+| `helper-text`         | The helper text                       | `string`  |                   |               |          |
+| `include-search-icon` | Whether to include the search icon    | `boolean` |                   | false         |          |
+| `label`               | The text input label                  | `string`  |                   |               |          |
+| `max-length`          | The maximum length of the value       | `number`  |                   |               |          |
+| `min-length`          | The minimum length of the value       | `number`  |                   |               |          |
+| `placeholder`         | The placeholder text                  | `string`  |                   |               |          |
+| `read-onl`y           | Whether the text input is read-only   | `boolean` |                   | false         |          |
+| `required`            | Whether the text input is required    | `boolean` |                   | false         |          |
+| `size`                | The size of the input                 | `string`  | 'medium', 'large' | 'medium'      |          |
+| `valid-text`          | The valid text                        | `string`  |                   |               |          |
+| `value`               | The text input string value           | `string`  |                   |               |          |
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>valueChange</td>
-        <td>Fires on text input value change</td>
-        <td>string</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name          | Description                      | Emits    |
+| ------------- | -------------------------------- | -------- |
+| `valueChange` | Fires on text input value change | `string` |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-toast/modus-toast-storybook-docs.mdx
+++ b/storybook/stories/components/modus-toast/modus-toast-storybook-docs.mdx
@@ -67,75 +67,18 @@ import { Anchor } from "@storybook/addon-docs";
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The toast's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>dismissible</td>
-        <td>Whether the toast is dismissible</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>show-icon</td>
-        <td>Whether to show the toast's</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>type</td>
-        <td>The toast's type</td>
-        <td>string</td>
-        <td>'danger', 'dark', 'default', 'primary', 'secondary', 'success', 'tertiary', 'warning'</td>
-        <td>'default'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name          | Description                      | Type      | Options                                                                               | Default Value | Required |
+| ------------- | -------------------------------- | --------- | ------------------------------------------------------------------------------------- | ------------- | -------- |
+| `aria-label`  | The toast's aria-label           | `string`  |                                                                                       |               |
+| `dismissible` | Whether the toast is dismissible | `boolean` |                                                                                       | false         |
+| `show-icon`   | Whether to show the toast's      | `boolean` |                                                                                       | false         |
+| `type`        | The toast's type                 | `string`  | 'danger', 'dark', 'default', 'primary', 'secondary', 'success', 'tertiary', 'warning' | 'default'     |
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>dismissClick</td>
-        <td>Fires on dismiss click</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name           | Description            | Emits |
+| -------------- | ---------------------- | ----- |
+| `dismissClick` | Fires on dismiss click |       |
 
 ### Accessibility
 

--- a/storybook/stories/components/modus-tooltip/modus-tooltip-storybook-docs.mdx
+++ b/storybook/stories/components/modus-tooltip/modus-tooltip-storybook-docs.mdx
@@ -19,46 +19,11 @@ This component utilizes the slot element, allowing you to wrap anything with a t
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The tooltip's aria-label</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>text</td>
-        <td>The tooltip's text</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>position</td>
-        <td>The tooltip's position relative to the item it's wrapping</td>
-        <td>string</td>
-        <td>'bottom', 'left', 'right', 'top'</td>
-        <td>'top'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name         | Description                                               | Type     | Options                          | Default Value | Required |
+| ------------ | --------------------------------------------------------- | -------- | -------------------------------- | ------------- | -------- |
+| `aria-label` | The tooltip's aria-label                                  |          |                                  |               |          |
+| `text`       | The tooltip's text                                        | `string` |                                  |               |          |
+| `position`   | The tooltip's position relative to the item it's wrapping | `string` | 'bottom', 'left', 'right', 'top' | 'top'         |          |
 
 ### Accessibility
 


### PR DESCRIPTION
CSS added to tables to make 1st column equal width (looks a bit neater).
partial fix for #370
This PR updates half of them. I'll tackle the others in a later PR