### PR TITLE
Adds `inputmode` to modus-text-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed Toast's ariaLabel type.
 - Added JSX to types output.
+- Added inputmode option to modus-text-input components.
 
 ## [0.1.7] - 2022-19-06
 ### Added

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -823,13 +823,13 @@ export declare interface ModusTextInput extends Components.ModusTextInput {
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
+  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
 })
 @Component({
   selector: 'modus-text-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
+  inputs: ['ariaLabel', 'clearable', 'disabled', 'errorText', 'helperText', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/stencil-workspace/.prettierrc
+++ b/stencil-workspace/.prettierrc
@@ -1,5 +1,5 @@
 {
   "bracketSameLine": true,
   "printWidth": 220,
-  "singleQuote": false
+  "singleQuote": true
 }

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -671,6 +671,10 @@ export namespace Components {
          */
         "includeSearchIcon": boolean;
         /**
+          * (optional) The input's inputmode.
+         */
+        "inputmode": 'decimal' | 'email' | 'numeric' | 'search' | 'tel' | 'text' | 'url';
+        /**
           * (optional) The input's label.
          */
         "label": string;
@@ -743,6 +747,94 @@ export namespace Components {
          */
         "text": string;
     }
+}
+export interface ModusAccordionItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusAccordionItemElement;
+}
+export interface ModusAlertCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusAlertElement;
+}
+export interface ModusBreadcrumbCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusBreadcrumbElement;
+}
+export interface ModusButtonCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusButtonElement;
+}
+export interface ModusCheckboxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusCheckboxElement;
+}
+export interface ModusChipCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusChipElement;
+}
+export interface ModusContentTreeItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusContentTreeItemElement;
+}
+export interface ModusDropdownCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusDropdownElement;
+}
+export interface ModusFileDropzoneCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusFileDropzoneElement;
+}
+export interface ModusListItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusListItemElement;
+}
+export interface ModusModalCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusModalElement;
+}
+export interface ModusNavbarCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusNavbarElement;
+}
+export interface ModusNavbarProfileMenuCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusNavbarProfileMenuElement;
+}
+export interface ModusNumberInputCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusNumberInputElement;
+}
+export interface ModusPaginationCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusPaginationElement;
+}
+export interface ModusRadioGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusRadioGroupElement;
+}
+export interface ModusSelectCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusSelectElement;
+}
+export interface ModusSliderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusSliderElement;
+}
+export interface ModusSwitchCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusSwitchElement;
+}
+export interface ModusTabsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusTabsElement;
+}
+export interface ModusTextInputCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusTextInputElement;
+}
+export interface ModusToastCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusToastElement;
 }
 declare global {
     interface HTMLModusAccordionElement extends Components.ModusAccordion, HTMLStencilElement {
@@ -1002,11 +1094,11 @@ declare namespace LocalJSX {
         /**
           * An event that fires on every accordion close.
          */
-        "onClosed"?: (event: CustomEvent<any>) => void;
+        "onClosed"?: (event: ModusAccordionItemCustomEvent<any>) => void;
         /**
           * An event that fires on every accordion open.
          */
-        "onOpened"?: (event: CustomEvent<any>) => void;
+        "onOpened"?: (event: ModusAccordionItemCustomEvent<any>) => void;
         /**
           * (optional) The size of accordion item.
          */
@@ -1028,7 +1120,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires when the alert is dismissed
          */
-        "onDismissClick"?: (event: CustomEvent<any>) => void;
+        "onDismissClick"?: (event: ModusAlertCustomEvent<any>) => void;
         /**
           * (optional) The type of alert, sets the color and icon to render
          */
@@ -1064,7 +1156,7 @@ declare namespace LocalJSX {
         /**
           * (optional) An event that fires on breadcrumb click.
          */
-        "onCrumbClick"?: (event: CustomEvent<Crumb>) => void;
+        "onCrumbClick"?: (event: ModusBreadcrumbCustomEvent<Crumb>) => void;
     }
     interface ModusButton {
         /**
@@ -1086,7 +1178,7 @@ declare namespace LocalJSX {
         /**
           * (optional) An event that fires on button click.
          */
-        "onButtonClick"?: (event: CustomEvent<any>) => void;
+        "onButtonClick"?: (event: ModusButtonCustomEvent<any>) => void;
         /**
           * (optional) The size of the button.
          */
@@ -1130,7 +1222,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on checkbox click.
          */
-        "onCheckboxClick"?: (event: CustomEvent<boolean>) => void;
+        "onCheckboxClick"?: (event: ModusCheckboxCustomEvent<boolean>) => void;
         /**
           * (optional) The size of the button
          */
@@ -1160,11 +1252,11 @@ declare namespace LocalJSX {
         /**
           * An event that fires on chip click.
          */
-        "onChipClick"?: (event: CustomEvent<any>) => void;
+        "onChipClick"?: (event: ModusChipCustomEvent<any>) => void;
         /**
           * An event that fires on close icon click.
          */
-        "onCloseClick"?: (event: CustomEvent<any>) => void;
+        "onCloseClick"?: (event: ModusChipCustomEvent<any>) => void;
         /**
           * (optional) Whether to show the checkmark.
          */
@@ -1222,15 +1314,15 @@ declare namespace LocalJSX {
         /**
           * An event that first on item checkbox click
          */
-        "onCheckboxClick"?: (event: CustomEvent<boolean>) => void;
+        "onCheckboxClick"?: (event: ModusContentTreeItemCustomEvent<boolean>) => void;
         /**
           * An event that fires on item expand click
          */
-        "onExpandClick"?: (event: CustomEvent<boolean>) => void;
+        "onExpandClick"?: (event: ModusContentTreeItemCustomEvent<boolean>) => void;
         /**
           * An event that fires on item click
          */
-        "onItemClick"?: (event: CustomEvent<any>) => void;
+        "onItemClick"?: (event: ModusContentTreeItemCustomEvent<any>) => void;
         /**
           * (optional) The selected state of the item
          */
@@ -1252,7 +1344,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on dropdown close.
          */
-        "onDropdownClose"?: (event: CustomEvent<any>) => void;
+        "onDropdownClose"?: (event: ModusDropdownCustomEvent<any>) => void;
         /**
           * (optional) The placement of the dropdown in related to the toggleElement.
          */
@@ -1306,7 +1398,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires when files have been added or removed, regardless of whether they're valid.
          */
-        "onFiles"?: (event: CustomEvent<[File[], string | null]>) => void;
+        "onFiles"?: (event: ModusFileDropzoneCustomEvent<[File[], string | null]>) => void;
     }
     interface ModusList {
     }
@@ -1318,7 +1410,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on list item click
          */
-        "onItemClick"?: (event: CustomEvent<any>) => void;
+        "onItemClick"?: (event: ModusListItemCustomEvent<any>) => void;
         /**
           * (optional) The selected state of the list item
          */
@@ -1354,19 +1446,19 @@ declare namespace LocalJSX {
         /**
           * An event that fires on modal close.
          */
-        "onClosed"?: (event: CustomEvent<any>) => void;
+        "onClosed"?: (event: ModusModalCustomEvent<any>) => void;
         /**
           * An event that fires on modal open.
          */
-        "onOpened"?: (event: CustomEvent<any>) => void;
+        "onOpened"?: (event: ModusModalCustomEvent<any>) => void;
         /**
           * An event that fires on primary button click.
          */
-        "onPrimaryButtonClick"?: (event: CustomEvent<any>) => void;
+        "onPrimaryButtonClick"?: (event: ModusModalCustomEvent<any>) => void;
         /**
           * An event that fires on secondary button click.
          */
-        "onSecondaryButtonClick"?: (event: CustomEvent<any>) => void;
+        "onSecondaryButtonClick"?: (event: ModusModalCustomEvent<any>) => void;
         /**
           * (optional) The modal's primary button text.
          */
@@ -1388,11 +1480,11 @@ declare namespace LocalJSX {
         /**
           * An event that fires on product logo click.
          */
-        "onProductLogoClick"?: (event: CustomEvent<MouseEvent>) => void;
+        "onProductLogoClick"?: (event: ModusNavbarCustomEvent<MouseEvent>) => void;
         /**
           * An event that fires on profile menu sign out click.
          */
-        "onProfileMenuSignOutClick"?: (event: CustomEvent<MouseEvent>) => void;
+        "onProfileMenuSignOutClick"?: (event: ModusNavbarCustomEvent<MouseEvent>) => void;
         /**
           * (required) Product logo options.
          */
@@ -1443,7 +1535,7 @@ declare namespace LocalJSX {
         "avatarUrl"?: string;
         "email"?: string;
         "initials"?: string;
-        "onSignOutClick"?: (event: CustomEvent<MouseEvent>) => void;
+        "onSignOutClick"?: (event: ModusNavbarProfileMenuCustomEvent<MouseEvent>) => void;
         "reverse"?: boolean;
         "username"?: string;
     }
@@ -1479,7 +1571,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on input value change.
          */
-        "onValueChange"?: (event: CustomEvent<string>) => void;
+        "onValueChange"?: (event: ModusNumberInputCustomEvent<string>) => void;
         /**
           * (optional) The input's placeholder text.
          */
@@ -1517,7 +1609,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on page change.
          */
-        "onPageChange"?: (event: CustomEvent<number>) => void;
+        "onPageChange"?: (event: ModusPaginationCustomEvent<number>) => void;
         "size"?: 'large' | 'medium' | 'small';
     }
     interface ModusProgressBar {
@@ -1574,7 +1666,7 @@ declare namespace LocalJSX {
         /**
           * Fires on radio button click.
          */
-        "onButtonClick"?: (event: CustomEvent<string>) => void;
+        "onButtonClick"?: (event: ModusRadioGroupCustomEvent<string>) => void;
         /**
           * The radio buttons to render.
          */
@@ -1604,7 +1696,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on input value change.
          */
-        "onValueChange"?: (event: CustomEvent<unknown>) => void;
+        "onValueChange"?: (event: ModusSelectCustomEvent<unknown>) => void;
         /**
           * The options for the dropdown list.
          */
@@ -1654,11 +1746,11 @@ declare namespace LocalJSX {
         /**
           * An event that fires on slider value change.
          */
-        "onValueChange"?: (event: CustomEvent<string>) => void;
+        "onValueChange"?: (event: ModusSliderCustomEvent<string>) => void;
         /**
           * An event that fires on slider value input.
          */
-        "onValueInput"?: (event: CustomEvent<string>) => void;
+        "onValueInput"?: (event: ModusSliderCustomEvent<string>) => void;
         /**
           * (optional) The slider's value.
          */
@@ -1694,14 +1786,14 @@ declare namespace LocalJSX {
         /**
           * An event that fires on switch click.
          */
-        "onSwitchClick"?: (event: CustomEvent<boolean>) => void;
+        "onSwitchClick"?: (event: ModusSwitchCustomEvent<boolean>) => void;
     }
     interface ModusTabs {
         "ariaLabel"?: string;
         /**
           * An event that fires on tab change.
          */
-        "onTabChange"?: (event: CustomEvent<string>) => void;
+        "onTabChange"?: (event: ModusTabsCustomEvent<string>) => void;
         "size"?: 'medium' | 'small';
         /**
           * The tabs to render.
@@ -1734,6 +1826,10 @@ declare namespace LocalJSX {
          */
         "includeSearchIcon"?: boolean;
         /**
+          * (optional) The input's inputmode.
+         */
+        "inputmode"?: 'decimal' | 'email' | 'numeric' | 'search' | 'tel' | 'text' | 'url';
+        /**
           * (optional) The input's label.
          */
         "label"?: string;
@@ -1748,7 +1844,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires on input value change.
          */
-        "onValueChange"?: (event: CustomEvent<string>) => void;
+        "onValueChange"?: (event: ModusTextInputCustomEvent<string>) => void;
         /**
           * (optional) The input's placeholder text.
          */
@@ -1790,7 +1886,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires when the toast is dismissed
          */
-        "onDismissClick"?: (event: CustomEvent<any>) => void;
+        "onDismissClick"?: (event: ModusToastCustomEvent<any>) => void;
         /**
           * (optional) Whether to show the toasts' icon.
          */

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
@@ -99,6 +99,19 @@ describe('modus-text-input', () => {
     expect(searchIcon).not.toBeNull();
   });
 
+  it('renders changes to inputmode', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-text-input></modus-text-input>');
+
+    const textInput = await page.find('modus-text-input');
+    textInput.setProperty('inputmode', 'search');
+    await page.waitForChanges();
+
+    const input = await page.find('modus-text-input >>> input');
+    expect(input.getAttribute('inputmode')).toEqual('search');
+  });
+
   it('renders changes to label', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
@@ -55,6 +55,11 @@ describe('modus-text-input', () => {
     expect(modusTextInput.helperText).toBeFalsy();
   });
 
+  it('should default to no inputmode', async () => {
+    const modusTextInput = new ModusTextInput();
+    expect(modusTextInput.inputmode).toBeFalsy();
+  });
+
   it('should default to size medium', async () => {
     const modusTextInput = new ModusTextInput();
     expect(modusTextInput.size).toEqual('medium');

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -27,6 +27,9 @@ export class ModusTextInput {
   /** (optional) Whether the search icon is included. */
   @Prop() includeSearchIcon: boolean;
 
+  /** (optional) The input's inputmode. */
+  @Prop() inputmode: 'decimal' | 'email' | 'numeric' | 'search' | 'tel' | 'text' | 'url';
+
   /** (optional) The input's label. */
   @Prop() label: string;
 
@@ -103,6 +106,7 @@ export class ModusTextInput {
             {this.includeSearchIcon ? <IconSearch size="16" /> : null}
             <input class={`${this.includeSearchIcon ? 'has-left-icon' : ''} ${this.clearable ? 'has-right-icon' : null}`}
                    disabled={this.disabled}
+                   inputmode={this.inputmode}
                    maxlength={this.maxLength}
                    minlength={this.minLength}
                    onInput={(event) => this.handleOnInput(event)}

--- a/stencil-workspace/src/components/modus-text-input/readme.md
+++ b/stencil-workspace/src/components/modus-text-input/readme.md
@@ -7,24 +7,25 @@
 
 ## Properties
 
-| Property            | Attribute             | Description                                                   | Type                   | Default     |
-| ------------------- | --------------------- | ------------------------------------------------------------- | ---------------------- | ----------- |
-| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`               | `undefined` |
-| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`              | `true`      |
-| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`              | `undefined` |
-| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`               | `undefined` |
-| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`               | `undefined` |
-| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`              | `undefined` |
-| `label`             | `label`               | (optional) The input's label.                                 | `string`               | `undefined` |
-| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`               | `undefined` |
-| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`               | `undefined` |
-| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`               | `undefined` |
-| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`              | `undefined` |
-| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`              | `undefined` |
-| `size`              | `size`                | (optional) The input's size.                                  | `"large" \| "medium"`  | `'medium'`  |
-| `type`              | `type`                | (optional) The input's type.                                  | `"password" \| "text"` | `'text'`    |
-| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`               | `undefined` |
-| `value`             | `value`               | (optional) The input's value.                                 | `string`               | `undefined` |
+| Property            | Attribute             | Description                                                   | Type                                                                        | Default     |
+| ------------------- | --------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------- |
+| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`                                                                    | `undefined` |
+| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`                                                                   | `true`      |
+| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`                                                                   | `undefined` |
+| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`                                                                    | `undefined` |
+| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`                                                                    | `undefined` |
+| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`                                                                   | `undefined` |
+| `inputmode`         | `inputmode`           | (optional) The input's inputmode.                             | `"decimal" \| "email" \| "numeric" \| "search" \| "tel" \| "text" \| "url"` | `'text'`    |
+| `label`             | `label`               | (optional) The input's label.                                 | `string`                                                                    | `undefined` |
+| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`                                                                    | `undefined` |
+| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`                                                                    | `undefined` |
+| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`                                                                    | `undefined` |
+| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`                                                                   | `undefined` |
+| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`                                                                   | `undefined` |
+| `size`              | `size`                | (optional) The input's size.                                  | `"large" \| "medium"`                                                       | `'medium'`  |
+| `type`              | `type`                | (optional) The input's type.                                  | `"password" \| "text"`                                                      | `'text'`    |
+| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`                                                                    | `undefined` |
+| `value`             | `value`               | (optional) The input's value.                                 | `string`                                                                    | `undefined` |
 
 
 ## Events

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -28,24 +28,25 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 ### Properties
 
-| Property            | Attribute             | Description                                                   | Type                 | Default     |
-| ------------------- | --------------------- | ------------------------------------------------------------- | -------------------- | ----------- |
-| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`             | `undefined` |
-| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`            | `true`      |
-| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`            | `undefined` |
-| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`             | `undefined` |
-| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`             | `undefined` |
-| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`            | `undefined` |
-| `label`             | `label`               | (optional) The input's label.                                 | `string`             | `undefined` |
-| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`             | `undefined` |
-| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`             | `undefined` |
-| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`             | `undefined` |
-| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`            | `undefined` |
-| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`            | `undefined` |
-| `size`              | `size`                | (optional) The input's size.                                  | `"large", "medium"`  | `'medium'`  |
-| `type`              | `type`                | (optional) The input's type.                                  | `"password", "text"` | `'text'`    |
-| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`             | `undefined` |
-| `value`             | `value`               | (optional) The input's value.                                 | `string`             | `undefined` |
+| Property            | Attribute             | Description                                                   | Type                                                            | Default     |
+| ------------------- | --------------------- | ------------------------------------------------------------- | --------------------------------------------------------------- | ----------- |
+| `ariaLabel`         | `aria-label`          | (optional) The input's aria-label.                            | `string`                                                        | `undefined` |
+| `clearable`         | `clearable`           | (optional) Whether the input has a clear button.              | `boolean`                                                       | `true`      |
+| `disabled`          | `disabled`            | (optional) Whether the input is disabled.                     | `boolean`                                                       | `undefined` |
+| `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`                                                        | `undefined` |
+| `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`                                                        | `undefined` |
+| `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`                                                       | `undefined` |
+| `inputmode`         | `inputmode`           | (optional) The input's inputmode.                             | `"decimal", "email", "numeric", "search", "tel", "text", "url"` | `undefined` |
+| `label`             | `label`               | (optional) The input's label.                                 | `string`                                                        | `undefined` |
+| `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`                                                        | `undefined` |
+| `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`                                                        | `undefined` |
+| `placeholder`       | `placeholder`         | (optional) The input's placeholder text.                      | `string`                                                        | `undefined` |
+| `readOnly`          | `read-only`           | (optional) Whether the input's content is read-only           | `boolean`                                                       | `undefined` |
+| `required`          | `required`            | (optional) Whether the input is required.                     | `boolean`                                                       | `undefined` |
+| `size`              | `size`                | (optional) The input's size.                                  | `"large", "medium"`                                             | `'medium'`  |
+| `type`              | `type`                | (optional) The input's type.                                  | `"password", "text"`                                            | `'text'`    |
+| `validText`         | `valid-text`          | (optional) The input's valid state text.                      | `string`                                                        | `undefined` |
+| `value`             | `value`               | (optional) The input's value.                                 | `string`                                                        | `undefined` |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
@@ -48,6 +48,16 @@ export default {
         type: { summary: 'boolean' },
       }
     },
+    inputmode: {
+      control: {
+        options: ['decimal', 'email', 'numeric', 'search', 'tel', 'text', 'url'],
+        type: 'select',
+      },
+      description: 'The inputmode type',
+      table: {
+        type: { summary: `'decimal' | 'email' | 'numeric' | 'search' | 'tel' | 'text' | 'url'` },
+      }
+    },
     label: {
       description: 'The text input\'s label',
       table: {
@@ -139,7 +149,7 @@ export default {
   },
 };
 
-const Template = ({ ariaLabel, clearable, disabled, errorText, helperText, includeSearchIcon, label, maxLength, minLength, placeholder, readOnly, required, size, type, validText, value }) => html`
+const Template = ({ ariaLabel, clearable, disabled, errorText, helperText, includeSearchIcon, inputmode, label, maxLength, minLength, placeholder, readOnly, required, size, type, validText, value }) => html`
   <modus-text-input
     aria-label=${ariaLabel}
     clearable=${clearable}
@@ -147,6 +157,7 @@ const Template = ({ ariaLabel, clearable, disabled, errorText, helperText, inclu
     error-text=${errorText}
     helper-text=${helperText}
     include-search-icon=${includeSearchIcon}
+    inputmode=${inputmode}
     label=${label}
     max-length=${maxLength}
     min-length=${minLength}
@@ -168,6 +179,7 @@ Default.args = {
   errorText: '',
   helperText: '',
   includeSearchIcon: false,
+  inputmode: '',
   label: '',
   maxLength: 100,
   minLength: 0,


### PR DESCRIPTION
## Description

Fixes: https://github.com/trimble-oss/modus-web-components/issues/533

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
