### PR TITLE
Change `modus-badge` weight. Add new 'standard' `modus-list-item` size option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -213,7 +213,7 @@ export namespace Components {
         /**
           * (optional) The size of list item
          */
-        "size": 'condensed' | 'standard';
+        "size": 'condensed' | 'large' | 'standard';
         /**
           * (optional) The type of list item
          */
@@ -1091,7 +1091,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The size of list item
          */
-        "size"?: 'condensed' | 'standard';
+        "size"?: 'condensed' | 'large' | 'standard';
         /**
           * (optional) The type of list item
          */

--- a/src/components/modus-badge/modus-badge.scss
+++ b/src/components/modus-badge/modus-badge.scss
@@ -8,7 +8,7 @@ div.badge {
   color: $col_white;
   font-family: $primary-font;
   font-size: $rem-12px;
-  font-weight: $chip-font-weight;
+  font-weight: $badge-font-weight;
   height: 20px;
   padding: 0 8px;
   position: relative;

--- a/src/components/modus-list-item/modus-list-item.e2e.ts
+++ b/src/components/modus-list-item/modus-list-item.e2e.ts
@@ -46,6 +46,10 @@ describe('modus-list-item', () => {
     component.setProperty('size', 'condensed');
     await page.waitForChanges();
     expect(element).toHaveClass('small');
+
+    component.setProperty('size', 'large');
+    await page.waitForChanges();
+    expect(element).toHaveClass('large');
   });
 
   it('emits itemClick event on li click', async () => {

--- a/src/components/modus-list-item/modus-list-item.scss
+++ b/src/components/modus-list-item/modus-list-item.scss
@@ -6,7 +6,7 @@ li {
   font-family: $primary-font;
   font-size: $rem-16px;
   min-height: $list-group-item-height;
-  padding: $rem-2px $rem-16px;
+  padding: 0 $rem-16px;
 
   .slot {
     overflow: hidden;
@@ -25,7 +25,10 @@ li {
   &.small {
     font-size: $rem-12px;
     min-height: $list-group-item-height-sm;
-    padding: $rem-3px $rem-12px;
+  }
+
+  &.large {
+    min-height: $list-group-item-height-lg;
   }
 
   &.disabled {

--- a/src/components/modus-list-item/modus-list-item.spec.ts
+++ b/src/components/modus-list-item/modus-list-item.spec.ts
@@ -46,5 +46,8 @@ describe('modus-list-item', () => {
 
     className = modusListItem.classBySize.get('condensed');
     expect(className).toEqual('small');
+
+    className = modusListItem.classBySize.get('large');
+    expect(className).toEqual('large');
   });
 });

--- a/src/components/modus-list-item/modus-list-item.tsx
+++ b/src/components/modus-list-item/modus-list-item.tsx
@@ -15,7 +15,7 @@ export class ModusListItem {
   @Prop() selected: boolean;
 
   /** (optional) The size of list item */
-  @Prop() size: 'condensed' | 'standard' = 'standard';
+  @Prop() size: 'condensed' | 'large' | 'standard' = 'standard';
 
   /** (optional) The type of list item */
   @Prop() type: 'standard' = 'standard'; // Future support for 'checkbox' | 'icon' | 'menu' | 'standard' | 'switchLeft' | 'switchRight'
@@ -26,18 +26,17 @@ export class ModusListItem {
   classBySize: Map<string, string> = new Map([
     ['condensed', 'small'],
     ['standard', 'standard'],
+    ['large', 'large'],
   ]);
 
   render(): unknown {
     const containerClass = `${this.classBySize.get(this.size)} ${this.disabled ? 'disabled' : ''} ${this.selected ? 'selected' : ''}`;
-    const iconSize = this.size === 'standard' ? '22' : '18';
+    const iconSize = this.size === 'condensed' ? '18' : '22';
 
     return (
       <li class={containerClass} onClick={() => !this.disabled ? this.itemClick.emit() : null}>
         <span class="slot"><slot /></span>
-        {this.selected ?
-          <IconCheck size={iconSize} />
-        : null}
+        {this.selected && <IconCheck size={iconSize} />}
       </li>
     );
   }

--- a/src/components/modus-list-item/readme.md
+++ b/src/components/modus-list-item/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                    | Type                        | Default      |
-| ---------- | ---------- | ---------------------------------------------- | --------------------------- | ------------ |
-| `disabled` | `disabled` | (optional) Disables the list item              | `boolean`                   | `undefined`  |
-| `selected` | `selected` | (optional) The selected state of the list item | `boolean`                   | `undefined`  |
-| `size`     | `size`     | (optional) The size of list item               | `"condensed" \| "standard"` | `'standard'` |
-| `type`     | `type`     | (optional) The type of list item               | `"standard"`                | `'standard'` |
+| Property   | Attribute  | Description                                    | Type                                   | Default      |
+| ---------- | ---------- | ---------------------------------------------- | -------------------------------------- | ------------ |
+| `disabled` | `disabled` | (optional) Disables the list item              | `boolean`                              | `undefined`  |
+| `selected` | `selected` | (optional) The selected state of the list item | `boolean`                              | `undefined`  |
+| `size`     | `size`     | (optional) The size of list item               | `"condensed" \| "large" \| "standard"` | `'standard'` |
+| `type`     | `type`     | (optional) The type of list item               | `"standard"`                           | `'standard'` |
 
 
 ## Events

--- a/src/global/modus-variables.scss
+++ b/src/global/modus-variables.scss
@@ -388,8 +388,9 @@ $list-group-bg:                     ui-color('main-background') !default;
 $list-group-item-border-color:      ui-color('hover') !default;
 $list-group-item-outline-color:     ui-color('hover') !default;
 
-$list-group-item-height:            3rem !default; // 48px
-$list-group-item-height-sm:         2rem !default; // 32px
+$list-group-item-height-lg:            2.875rem !default; // 46px, 2px removed to account for border width
+$list-group-item-height:               2.375rem !default; // 38px, 2px removed to account for border width
+$list-group-item-height-sm:            1.875rem !default; // 30px, 2px removed to account for border width
 
 $list-group-item-padding-y:         $rem-7px !default;
 $list-group-item-padding-y-sm:      $rem-3px !default;

--- a/src/global/modus-variables.scss
+++ b/src/global/modus-variables.scss
@@ -338,6 +338,7 @@ $toast-border-radius:               $border-radius !default;
 // Badges
 
 $badge-font-size:                   $rem-12px !default;
+$badge-font-weight:                 700 !default;
 $badge-padding-y:                   calc((20px - #{$badge-font-size}) / 2) !default;
 $badge-padding-x:                   .5rem !default;
 

--- a/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
+++ b/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
@@ -13,22 +13,28 @@ Implementation Details
 ### Default
 
 <modus-list>
-  <modus-list-item>Default</modus-list-item>
-  <modus-list-item selected>Selected</modus-list-item>
-  <modus-list-item disabled>Disabled</modus-list-item>
   <modus-list-item size="condensed">Condensed</modus-list-item>
   <modus-list-item selected size="condensed">
     Condensed & Selected
+  </modus-list-item>
+  <modus-list-item>Default</modus-list-item>
+  <modus-list-item selected>Selected</modus-list-item>
+  <modus-list-item disabled>Disabled</modus-list-item>
+  <modus-list-item size="large">Large</modus-list-item>
+  <modus-list-item selected size="large">
+    Large & Selected
   </modus-list-item>
 </modus-list>
 
 ```html
 <modus-list>
+  <modus-list-item size="condensed">Condensed</modus-list-item>
+  <modus-list-item selected size="condensed">Condensed & Selected</modus-list-item>
   <modus-list-item>Default</modus-list-item>
   <modus-list-item selected>Selected</modus-list-item>
   <modus-list-item disabled>Disabled</modus-list-item>
-  <modus-list-item size="condensed">Condensed</modus-list-item>
-  <modus-list-item selected size="condensed">Condensed & Selected</modus-list-item>
+  <modus-list-item size="large">Large</modus-list-item>
+  <modus-list-item selected size="large">Large & Selected</modus-list-item>
 </modus-list>
 ```
 
@@ -69,7 +75,7 @@ Implementation Details
         <td>size</td>
         <td>The size of the list item</td>
         <td>string</td>
-        <td>'condensed', 'standard'</td>
+        <td>'condensed', 'large', 'standard'</td>
         <td>'standard'</td>
         <td></td>
       </tr>


### PR DESCRIPTION
## Description

This PR covers two items:
1. Updating the `modus-badge` to have a font-weight of 700.
2. Adding a third option to the `modus-list-item` component. This changes the default 'standard' size, and adds a new 'large' size.

Fixes #394
Closes #397 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

This has been tested manually in the StencilJS dev and Storybook environments, as well as unit and e2e code tested.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
