### PR TITLE
Remove unneeded `@types/autoprefixer`

### DIFF
--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -16,7 +16,6 @@
         "@stencil/postcss": "^2.1.0",
         "@stencil/react-output-target": "^0.3.1",
         "@stencil/sass": "^1.5.2",
-        "@types/autoprefixer": "^10.2.0",
         "@types/jest": "^27.5.1",
         "@types/puppeteer": "^5.4.6",
         "@types/puppeteer-core": "^5.4.0",
@@ -1168,16 +1167,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@types/autoprefixer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@types/autoprefixer/-/autoprefixer-10.2.0.tgz",
-      "integrity": "sha512-ClU0uw3HhUra890K4xcf2IQxD6w0WOjPIaKb8jrRXYPHvvUW1P5dGufPlDtTo5gtWPWH+4L6tSBAoAKVf93uBQ==",
-      "deprecated": "This is a stub types definition. autoprefixer provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "autoprefixer": "*"
       }
     },
     "node_modules/@types/babel__core": {
@@ -7929,15 +7918,6 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
-    },
-    "@types/autoprefixer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@types/autoprefixer/-/autoprefixer-10.2.0.tgz",
-      "integrity": "sha512-ClU0uw3HhUra890K4xcf2IQxD6w0WOjPIaKb8jrRXYPHvvUW1P5dGufPlDtTo5gtWPWH+4L6tSBAoAKVf93uBQ==",
-      "dev": true,
-      "requires": {
-        "autoprefixer": "*"
-      }
     },
     "@types/babel__core": {
       "version": "7.1.19",

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -46,7 +46,6 @@
     "@stencil/postcss": "^2.1.0",
     "@stencil/react-output-target": "^0.3.1",
     "@stencil/sass": "^1.5.2",
-    "@types/autoprefixer": "^10.2.0",
     "@types/jest": "^27.5.1",
     "@types/puppeteer": "^5.4.6",
     "@types/puppeteer-core": "^5.4.0",


### PR DESCRIPTION
This was displaying in CLI log as a warning when included. Build completes successfully with it removed.

Fixes #613 

Note: I didn't add to CHANGELOG due to it being a dependency change which we usually don't mention.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Build completes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
