### PR TITLE
Styles synced to match Modus style guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 - Remove _italic_ style from text input placeholder
 - Change disabled text input to lighter gray (from `$col_gray_3` to `$col_gray_1`)
 - Correct checkbox border color (from `$col_gray_6` to `$col_gray_4`)
+- Add border-radius to Modus Dropdowns
+- Correct bg color for disabled Modus number inputs
+- Correct Active color for Pagination (now `$col_blue_light`).
 
 ## 0.1.9 - 2022-07-07
 

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
@@ -7,6 +7,7 @@
   }
 
   .dropdown-list {
+    border-radius: $rem-2px;
     display: none;
     max-height: 200px;
     max-width: 300px;

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
@@ -101,10 +101,11 @@
     pointer-events: none;
 
     .input-container {
-      background-color: $col_gray_3;
+      background-color: $col_gray_1;
 
       input {
-        background-color: $col_gray_3;
+        background-color: $col_gray_1;
+        color: $col_gray_6;
       }
     }
   }

--- a/stencil-workspace/src/components/modus-pagination/modus-pagination.scss
+++ b/stencil-workspace/src/components/modus-pagination/modus-pagination.scss
@@ -25,7 +25,7 @@ nav {
 
       &.active {
         background-color: $col_blue_pale;
-        color: $col_trimble_blue;
+        color: $col_blue_light;
       }
 
       &.disabled {


### PR DESCRIPTION
## Description

- Add border-radius to Modus Dropdowns
- Modus number inputs has correct color bg when disabled
- Pagination active color is now `$col_blue_light`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

locally windows 10 Edge v103

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
