### PR TITLE
Fixed Toast's ariaLabel, and added JSX output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.8] - 2022-24-07
+### Fixed
+- Fixed Toast's ariaLabel type.
+- Added JSX to types output.
+
 ## [0.1.7] - 2022-19-06
 ### Added
 - Input to change the modal's z-index.

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -715,7 +715,7 @@ export namespace Components {
         /**
           * (optional) The toast's aria-label.
          */
-        "ariaLabel": boolean;
+        "ariaLabel": string;
         /**
           * (optional) Whether the toast has a dismiss button.
          */
@@ -1782,7 +1782,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The toast's aria-label.
          */
-        "ariaLabel"?: boolean;
+        "ariaLabel"?: string;
         /**
           * (optional) Whether the toast has a dismiss button.
          */

--- a/stencil-workspace/src/components/modus-toast/modus-toast.tsx
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.tsx
@@ -14,7 +14,7 @@ import { IconClose } from '../icons/icon-close';
 })
 export class ModusToast {
   /** (optional) The toast's aria-label. */
-  @Prop() ariaLabel: boolean;
+  @Prop() ariaLabel: string;
 
   /** (optional) Whether the toast has a dismiss button. */
   @Prop() dismissible: boolean;

--- a/stencil-workspace/src/components/modus-toast/readme.md
+++ b/stencil-workspace/src/components/modus-toast/readme.md
@@ -9,7 +9,7 @@
 
 | Property      | Attribute     | Description                                        | Type                                                                                                  | Default     |
 | ------------- | ------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------- |
-| `ariaLabel`   | `aria-label`  | (optional) The toast's aria-label.                 | `boolean`                                                                                             | `undefined` |
+| `ariaLabel`   | `aria-label`  | (optional) The toast's aria-label.                 | `string`                                                                                              | `undefined` |
 | `dismissible` | `dismissible` | (optional) Whether the toast has a dismiss button. | `boolean`                                                                                             | `undefined` |
 | `showIcon`    | `show-icon`   | (optional) Whether to show the toasts' icon.       | `boolean`                                                                                             | `true`      |
 | `type`        | `type`        | (optional) The toasts' type.                       | `"danger" \| "dark" \| "default" \| "primary" \| "secondary" \| "success" \| "tertiary" \| "warning"` | `'default'` |

--- a/stencil-workspace/src/interfaces.d.ts
+++ b/stencil-workspace/src/interfaces.d.ts
@@ -1,2 +1,2 @@
-export { Components } from './components';
+export { Components, JSX } from './components';
 export { Crumb } from './components/modus-breadcrumb/modus-breadcrumb';


### PR DESCRIPTION
## Description

Added JSX output for React Component generation. Fixed the type of the Toast's ariaLabel, it shouldn't have been boolean.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Running tests, and manually building/packing the package

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
