### PR TITLE
Fix role="region" a11y issue with accordion-items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 ## Unreleased
 
-- Images in Modus Chips now have an alt tag for improve accessibility
+- Images in Modus Chips now have an alt tag for improve accessibility.
+- Removed unneeded `role="region"` from accordion-items.
 
 ## 0.1.10 - 2022-19-07
 

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.spec.ts
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.spec.ts
@@ -10,7 +10,7 @@ describe('modus-accordion-item', () => {
     expect(root).toEqualHtml(`
       <modus-accordion-item>
         <mock:shadow-root>
-          <div class="accordion-item" role="region">
+          <div class="accordion-item">
             <div class="header standard" tabindex="0">
               <span class="title"></span>
               <svg class="icon-chevron-down-thick" fill="currentColor" height="24" viewBox="0 0 32 32" width="24" xmlns="http://www.w3.org/2000/svg">
@@ -36,7 +36,7 @@ describe('modus-accordion-item', () => {
     expect(root).toEqualHtml(`
       <modus-accordion-item>
         <mock:shadow-root>
-          <div class="accordion-item" role="region">
+          <div class="accordion-item">
             <div class="header standard" tabindex="0">
               <span class="title"></span>
               <svg class="icon-chevron-down-thick" fill="currentColor" height="24" viewBox="0 0 32 32" width="24" xmlns="http://www.w3.org/2000/svg">

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
@@ -56,7 +56,7 @@ export class ModusAccordionItem {
     const bodyClass = `body ${sizeClass} ${this.expanded ? 'expanded' : ''}`;
 
     return (
-      <div aria-disabled={this.disabled} aria-expanded={this.expanded} class="accordion-item" role="region">
+      <div aria-disabled={this.disabled} aria-expanded={this.expanded} class="accordion-item">
         <div class={`header ${sizeClass} ${disabledClass}`} onClick={() => this.handleHeaderClick()} onKeyDown={(event) => this.handleKeydown(event)} tabIndex={0}>
           <span class="title">{this.headerText}</span>
           {this.expanded ? <IconChevronUpThick size={iconSize}></IconChevronUpThick> : <IconChevronDownThick size={iconSize}></IconChevronDownThick>}

--- a/stencil-workspace/storybook/stories/components/modus-accordion/modus-accordion-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-accordion/modus-accordion-storybook-docs.mdx
@@ -46,90 +46,20 @@ The `<modus-accordion-item>` utilizes the slot element, allowing you to render y
 
 ### Properties
 
-<section>
-  <h5>Modus Accordion Item</h5>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The accordion's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>disabled</td>
-        <td>Disables the accordion item</td>
-        <td>boolean</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>expanded</td>
-        <td>The expanded state of the accordion item</td>
-        <td>boolean</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>header-text</td>
-        <td>The text to render in the accordion item header</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>size</td>
-        <td>The size of the accordion item</td>
-        <td>string</td>
-        <td>'condensed', 'standard'</td>
-        <td>'standard'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name          | Description                                     | Type      | Options                 | Default Value | Required |
+| ------------- | ----------------------------------------------- | --------- | ----------------------- | ------------- | -------- |
+| `aria-label`  | The accordion's aria-label                      | `string`  |                         |               |          |
+| `disabled`    | Disables the accordion item                     | `boolean` |                         |               |          |
+| `expanded`    | The expanded state of the accordion item        | `boolean` |                         |               |          |
+| `header-text` | The text to render in the accordion item header | `string`  |                         |               |          |
+| `size`        | The size of the accordion item                  | `string`  | 'condensed', 'standard' | 'standard'    |          |
 
 ### DOM Events
 
-<section>
-  <h5>Modus Accordion Item</h5>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>closed</td>
-        <td>Fires on accordion item collapse</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>opened</td>
-        <td>Fires on accordion item expand</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name     | Description                      | Emits |
+| -------- | -------------------------------- | ----- |
+| `closed` | Fires on accordion item collapse |       |
+| `opened` | Fires on accordion item expand   |       |
 
 ### Accessibility
 


### PR DESCRIPTION
This removes the unneeded `role="region"` attribute from accordion-items.

See issue #594 for details

Netlify preview: https://deploy-preview-595--modus-web-components.netlify.app/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
