### PR TITLE
change ul to div to fix a11y issue with radio button group

### DIFF
--- a/stencil-workspace/src/components/modus-radio-group/modus-radio-group.scss
+++ b/stencil-workspace/src/components/modus-radio-group/modus-radio-group.scss
@@ -1,9 +1,7 @@
-ul {
-  border-radius: $rem-2px;
+div.modus-radio-group {
   display: flex;
   flex-direction: column;
   font-family: $primary-font;
-  list-style: none;
   margin: 0;
   padding: 0;
   position: relative;

--- a/stencil-workspace/src/components/modus-radio-group/modus-radio-group.spec.ts
+++ b/stencil-workspace/src/components/modus-radio-group/modus-radio-group.spec.ts
@@ -10,7 +10,7 @@ describe('modus-radio-group', () => {
     expect(root).toEqualHtml(`
       <modus-radio-group>
         <mock:shadow-root>
-          <div></div>
+          <div class="modus-radio-group"></div>
         </mock:shadow-root>
       </modus-radio-group>
     `);

--- a/stencil-workspace/src/components/modus-radio-group/modus-radio-group.spec.ts
+++ b/stencil-workspace/src/components/modus-radio-group/modus-radio-group.spec.ts
@@ -10,7 +10,7 @@ describe('modus-radio-group', () => {
     expect(root).toEqualHtml(`
       <modus-radio-group>
         <mock:shadow-root>
-          <ul></ul>
+          <div></div>
         </mock:shadow-root>
       </modus-radio-group>
     `);

--- a/stencil-workspace/src/components/modus-radio-group/modus-radio-group.tsx
+++ b/stencil-workspace/src/components/modus-radio-group/modus-radio-group.tsx
@@ -50,8 +50,8 @@ export class ModusRadioGroup {
 
   render(): unknown {
     return (
-      <ul aria-label={this.ariaLabel}>
-        {this.radioButtons.map(radioButton => {
+      <div class="modus-radio-group" aria-label={this.ariaLabel}>
+        {this.radioButtons.map((radioButton) => {
           return (
             <ModusRadioButton
               checked={radioButton.checked}
@@ -60,11 +60,10 @@ export class ModusRadioGroup {
               name={this.name}
               id={radioButton.id}
               handleButtonClick={(id) => this.handleButtonClick(id)}
-              handleKeydown={(event, id) => this.handleButtonKeydown(event, id)}>
-            </ModusRadioButton>
+              handleKeydown={(event, id) => this.handleButtonKeydown(event, id)}></ModusRadioButton>
           );
         })}
-      </ul>
+      </div>
     );
   }
 }


### PR DESCRIPTION
## Description

Change `ul` to `div` to fix a11y issue with radio button group.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Edge v103 on Windows 10

Screenshot of change: (note: no a11y violations!)

![image](https://user-images.githubusercontent.com/1212885/181182251-a691e604-3cca-4407-8413-0b0e4c0cf352.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
