### PR TITLE
Accordion and Modal spec updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,19 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 ## Unreleased
 
+- Added `role="button"` and `aria-label="Close"` to Modal Close button.
+- Correct font size for modal header and body text.
+- Correct font size for accordion header.
+
+## 0.1.9 - 2022-07-07
+
 ### Fixed
 
 - Fixed Modus Modal's sizing minimum sizing for mobile views.
 - Fixed aria-labels on Modus Progress Bar and Modus File Dropzone by moving to host elements.
 - Fixed Modus Dropdown closing issue, it now closes when you click outside.
 - Added inputmode option to modus-text-input components.
-- Add `cursor: pointer;` CSS to acccordion headers
+- Add `cursor: pointer;` CSS to acccordion headers.
 
 ## 0.1.8 - 2022-24-07
 

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.scss
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.scss
@@ -9,7 +9,7 @@
     align-items: center;
     display: inline-flex;
     cursor: pointer;
-    font-size: $rem-18px;
+    font-size: $rem-16px;
     font-weight: $font-weight-semi-bold;
     height: 48px;
 

--- a/stencil-workspace/src/components/modus-modal/modus-modal.scss
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.scss
@@ -3,6 +3,7 @@
   background-color: rgba(0, 0, 0, 0.4);
   color: $col_black;
   font-family: $primary-font;
+  font-size: $rem-14px;
   height: 100%;
   justify-content: center;
   left: 0;
@@ -32,7 +33,7 @@
     .header {
       align-items: center;
       display: flex;
-      font-size: $rem-18px;
+      font-size: $rem-16px;
       font-weight: $font-weight-semi-bold;
       height: 64px;
       justify-content: space-between;

--- a/stencil-workspace/src/components/modus-modal/modus-modal.spec.ts
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.spec.ts
@@ -13,7 +13,7 @@ describe('modus-modal', () => {
           <div class="hidden modus-modal overlay" role="dialog" style="z-index: 1;">
             <div class="content">
               <div class="header">
-                <div class="icon-close">
+                <div class="icon-close" role="button" aria-label="Close">
                   <svg class="icon-close" fill="none" height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
                     <g clip-path="url(#clip0)">
                       <path d="M19 7.30929L17.6907 6L12.5 11.1907L7.30929 6L6 7.30929L11.1907 12.5L6 17.6907L7.30929 19L12.5 13.8093L17.6907 19L19 17.6907L13.8093 12.5L19 7.30929Z" fill="#6A6976"></path>

--- a/stencil-workspace/src/components/modus-modal/modus-modal.tsx
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.tsx
@@ -88,8 +88,8 @@ export class ModusModal {
         <div class="content">
           <div class="header">
             {this.headerText}
-            <div class="icon-close" onClick={() => this.close()} >
-              <IconClose size="20"/>
+            <div class="icon-close" role="button" aria-label="Close" onClick={() => this.close()}>
+              <IconClose size="20" />
             </div>
           </div>
           <div class="body">

--- a/stencil-workspace/src/components/modus-text-input/readme.md
+++ b/stencil-workspace/src/components/modus-text-input/readme.md
@@ -15,7 +15,7 @@
 | `errorText`         | `error-text`          | (optional) The input's error state text.                      | `string`                                                                    | `undefined` |
 | `helperText`        | `helper-text`         | (optional) The input's helper text displayed below the input. | `string`                                                                    | `undefined` |
 | `includeSearchIcon` | `include-search-icon` | (optional) Whether the search icon is included.               | `boolean`                                                                   | `undefined` |
-| `inputmode`         | `inputmode`           | (optional) The input's inputmode.                             | `"decimal" \| "email" \| "numeric" \| "search" \| "tel" \| "text" \| "url"` | `'text'`    |
+| `inputmode`         | `inputmode`           | (optional) The input's inputmode.                             | `"decimal" \| "email" \| "numeric" \| "search" \| "tel" \| "text" \| "url"` | `undefined` |
 | `label`             | `label`               | (optional) The input's label.                                 | `string`                                                                    | `undefined` |
 | `maxLength`         | `max-length`          | (optional) The input's maximum length.                        | `number`                                                                    | `undefined` |
 | `minLength`         | `min-length`          | (optional) The input's minimum length.                        | `number`                                                                    | `undefined` |

--- a/stencil-workspace/storybook/stories/components/modus-modal/modus-modal-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-modal/modus-modal-storybook-docs.mdx
@@ -13,9 +13,9 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <Story id="components-modal--default" />
 
 ```html
-<modus-button color="primary">Open Modal</modus-button>
-<modus-modal header-text="Modus Modal" primary-button-text="Sweet!" secondary-button-text="Ahh okay...">
-  <p>Here is some modal content. Render anything here.</p>
+<modus-button color="primary">Open modal</modus-button>
+<modus-modal header-text="Modal title" primary-button-text="Save changes" secondary-button-text="Close">
+  <p>Modal body text goes here.</p>
 </modus-modal>
 
 <script>

--- a/stencil-workspace/storybook/stories/components/modus-modal/modus-modal.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-modal/modus-modal.stories.tsx
@@ -22,9 +22,9 @@ export default {
 };
 
 const Template = () => html`
-  <modus-button color="primary">Open Modal</modus-button>
-  <modus-modal header-text="Modus Modal" primary-button-text="Sweet!" secondary-button-text="Ahh okay...">
-    <p>Here is some modal content. Render anything here.</p>
+  <modus-button color="primary">Open modal</modus-button>
+  <modus-modal header-text="Modal title" primary-button-text="Save changes" secondary-button-text="Sweet!">
+    <p>Woo-hoo, you're reading this text in a modal!</p>
   </modus-modal>
   ${setScript()}
 `;


### PR DESCRIPTION
## Description

- Correct font size for accordion header
- Correct font size for modal header and body text
- Added `role="button"` and `aria-label="Close"` to Modal Close button (accessibility fix)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v103 on Windows 10

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
