### PR TITLE
Add password option to Modus Text Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-### Added
-- Added angular-workspace project directory to house the generated angular wrapper components
-- Added a 'size' input to the modus-progress-bar component. This includes a new 'compact' size.
 
-## [Unreleased]
+## [0.1.6] - 2022-19-06
 ### Added
 - Modus File Dropzone component.
 - Created modus-content-tree-item to aid content tree development.
+- Added angular-workspace project directory to house the generated angular wrapper components
+- Added a 'size' input to the modus-progress-bar component. This includes a new 'compact' size.
+- Added a 'type' input to the modus-text-component, allows values 'text' or 'password'.
 
 ### Changed
 Restructured the repo to allow for build generated angular and react components:

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -823,13 +823,13 @@ export declare interface ModusTextInput extends Components.ModusTextInput {
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value']
+  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
 })
 @Component({
   selector: 'modus-text-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value']
+  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.15.2"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -695,6 +695,10 @@ export namespace Components {
          */
         "size": 'medium' | 'large';
         /**
+          * (optional) The input's type.
+         */
+        "type": 'text' | 'password';
+        /**
           * (optional) The input's valid state text.
          */
         "validText": string;
@@ -1753,6 +1757,10 @@ declare namespace LocalJSX {
           * (optional) The input's size.
          */
         "size"?: 'medium' | 'large';
+        /**
+          * (optional) The input's type.
+         */
+        "type"?: 'text' | 'password';
         /**
           * (optional) The input's valid state text.
          */

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
@@ -138,6 +138,19 @@ describe('modus-text-input', () => {
     expect(required).not.toBeNull();
   });
 
+  it('renders changes to type', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-text-input></modus-text-input>');
+
+    const textInput = await page.find('modus-text-input');
+    textInput.setProperty('type', 'password');
+    await page.waitForChanges();
+
+    const input = await page.find('modus-text-input >>> input');
+    expect(input.getAttribute('type')).toEqual('password');
+  });
+
   it('renders changes to value', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -48,6 +48,9 @@ export class ModusTextInput {
   /** (optional) The input's size. */
   @Prop() size: 'medium' | 'large' = 'medium';
 
+  /** (optional) The input's type. */
+  @Prop() type: 'text' | 'password' = 'text';
+
   /** (optional) The input's valid state text. */
   @Prop() validText: string;
 
@@ -107,7 +110,7 @@ export class ModusTextInput {
                    readonly={this.readOnly}
                    ref={(el) => this.textInput = el as HTMLInputElement}
                    tabIndex={0}
-                   type="text"
+                   type={this.type}
                    value={this.value}/>
             {this.clearable && !this.readOnly && !!this.value
              ? <span class="icons clear">

--- a/stencil-workspace/src/components/modus-text-input/readme.md
+++ b/stencil-workspace/src/components/modus-text-input/readme.md
@@ -7,23 +7,24 @@
 
 ## Properties
 
-| Property            | Attribute             | Description                                                   | Type                  | Default     |
-| ------------------- | --------------------- | ------------------------------------------------------------- | --------------------- | ----------- |
-| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`              | `undefined` |
-| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`             | `true`      |
-| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`             | `undefined` |
-| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`              | `undefined` |
-| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`              | `undefined` |
-| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`             | `undefined` |
-| `label`             | `label`               | (optional) The input's label.                                 | `string`              | `undefined` |
-| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`              | `undefined` |
-| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`              | `undefined` |
-| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`              | `undefined` |
-| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`             | `undefined` |
-| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`             | `undefined` |
-| `size`              | `size`                | (optional) The input's size.                                  | `"large" \| "medium"` | `'medium'`  |
-| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`              | `undefined` |
-| `value`             | `value`               | (optional) The input's value.                                 | `string`              | `undefined` |
+| Property            | Attribute             | Description                                                   | Type                   | Default     |
+| ------------------- | --------------------- | ------------------------------------------------------------- | ---------------------- | ----------- |
+| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`               | `undefined` |
+| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`              | `true`      |
+| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`              | `undefined` |
+| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`               | `undefined` |
+| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`               | `undefined` |
+| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`              | `undefined` |
+| `label`             | `label`               | (optional) The input's label.                                 | `string`               | `undefined` |
+| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`               | `undefined` |
+| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`               | `undefined` |
+| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`               | `undefined` |
+| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`              | `undefined` |
+| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`              | `undefined` |
+| `size`              | `size`                | (optional) The input's size.                                  | `"large" \| "medium"`  | `'medium'`  |
+| `type`              | `type`                | (optional) The input's type.                                  | `"password" \| "text"` | `'text'`    |
+| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`               | `undefined` |
+| `value`             | `value`               | (optional) The input's value.                                 | `string`               | `undefined` |
 
 
 ## Events

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -14,6 +14,7 @@ This component is compatible with Angular reactive forms. This can be achieved t
 <modus-text-input label="Text Input Demo 4" placeholder="Placeholder" value="Value" error-text="Error Demo" include-search-icon></modus-text-input>
 <modus-text-input label="Text Input Demo 5" placeholder="Placeholder" value="Value" valid-text="Valid Demo" include-search-icon></modus-text-input>
 <modus-text-input label="Text Input Demo 6" placeholder="Placeholder" value="Value" size="large" include-search-icon></modus-text-input>
+<modus-text-input label="Text Input Demo Password" placeholder="Password" type="password"></modus-text-input>
 
 ```html
 <modus-text-input label="Text Input Demo 1" placeholder="Placeholder" include-search-icon required></modus-text-input>
@@ -22,27 +23,29 @@ This component is compatible with Angular reactive forms. This can be achieved t
 <modus-text-input label="Text Input Demo 4" placeholder="Placeholder" value="Value" error-text="Error Demo" include-search-icon></modus-text-input>
 <modus-text-input label="Text Input Demo 5" placeholder="Placeholder" value="Value" valid-text="Valid Demo" include-search-icon></modus-text-input>
 <modus-text-input label="Text Input Demo 6" placeholder="Placeholder" value="Value" size="large" include-search-icon></modus-text-input>
+<modus-text-input label="Text Input Demo Password" placeholder="Password" type="password"></modus-text-input>
 ```
 
 ### Properties
 
-| Name                  | Description                           | Type      | Options           | Default Value | Required |
-| --------------------- | ------------------------------------- | --------- | ----------------- | ------------- | -------- |
-| `aria-label`          | The input's aria-label                | `string`  |                   |               |          |
-| `clearable`           | Whether the text input can be cleared | `boolean` |                   | true          |          |
-| `disabled`            | Whether the text input is disabled    | `boolean` |                   | false         |          |
-| `error-text`          | The error text                        | `string`  |                   |               |          |
-| `helper-text`         | The helper text                       | `string`  |                   |               |          |
-| `include-search-icon` | Whether to include the search icon    | `boolean` |                   | false         |          |
-| `label`               | The text input label                  | `string`  |                   |               |          |
-| `max-length`          | The maximum length of the value       | `number`  |                   |               |          |
-| `min-length`          | The minimum length of the value       | `number`  |                   |               |          |
-| `placeholder`         | The placeholder text                  | `string`  |                   |               |          |
-| `read-onl`y           | Whether the text input is read-only   | `boolean` |                   | false         |          |
-| `required`            | Whether the text input is required    | `boolean` |                   | false         |          |
-| `size`                | The size of the input                 | `string`  | 'medium', 'large' | 'medium'      |          |
-| `valid-text`          | The valid text                        | `string`  |                   |               |          |
-| `value`               | The text input string value           | `string`  |                   |               |          |
+| Property            | Attribute             | Description                                                   | Type                   | Default     |
+| ------------------- | --------------------- | ------------------------------------------------------------- | ---------------------- | ----------- |
+| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`               | `undefined` |
+| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`              | `true`      |
+| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`              | `undefined` |
+| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`               | `undefined` |
+| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`               | `undefined` |
+| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`              | `undefined` |
+| `label`             | `label`               | (optional) The input's label.                                 | `string`               | `undefined` |
+| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`               | `undefined` |
+| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`               | `undefined` |
+| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`               | `undefined` |
+| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`              | `undefined` |
+| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`              | `undefined` |
+| `size`              | `size`                | (optional) The input's size.                                  | `"large", "medium"`  | `'medium'`  |
+| `type`              | `type`                | (optional) The input's type.                                  | `"password", "text"` | `'text'`    |
+| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`               | `undefined` |
+| `value`             | `value`               | (optional) The input's value.                                 | `string`               | `undefined` |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
@@ -100,6 +100,17 @@ export default {
         type: { summary: `'medium' | 'large'` },
       }
     },
+    type: {
+      control: {
+        options: ['text', 'password'],
+        type: 'select',
+      },
+      description: 'The input type',
+      table: {
+        defaultValue: { summary: `'text'` },
+        type: { summary: `'text' | 'password'` },
+      }
+    },
     validText: {
       name: 'valid-text',
       description: 'The text input\'s valid text',
@@ -128,7 +139,7 @@ export default {
   },
 };
 
-const Template = ({ ariaLabel, clearable, disabled, errorText, helperText, includeSearchIcon, label, maxLength, minLength, placeholder, readOnly, required, size, validText, value }) => html`
+const Template = ({ ariaLabel, clearable, disabled, errorText, helperText, includeSearchIcon, label, maxLength, minLength, placeholder, readOnly, required, size, type, validText, value }) => html`
   <modus-text-input
     aria-label=${ariaLabel}
     clearable=${clearable}
@@ -143,6 +154,7 @@ const Template = ({ ariaLabel, clearable, disabled, errorText, helperText, inclu
     read-only=${readOnly}
     required=${required}
     size=${size}
+    type=${type}
     valid-text=${validText}
     value=${value}
   ></modus-text-input>
@@ -163,6 +175,7 @@ Default.args = {
   readOnly: false,
   required: false,
   size: 'medium',
+  type: 'text',
   validText: '',
   value: 'Hello, text input!'
 };


### PR DESCRIPTION
## Description

Add a `type` input the Modus Text Input, which allows for either 'text' or 'password', changing the wrapped input type.

Closes #486

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## How Has This Been Tested?

Manually, unit and e2e.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
