### PR TITLE
Add empty alt tag to images in chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 ## Unreleased
 
+- Images in Modus Chips now have an alt tag for improve accessibility
+
 ## 0.1.10 - 2022-19-07
 
 ### Added
+
 - Added `role="button"` and `aria-label="Close"` to Modal Close button.
 
 ### Fixed
+
 - Correct font size for modal header and body text.
 - Correct font size for accordion header.
 - Change Accordion items border from 2px to 1px

--- a/stencil-workspace/src/components/modus-chip/modus-chip.tsx
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.tsx
@@ -101,7 +101,7 @@ export class ModusChip {
         onClick={this.disabled ? null : (event) => this.onChipClick(event)}
         tabIndex={0}>
         {
-          this.imageUrl ? <img src={this.imageUrl}/> :
+          this.imageUrl ? <img src={this.imageUrl} alt=""/> :
           this.showCheckmark ? <IconCheck size={'24'}></IconCheck> :
           null
         }

--- a/stencil-workspace/storybook/stories/components/modus-chip/modus-chip-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-chip/modus-chip-storybook-docs.mdx
@@ -40,120 +40,24 @@ import { Anchor } from "@storybook/addon-docs";
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The chip's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>chip-style</td>
-        <td>The chip's style</td>
-        <td>string</td>
-        <td>'outline', 'solid'</td>
-        <td>'solid'</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>disabled</td>
-        <td>Whether the chip is disabled</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>has-error</td>
-        <td>Whether the chip has an error</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>image-url</td>
-        <td>The chip's image url</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>show-checkmark</td>
-        <td>Whether to show the checkmark</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>show-close</td>
-        <td>Whether to show the close icon</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>size</td>
-        <td>The chip's size</td>
-        <td>string</td>
-        <td>'medium', 'large'</td>
-        <td>'medium'</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>value</td>
-        <td>The chip's value</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name           | Description                    | Type    | Options            | Default Value | Required |
+| -------------- | ------------------------------ | ------- | ------------------ | ------------- | -------- |
+| aria-label     | The chip's aria-label          | string  |                    |               |          |
+| chip-style     | The chip's style               | string  | 'outline', 'solid' | 'solid'       |          |
+| disabled       | Whether the chip is disabled   | boolean |                    | false         |          |
+| has-error      | Whether the chip has an error  | boolean |                    | false         |          |
+| image-url      | The chip's image url           | string  |                    |               |          |
+| show-checkmark | Whether to show the checkmark  | boolean |                    | false         |          |
+| show-close     | Whether to show the close icon | boolean |                    | false         |          |
+| size           | The chip's size                | string  | 'medium', 'large'  | 'medium'      |          |
+| value          | The chip's value               | string  |                    |               |          |
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>chipClick</td>
-        <td>Fires on chip click</td>
-        <td>KeyboardEvent, MouseEvent</td>
-      </tr>
-      <tr>
-        <td>closeClick</td>
-        <td>Fires on close icon click</td>
-        <td>KeyboardEvent, MouseEvent</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name       | Description               | Emits                     |
+| ---------- | ------------------------- | ------------------------- |
+| chipClick  | Fires on chip click       | KeyboardEvent, MouseEvent |
+| closeClick | Fires on close icon click | KeyboardEvent, MouseEvent |
 
 ### Accessibility
 


### PR DESCRIPTION
Fix for: Accessibility: Chips images don't have alternate text.
This adds an empty alt tag. I considered adding an option to add a custom alt text to the image but deemed it to not be worthwhile for now as the image is decorative and the text in the chip should suffice.

This PR also converts docs tables for chips to markdown tables.

with fix:

![image](https://user-images.githubusercontent.com/1212885/180457001-28420404-28cb-4a1c-b433-10617c97cb42.png)

without fix:

![image](https://user-images.githubusercontent.com/1212885/180457076-feaff43a-cae4-4cf2-8c96-febcdbe7086d.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
