### PR TITLE
Update README badge links. Update Navbar docs info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,15 @@
   <a href="https://modus-web-components.trimble.com/" target="_blank">
     <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg" alt/>
   </a>
-  <a href="https://github.com/trimble-oss/modus-web-components/releases">
+  <a href="https://www.npmjs.com/package/@trimble-oss/modus-web-components">
     <img src="https://img.shields.io/github/package-json/v/trimble-oss/modus-web-components?color=blue" alt/>
   </a>
   <a href="https://app.netlify.com/sites/modus-web-components/deploys">
     <img src="https://api.netlify.com/api/v1/badges/c9f1de7d-daf8-4dd4-876d-4aa36a077213/deploy-status" alt/>
   </a>
-  <img src="https://img.shields.io/github/contributors/trimble-oss/modus-web-components?color=lightblue" alt/>
+  <a href="https://github.com/trimble-oss/modus-web-components/graphs/contributors">
+    <img src="https://img.shields.io/github/contributors/trimble-oss/modus-web-components?color=lightblue" alt/>
+  </a>
 </p>
 
 The [Trimble Modus Design System](https://modus.trimble.com/) describes the UX that Trimble wants to provide in its UI across its many applications. The benefits of using Modus include rapid prototyping, development efficiency, and UX consistency.

--- a/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -22,7 +22,8 @@ A new TypeScript typing has been provided named App defined as:
 Implementation Details
 
 - The only required navigation items are the product logo and the user menu. The rest are hidden by default.
-- If profile menu avatarUrl is provided it will take rendering preference over initials.
+- If a profile menu avatarUrl is provided it will take rendering preference over initials.
+    - If the provided avatarUrl fails to load, initials will be used as a fallback.
 
 ### Default
 
@@ -31,7 +32,6 @@ Implementation Details
 ```html
 <modus-navbar show-apps-menu show-help-menu show-main-menu show-notifications>
   <div slot="main">Render your own main menu.</div>
-  <div slot="help">Render your own help.</div>
   <div slot="notifications">Render your own notifications.</div>
 </modus-navbar>
 
@@ -107,14 +107,6 @@ Implementation Details
         <td></td>
       </tr>
       <tr>
-        <td>show-help-menu</td>
-        <td>Whether to show the help menu item</td>
-        <td>boolean</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
         <td>show-main-menu</td>
         <td>Whether to show the main menu item</td>
         <td>boolean</td>
@@ -125,6 +117,14 @@ Implementation Details
       <tr>
         <td>show-notifications</td>
         <td>Whether to show the notifications item</td>
+        <td>boolean</td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+      <tr>
+        <td>show-pendo-placeholder</td>
+        <td>Whether to show the placeholder for Pendo</td>
         <td>boolean</td>
         <td></td>
         <td></td>

--- a/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -23,7 +23,6 @@ export default {
 const Template = () => html`
   <modus-navbar show-apps-menu show-help-menu show-main-menu show-notifications>
     <div slot="main">Render your own main menu.</div>
-    <div slot="help">Render your own help.</div>
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>
   ${setNavbar()}
@@ -47,5 +46,4 @@ const setNavbar = () => {
 
   return tag;
 }
-
 


### PR DESCRIPTION
## Description

Updated the README badge links to link to appropriate pages.

Updated the Navbar's implementation info about the avatar falling back to initials if it fails to load. Removed the 'help' menu from the examples as that is no longer an option.

I was having issues getting the initial fallback to work when there were two Navbars on the same page. So I will only link this as a Reference to that Issue, not a Closer.

Closes #362
References #392 

## Type of change

- [X] Documentation update

## How Has This Been Tested?

Manually running the Storybook site


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
