### PR TITLE
Update available button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 ### Fixed
 
 - Modus Chips active state color is now blue
+- Remove unused Warning button and make Primary button the default
 
 ## 0.1.11 - 2022-05-08
 

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -93,7 +93,7 @@ export namespace Components {
         /**
           * (optional) The color of the button.
          */
-        "color": 'danger' | 'default' | 'primary' | 'secondary' | 'warning';
+        "color": 'danger' | 'primary' | 'secondary' | 'tertiary';
         /**
           * (optional) Disables the button.
          */
@@ -1185,7 +1185,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The color of the button.
          */
-        "color"?: 'danger' | 'default' | 'primary' | 'secondary' | 'warning';
+        "color"?: 'danger' | 'primary' | 'secondary' | 'tertiary';
         /**
           * (optional) Disables the button.
          */

--- a/stencil-workspace/src/components/modus-button/modus-button.e2e.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.e2e.ts
@@ -28,7 +28,7 @@ describe('modus-button', () => {
     await page.setContent('<modus-button></modus-button>');
     const component = await page.find('modus-button');
     const element = await page.find('modus-button >>> button');
-    expect(element).toHaveClass('color-tertiary');
+    expect(element).toHaveClass('color-primary');
 
     component.setProperty('color', 'primary');
     await page.waitForChanges();

--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -122,23 +122,6 @@ button {
       background-color: $col_gray_2;
       border-color: $col_gray_2;
     }
-
-    &.color-warning {
-      background-color: $col_yellow;
-      border-color: $col_yellow;
-      color: $col_white;
-      fill: $col_white;
-    }
-
-    &.color-warning:hover:not([disabled]) {
-      background-color: $col_yellow_light;
-      border-color: $col_yellow_light;
-    }
-
-    &.color-warning:active:not([disabled]) {
-      background-color: $col_yellow_dark;
-      border-color: $col_yellow_dark;
-    }
   }
 
   &.style-outline {

--- a/stencil-workspace/src/components/modus-button/modus-button.spec.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.spec.ts
@@ -10,7 +10,7 @@ describe('modus-button', () => {
     expect(root).toEqualHtml(`
       <modus-button>
         <mock:shadow-root>
-          <button class="size-medium color-tertiary style-fill" role="button">
+          <button class="size-medium color-primary style-fill" role="button">
             <slot></slot>
           </button>
         </mock:shadow-root>
@@ -26,7 +26,7 @@ describe('modus-button', () => {
     expect(root).toEqualHtml(`
       <modus-button>
         <mock:shadow-root>
-          <button class="size-medium color-tertiary style-fill" role="button">
+          <button class="size-medium color-primary style-fill" role="button">
             <slot></slot>
           </button>
         </mock:shadow-root>
@@ -50,7 +50,7 @@ describe('modus-button', () => {
   it('should get the correct class by color', async () => {
     const modusButton = new ModusButton();
     let className = modusButton.classByColor.get(modusButton.color);
-    expect(className).toEqual('color-tertiary');
+    expect(className).toEqual('color-primary');
 
     className = modusButton.classByColor.get('danger');
     expect(className).toEqual('color-danger');
@@ -61,8 +61,8 @@ describe('modus-button', () => {
     className = modusButton.classByColor.get('secondary');
     expect(className).toEqual('color-secondary');
 
-    className = modusButton.classByColor.get('warning');
-    expect(className).toEqual('color-warning');
+    className = modusButton.classByColor.get('tertiary');
+    expect(className).toEqual('color-tertiary');
   });
 
   it('should get the correct class by size', async () => {

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -14,7 +14,7 @@ export class ModusButton {
   @Prop() buttonStyle: 'borderless' | 'fill' | 'outline' = 'fill';
 
   /** (optional) The color of the button. */
-  @Prop() color: 'danger' | 'default' | 'primary' | 'secondary' | 'warning' = 'default';
+  @Prop() color: 'danger' | 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   /** (optional) Disables the button. */
   @Prop() disabled: boolean;
@@ -37,10 +37,9 @@ export class ModusButton {
 
   classByColor: Map<string, string> = new Map([
     ['danger', 'color-danger'],
-    ['default', 'color-tertiary'],
     ['primary', 'color-primary'],
     ['secondary', 'color-secondary'],
-    ['warning', 'color-warning'],
+    ['tertiary', 'color-tertiary'],
   ]);
 
   classBySize: Map<string, string> = new Map([
@@ -68,11 +67,11 @@ export class ModusButton {
         aria-pressed={this.pressed}
         class={className}
         disabled={this.disabled}
-        onClick={() => !this.disabled ? this.buttonClick.emit() : null}
-        onKeyDown={() => this.pressed = true}
-        onKeyUp={() => this.pressed = false}
-        onMouseDown={() => this.pressed = true}
-        onMouseUp={() => this.pressed = false}
+        onClick={() => (!this.disabled ? this.buttonClick.emit() : null)}
+        onKeyDown={() => (this.pressed = true)}
+        onKeyUp={() => (this.pressed = false)}
+        onMouseDown={() => (this.pressed = true)}
+        onMouseUp={() => (this.pressed = false)}
         role="button">
         <slot />
       </button>

--- a/stencil-workspace/src/components/modus-button/readme.md
+++ b/stencil-workspace/src/components/modus-button/readme.md
@@ -7,13 +7,13 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                         | Type                                                             | Default     |
-| ------------- | -------------- | ----------------------------------- | ---------------------------------------------------------------- | ----------- |
-| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label. | `string`                                                         | `undefined` |
-| `buttonStyle` | `button-style` | (optional) The style of the button  | `"borderless" \| "fill" \| "outline"`                            | `'fill'`    |
-| `color`       | `color`        | (optional) The color of the button. | `"danger" \| "default" \| "primary" \| "secondary" \| "warning"` | `'default'` |
-| `disabled`    | `disabled`     | (optional) Disables the button.     | `boolean`                                                        | `undefined` |
-| `size`        | `size`         | (optional) The size of the button.  | `"large" \| "medium" \| "small"`                                 | `'medium'`  |
+| Property      | Attribute      | Description                         | Type                                                 | Default     |
+| ------------- | -------------- | ----------------------------------- | ---------------------------------------------------- | ----------- |
+| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label. | `string`                                             | `undefined` |
+| `buttonStyle` | `button-style` | (optional) The style of the button  | `"borderless" \| "fill" \| "outline"`                | `'fill'`    |
+| `color`       | `color`        | (optional) The color of the button. | `"danger" \| "primary" \| "secondary" \| "tertiary"` | `'primary'` |
+| `disabled`    | `disabled`     | (optional) Disables the button.     | `boolean`                                            | `undefined` |
+| `size`        | `size`         | (optional) The size of the button.  | `"large" \| "medium" \| "small"`                     | `'medium'`  |
 
 
 ## Events

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
@@ -91,8 +91,8 @@ This component utilizes the slot element, allowing you to render your own HTML i
         <td>color</td>
         <td>The color of the button</td>
         <td>string</td>
-        <td>'danger', 'default', 'primary', 'secondary', 'warning'</td>
-        <td>'default'</td>
+        <td>'danger', 'primary', 'secondary', 'tertiary'</td>
+        <td>'primary'</td>
         <td></td>
       </tr>
       <tr>

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
@@ -7,10 +7,10 @@ export default {
   argTypes: {
     ariaLabel: {
       name: 'aria-label',
-      description: 'The button\'s aria-label',
+      description: "The button's aria-label",
       table: {
-        type: { summary: 'string' }
-      }
+        type: { summary: 'string' },
+      },
     },
     buttonStyle: {
       name: 'button-style',
@@ -22,25 +22,25 @@ export default {
       table: {
         defaultValue: { summary: `'fill'` },
         type: { summary: `'borderless' | 'fill' | 'outline'` },
-      }
+      },
     },
     color: {
       control: {
-        options: ['danger', 'default', 'primary', 'secondary', 'warning'],
+        options: ['danger', 'primary', 'secondary', 'tertiary'],
         type: 'select',
       },
       description: 'The color of the button',
       table: {
-        defaultValue: { summary: `'default'` },
-        type: { summary: `'danger' | 'default' | 'primary' | 'secondary' | 'warning'` },
-      }
+        defaultValue: { summary: `'primary'` },
+        type: { summary: `'danger' | 'primary' | 'secondary' | 'tertiary'` },
+      },
     },
     disabled: {
       description: 'Whether the button is disabled',
       table: {
         defaultValue: { summary: false },
         type: { summary: 'boolean' },
-      }
+      },
     },
     size: {
       control: {
@@ -51,8 +51,8 @@ export default {
       table: {
         defaultValue: { summary: `'medium'` },
         type: { summary: `'small' | 'medium' | 'large'` },
-      }
-    }
+      },
+    },
   },
   parameters: {
     controls: { expanded: true, sort: 'alpha' },
@@ -63,22 +63,15 @@ export default {
       page: docs,
     },
     options: {
-      isToolshown: true
+      isToolshown: true,
     },
   },
 };
 
 export const Default = ({ ariaLabel, buttonStyle, color, disabled, size }) => html`
-  <modus-button
-    aria-label=${ariaLabel}
-    button-style=${buttonStyle}
-    color=${color}
-    disabled=${disabled}
-    size=${size}>
-    Default
-  </modus-button>
+  <modus-button aria-label=${ariaLabel} button-style=${buttonStyle} color=${color} disabled=${disabled} size=${size}> Default </modus-button>
 `;
-Default.args = { ariaLabel: '', buttonStyle: 'fill', color: 'default', disabled: false, size: 'medium' };
+Default.args = { ariaLabel: '', buttonStyle: 'fill', color: 'primary', disabled: false, size: 'medium' };
 
 export const Borderless = ({ ariaLabel, buttonStyle, color, disabled, size }) => html`
   <modus-button


### PR DESCRIPTION
Remove (yellow) warning button color and make primary the default
Change button colors for docs

Fixes #635

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

locally with Edge v104

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
