### PR TITLE
Change dropdown example from 1 to 3 items

### DIFF
--- a/stencil-workspace/storybook/public/storybook-styles.css
+++ b/stencil-workspace/storybook/public/storybook-styles.css
@@ -49,3 +49,8 @@ body,
 body .sbdocs a {
   color: #217cbb;
 }
+
+/* Fixes code block z-index issue */
+pre .os-padding {
+  z-index: inherit !important;
+}

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
@@ -19,6 +19,8 @@
   </modus-button>
   <modus-list slot="dropdownList">
     <modus-list-item size="condensed">Item 1</modus-list-item>
+    <modus-list-item size="condensed">Item 2</modus-list-item>
+    <modus-list-item size="condensed">Item 3</modus-list-item>
   </modus-list>
 </modus-dropdown>
 
@@ -27,6 +29,8 @@
   <modus-button id="toggleElement" slot="dropdownToggle">Dropdown</modus-button>
   <modus-list slot="dropdownList">
     <modus-list-item size="condensed">Item 1</modus-list-item>
+    <modus-list-item size="condensed">Item 2</modus-list-item>
+    <modus-list-item size="condensed">Item 3</modus-list-item>
   </modus-list>
 </modus-dropdown>
 ```

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
@@ -25,6 +25,8 @@ const Template = () => html`
   <modus-button id="toggleElement" slot="dropdownToggle">Dropdown</modus-button>
   <modus-list slot="dropdownList">
     <modus-list-item size="condensed">Item 1</modus-list-item>
+    <modus-list-item size="condensed">Item 2</modus-list-item>
+    <modus-list-item size="condensed">Item 3</modus-list-item>
   </modus-list>
   </modus-dropdown>
 `;


### PR DESCRIPTION
Change dropdown example from 1 to 3 items to make it more real-world usage looking... also fix for z-index issue on code blocks.

PREVIEW: https://deploy-preview-558--modus-web-components.netlify.app/?path=/docs/components-dropdown--default

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
