### PR TITLE
Barebones Modus Data Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 ## Unreleased
 
+### Added
+- Barebones Modus Data Table
+
 ### Fixed
 
 - Modus Chips active state color is now blue

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,8 @@ For more information about Stencil's testing, and a better distinction between t
 
 Run the tests with `npm run test`.
 
+To run a specific test, run `stencil test --spec --e2e --silent [test file name]`.
+
 ## Making Changes and Submitting a PR
 
 1. Before working on an issue, the repository should be forked with intent to contribute to the parent repository.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@
   <a href="https://www.npmjs.com/package/@trimble-oss/modus-web-components">
     <img src="https://img.shields.io/github/package-json/v/trimble-oss/modus-web-components?color=blue&filename=stencil-workspace%2Fpackage.json" alt/>
   </a>
-  <a href="https://app.netlify.com/sites/modus-web-components/deploys">
-    <img src="https://api.netlify.com/api/v1/badges/c9f1de7d-daf8-4dd4-876d-4aa36a077213/deploy-status" alt/>
-  </a>
   <a href="https://github.com/trimble-oss/modus-web-components/graphs/contributors">
     <img src="https://img.shields.io/github/contributors/trimble-oss/modus-web-components?color=lightblue" alt/>
   </a>

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -246,6 +246,34 @@ export class ModusChip {
   }
 }
 
+import type { ModusDataTableSortEvent as IModusDataTableModusDataTableSortEvent } from '@trimble-oss/modus-web-components';
+export declare interface ModusDataTable extends Components.ModusDataTable {
+  /**
+   *  
+   */
+  sort: EventEmitter<CustomEvent<IModusDataTableModusDataTableSortEvent>>;
+
+}
+
+@ProxyCmp({
+  defineCustomElementFn: undefined,
+  inputs: ['columns', 'data', 'size', 'sortOptions']
+})
+@Component({
+  selector: 'modus-data-table',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  inputs: ['columns', 'data', 'size', 'sortOptions']
+})
+export class ModusDataTable {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['sort']);
+  }
+}
+
 
 export declare interface ModusDropdown extends Components.ModusDropdown {
   /**

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
@@ -11,6 +11,7 @@ export const DIRECTIVES = [
   d.ModusCard,
   d.ModusCheckbox,
   d.ModusChip,
+  d.ModusDataTable,
   d.ModusDropdown,
   d.ModusFileDropzone,
   d.ModusList,

--- a/react-workspace/src/components/stencil-generated/index.ts
+++ b/react-workspace/src/components/stencil-generated/index.ts
@@ -17,6 +17,7 @@ export const ModusButton = /*@__PURE__*/createReactComponent<JSX.ModusButton, HT
 export const ModusCard = /*@__PURE__*/createReactComponent<JSX.ModusCard, HTMLModusCardElement>('modus-card');
 export const ModusCheckbox = /*@__PURE__*/createReactComponent<JSX.ModusCheckbox, HTMLModusCheckboxElement>('modus-checkbox');
 export const ModusChip = /*@__PURE__*/createReactComponent<JSX.ModusChip, HTMLModusChipElement>('modus-chip');
+export const ModusDataTable = /*@__PURE__*/createReactComponent<JSX.ModusDataTable, HTMLModusDataTableElement>('modus-data-table');
 export const ModusDropdown = /*@__PURE__*/createReactComponent<JSX.ModusDropdown, HTMLModusDropdownElement>('modus-dropdown');
 export const ModusFileDropzone = /*@__PURE__*/createReactComponent<JSX.ModusFileDropzone, HTMLModusFileDropzoneElement>('modus-file-dropzone');
 export const ModusList = /*@__PURE__*/createReactComponent<JSX.ModusList, HTMLModusListElement>('modus-list');

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -6,6 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Crumb } from "./components/modus-breadcrumb/modus-breadcrumb";
+import { ModusDataTableSortEvent, ModusTableSortOptions, TCell, TColumn, TRow } from "./components/modus-data-table/modus-data-table.models";
 import { App } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
 import { App as App1 } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
 import { RadioButton } from "./components/modus-radio-group/modus-radio-button";
@@ -180,6 +181,18 @@ export namespace Components {
           * (optional) The chip's value.
          */
         "value": string;
+    }
+    interface ModusDataTable {
+        "columns": string[] | TColumn[];
+        "data": TCell[][] | TRow[];
+        /**
+          * The size of the table.
+         */
+        "size"?: 'condensed' | 'standard';
+        /**
+          * Options for data table column sort.
+         */
+        "sortOptions"?: ModusTableSortOptions;
     }
     interface ModusDropdown {
         /**
@@ -780,6 +793,10 @@ export interface ModusChipCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusChipElement;
 }
+export interface ModusDataTableCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusDataTableElement;
+}
 export interface ModusDropdownCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusDropdownElement;
@@ -898,6 +915,12 @@ declare global {
     var HTMLModusChipElement: {
         prototype: HTMLModusChipElement;
         new (): HTMLModusChipElement;
+    };
+    interface HTMLModusDataTableElement extends Components.ModusDataTable, HTMLStencilElement {
+    }
+    var HTMLModusDataTableElement: {
+        prototype: HTMLModusDataTableElement;
+        new (): HTMLModusDataTableElement;
     };
     interface HTMLModusDropdownElement extends Components.ModusDropdown, HTMLStencilElement {
     }
@@ -1059,6 +1082,7 @@ declare global {
         "modus-card": HTMLModusCardElement;
         "modus-checkbox": HTMLModusCheckboxElement;
         "modus-chip": HTMLModusChipElement;
+        "modus-data-table": HTMLModusDataTableElement;
         "modus-dropdown": HTMLModusDropdownElement;
         "modus-file-dropzone": HTMLModusFileDropzoneElement;
         "modus-list": HTMLModusListElement;
@@ -1288,6 +1312,19 @@ declare namespace LocalJSX {
           * (optional) The chip's value.
          */
         "value"?: string;
+    }
+    interface ModusDataTable {
+        "columns"?: string[] | TColumn[];
+        "data"?: TCell[][] | TRow[];
+        "onSort"?: (event: ModusDataTableCustomEvent<ModusDataTableSortEvent>) => void;
+        /**
+          * The size of the table.
+         */
+        "size"?: 'condensed' | 'standard';
+        /**
+          * Options for data table column sort.
+         */
+        "sortOptions"?: ModusTableSortOptions;
     }
     interface ModusDropdown {
         /**
@@ -1944,6 +1981,7 @@ declare namespace LocalJSX {
         "modus-card": ModusCard;
         "modus-checkbox": ModusCheckbox;
         "modus-chip": ModusChip;
+        "modus-data-table": ModusDataTable;
         "modus-dropdown": ModusDropdown;
         "modus-file-dropzone": ModusFileDropzone;
         "modus-list": ModusList;
@@ -1984,6 +2022,7 @@ declare module "@stencil/core" {
             "modus-card": LocalJSX.ModusCard & JSXBase.HTMLAttributes<HTMLModusCardElement>;
             "modus-checkbox": LocalJSX.ModusCheckbox & JSXBase.HTMLAttributes<HTMLModusCheckboxElement>;
             "modus-chip": LocalJSX.ModusChip & JSXBase.HTMLAttributes<HTMLModusChipElement>;
+            "modus-data-table": LocalJSX.ModusDataTable & JSXBase.HTMLAttributes<HTMLModusDataTableElement>;
             "modus-dropdown": LocalJSX.ModusDropdown & JSXBase.HTMLAttributes<HTMLModusDropdownElement>;
             "modus-file-dropzone": LocalJSX.ModusFileDropzone & JSXBase.HTMLAttributes<HTMLModusFileDropzoneElement>;
             "modus-list": LocalJSX.ModusList & JSXBase.HTMLAttributes<HTMLModusListElement>;

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.e2e.ts
@@ -1,0 +1,268 @@
+import { E2EPage, newE2EPage } from '@stencil/core/testing';
+
+describe('modus-data-table', () => {
+  let page: E2EPage;
+
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent('<modus-data-table />');
+  });
+
+  it('renders', async () => {
+    const element = await page.find('modus-data-table');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('renders changes to column prop', async () => {
+    const component = await page.find('modus-data-table');
+    let header = await page.find('modus-data-table >>> th');
+    expect(header).toBeFalsy();
+
+    component.setProperty('columns', ['Column 1']);
+    await page.waitForChanges();
+    header = await page.find('modus-data-table >>> th');
+    expect(header).toBeTruthy();
+  });
+
+  it('renders changes to data prop', async () => {
+    const component = await page.find('modus-data-table');
+    let row = await page.find('modus-data-table >>> td');
+    expect(row).toBeFalsy();
+
+    component.setProperty('columns', ['Col1']);
+    component.setProperty('data', [{ col1: 'value 1' }]);
+    await page.waitForChanges();
+    row = await page.find('modus-data-table >>> td');
+    expect(row).toBeTruthy();
+  });
+
+  it('renders changes to size prop', async () => {
+    const component = await page.find('modus-data-table');
+    let size = await page.find('modus-data-table >>> .size-standard');
+    expect(size).toBeTruthy();
+
+    component.setProperty('columns', ['Col1']);
+    component.setProperty('size', 'condensed');
+    await page.waitForChanges();
+    size = await page.find('modus-data-table >>> .size-condensed');
+    expect(size).toBeTruthy();
+  });
+
+  it('renders with primitive columns and data', async () => {
+    const component = await page.find('modus-data-table');
+    let col = await page.find('modus-data-table >>> th');
+    let row = await page.find('modus-data-table >>> td');
+    expect(col).toBeFalsy();
+    expect(row).toBeFalsy();
+
+    component.setProperty('columns', ['Col1']);
+    component.setProperty('data', [['Val1']]);
+    await page.waitForChanges();
+    col = await page.find('modus-data-table >>> th');
+    row = await page.find('modus-data-table >>> td');
+    expect(col).toBeTruthy();
+    expect(row).toBeTruthy();
+  });
+
+  it('renders with primitive columns and object data', async () => {
+    const component = await page.find('modus-data-table');
+    let col = await page.find('modus-data-table >>> th');
+    let row = await page.find('modus-data-table >>> td');
+    expect(col).toBeFalsy();
+    expect(row).toBeFalsy();
+
+    component.setProperty('columns', ['Col1']);
+    component.setProperty('data', [{ col1: 'Val1' }]);
+    await page.waitForChanges();
+    col = await page.find('modus-data-table >>> th');
+    row = await page.find('modus-data-table >>> td');
+    expect(col).toBeTruthy();
+    expect(row).toBeTruthy();
+  });
+
+  it('renders with object columns and primitive data', async () => {
+    const component = await page.find('modus-data-table');
+    let col = await page.find('modus-data-table >>> th');
+    let row = await page.find('modus-data-table >>> td');
+    expect(col).toBeFalsy();
+    expect(row).toBeFalsy();
+
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val1']]);
+    await page.waitForChanges();
+    col = await page.find('modus-data-table >>> th');
+    row = await page.find('modus-data-table >>> td');
+    expect(col).toBeTruthy();
+    expect(row).toBeTruthy();
+  });
+
+  it('renders with object columns and data', async () => {
+    const component = await page.find('modus-data-table');
+    let col = await page.find('modus-data-table >>> th');
+    let row = await page.find('modus-data-table >>> td');
+    expect(col).toBeFalsy();
+    expect(row).toBeFalsy();
+
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [{ col1: 'Val1' }]);
+    await page.waitForChanges();
+    col = await page.find('modus-data-table >>> th');
+    row = await page.find('modus-data-table >>> td');
+    expect(col).toBeTruthy();
+    expect(row).toBeTruthy();
+  });
+
+  it('converts header text to single space title case', async () => {
+    const component = await page.find('modus-data-table');
+    let col = await page.find('modus-data-table >>> th');
+    expect(col).toBeFalsy();
+
+    component.setProperty('columns', ['some   TItLe wiTh  Weird Spacing AND   CasING']);
+    await page.waitForChanges();
+    col = await page.find('modus-data-table >>> th > div');
+    expect(col.innerHTML).toEqual('Some Title With Weird Spacing And Casing');
+  });
+
+  it('should apply column display', async () => {
+    const component = await page.find('modus-data-table');
+    let col = await page.find('modus-data-table >>> th');
+    expect(col).toBeFalsy();
+
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    await page.waitForChanges();
+    col = await page.find('modus-data-table >>> th > div');
+    expect(col.innerHTML).toEqual('Col1');
+  });
+
+  it('should apply column align', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    await page.waitForChanges();
+    let align = await page.find('modus-data-table >>> .align-left');
+    expect(align).toBeTruthy();
+
+    component.setProperty('columns', [{ display: 'Col1', align: 'right' }]);
+    await page.waitForChanges();
+    align = await page.find('modus-data-table >>> .align-right');
+    expect(align).toBeTruthy();
+  });
+
+  it('should apply column readonly', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val1']]);
+    await page.waitForChanges();
+    let readonly = await page.find('modus-data-table >>> .readonly');
+    expect(readonly).toBeTruthy();
+
+    component.setProperty('columns', [{ display: 'Col1', readonly: false }]);
+    await page.waitForChanges();
+    readonly = await page.find('modus-data-table >>> .readonly');
+    expect(readonly).toBeFalsy();
+  });
+
+  it('should output sort event on column header click with sort enabled', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val1'], ['Val2'], ['Val3']]);
+    component.setProperty('sortOptions', { canSort: true, serverSide: false});
+    await page.waitForChanges();
+    const sortEvent = await page.spyOnEvent('sort');
+
+    const header = await page.find('modus-data-table >>> th');
+    await header.click();
+    await header.click();
+    await header.click();
+
+    expect(sortEvent).toHaveReceivedEventTimes(3);
+  });
+
+  it('should not output sort event on column header click with sort disabled', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val1'], ['Val2'], ['Val3']]);
+    component.setProperty('sortOptions', { canSort: false, serverSide: false});
+    await page.waitForChanges();
+    const sortEvent = await page.spyOnEvent('sort');
+
+    const header = await page.find('modus-data-table >>> th');
+    await header.click();
+    await header.click();
+    await header.click();
+
+    expect(sortEvent).toHaveReceivedEventTimes(0);
+  });
+
+  it('should output sort event with correct sort direction (tri-state)', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val1'], ['Val2'], ['Val3']]);
+    component.setProperty('sortOptions', { canSort: true, serverSide: false});
+    await page.waitForChanges();
+    const sortEvent = await page.spyOnEvent('sort');
+
+    const header = await page.find('modus-data-table >>> th');
+    await header.click();
+    expect(sortEvent).toHaveReceivedEventDetail({ columnId: 'col1', direction: 'asc' });
+
+    await header.click();
+    expect(sortEvent).toHaveReceivedEventDetail({ columnId: 'col1', direction: 'desc' });
+
+    await header.click();
+    expect(sortEvent).toHaveReceivedEventDetail({ columnId: 'col1', direction: 'none' });
+    expect(sortEvent).toHaveReceivedEventTimes(3);
+  });
+
+  it('should sort rows if serverSide sort is false', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val2'], ['Val3'], ['Val1']]);
+    component.setProperty('sortOptions', { canSort: true, serverSide: false });
+    await page.waitForChanges();
+
+    const header = await page.find('modus-data-table >>> th');
+    await header.click();
+    await page.waitForChanges();
+
+    // Ascending sort
+    let cells = await page.findAll('modus-data-table >>> td');
+    expect(cells[0].innerHTML).toEqual('Val1');
+    expect(cells[1].innerHTML).toEqual('Val2');
+    expect(cells[2].innerHTML).toEqual('Val3');
+
+    await header.click();
+    await page.waitForChanges();
+
+    // Descending sort
+    cells = await page.findAll('modus-data-table >>> td');
+    expect(cells[0].innerHTML).toEqual('Val3');
+    expect(cells[1].innerHTML).toEqual('Val2');
+    expect(cells[2].innerHTML).toEqual('Val1');
+
+    await header.click();
+    await page.waitForChanges();
+
+    // No sort
+    cells = await page.findAll('modus-data-table >>> td');
+    expect(cells[0].innerHTML).toEqual('Val2');
+    expect(cells[1].innerHTML).toEqual('Val3');
+    expect(cells[2].innerHTML).toEqual('Val1');
+  });
+
+  it('should not sort rows if serverSide sort is false', async () => {
+    const component = await page.find('modus-data-table');
+    component.setProperty('columns', [{ display: 'Col1' }]);
+    component.setProperty('data', [['Val2'], ['Val3'], ['Val1']]);
+    component.setProperty('sortOptions', { canSort: true, serverSide: true });
+    await page.waitForChanges();
+
+    const header = await page.find('modus-data-table >>> th');
+    await header.click();
+    await page.waitForChanges();
+
+    const cells = await page.findAll('modus-data-table >>> td');
+    expect(cells[0].innerHTML).toEqual('Val2');
+    expect(cells[1].innerHTML).toEqual('Val3');
+    expect(cells[2].innerHTML).toEqual('Val1');
+  });
+});

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.models.ts
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.models.ts
@@ -1,0 +1,24 @@
+export type TCell = number | string | boolean;
+
+export type TRow = { [key: string]: TCell };
+
+export interface ModusDataTableSort {
+  columnId: string;
+  direction: 'asc' | 'desc' | 'none';
+}
+
+// eslint-disable-next-line
+export interface ModusDataTableSortEvent extends ModusDataTableSort {}
+
+export interface TColumn {
+  align?: 'left' | 'right';
+  display: string;
+  id?: string;
+  readonly?: boolean;
+  width?: string;
+}
+
+export interface ModusTableSortOptions {
+  canSort: boolean;
+  serverSide: boolean;
+}

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
@@ -1,0 +1,58 @@
+table, td, th {
+  border: $rem-1px $col_gray_4 solid;
+}
+
+table {
+  border-collapse: collapse;
+
+  th {
+    background-color: $col_gray_light;
+    color: $col_gray_8;
+    font-size: $rem-14px;
+    font-weight: $font-weight-semi-bold;
+    height: 3rem;
+
+    div {
+      padding: 0 $rem-4px;
+
+      &.align-left {
+        text-align: left;
+      }
+
+      &.align-right {
+        text-align: right;
+      }
+    }
+  }
+
+  tr {
+    color: $col_trimble_gray;
+    font-size: $rem-14px;
+    font-weight: $font-weight-semi-bold;
+    height: 3rem;
+
+    td {
+      background-color: $col_white;
+      padding: 0 $rem-4px;
+
+      &.align-left {
+        text-align: left;
+      }
+
+      &.align-right {
+        text-align: right;
+      }
+
+      &.readonly {
+        background-color: $col_gray_0;
+      }
+    }
+  }
+
+  &.size-condensed {
+    th,
+    tr {
+      height: 2rem;
+    }
+  }
+}

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.spec.ts
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.spec.ts
@@ -1,0 +1,107 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusDataTable } from './modus-data-table';
+import { ModusDataTableUtilities } from './modus-data-table.utilities';
+import { TColumn } from './modus-data-table.models';
+
+describe('modus-data-table', () => {
+  it('renders', async () => {
+    const { root } = await newSpecPage({
+      components: [ModusDataTable],
+      html: '<modus-data-table></modus-data-table>',
+    });
+    expect(root).toEqualHtml(`
+      <modus-data-table>
+        <mock:shadow-root>
+          <table class="size-standard">
+            <colgroup></colgroup>
+            <thead>
+              <tr></tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </mock:shadow-root>
+      </modus-data-table>
+    `);
+  });
+
+  it('should get the correct class by size', async () => {
+    const table = new ModusDataTable();
+    let className = table.classBySize.get(table.size);
+    expect(className).toEqual('size-standard');
+
+    className = table.classBySize.get('condensed');
+    expect(className).toEqual('size-condensed');
+  });
+
+  it('should convert column prop as string array to TColumn array', async () => {
+    const cols: TColumn[] = ModusDataTableUtilities.convertToTColumns(['name', 'age']);
+    expect(cols).toEqual([
+        { align: 'left', display: 'name', id: 'name', readonly: true, width: '' },
+        { align: 'left', display: 'age', id: 'age', readonly: true, width: '' }
+      ]
+    );
+  });
+
+  it('should convert column prop as TColumn array to TColumn array', async () => {
+    const cols: TColumn[] = ModusDataTableUtilities.convertToTColumns([
+      { display: 'name' },
+      { display: 'age' }
+    ]);
+    expect(cols).toEqual([
+        { align: 'left', display: 'name', id: 'name', readonly: true, width: '' },
+        { align: 'left', display: 'age', id: 'age', readonly: true, width: '' }
+      ]
+    );
+  });
+
+  it('should convert row prop as string array to TRow array', async () => {
+    const cols: TColumn[] = [
+      { align: 'left', display: 'Name', id: 'name', readonly: true, width: '' },
+      { align: 'left', display: 'Age', id: 'age', readonly: true, width: '' }
+    ];
+    const rows = ModusDataTableUtilities.convertToTRows([['John', 32], ['Joe', 28]], cols);
+    expect(rows).toEqual([
+      { name: 'John', age: 32 },
+      { name: 'Joe', age: 28 }
+    ]);
+  });
+
+  it('should convert row prop as TRow array to TRow array', async () => {
+    const cols: TColumn[] = [
+      { align: 'left', display: 'Name', id: 'name', readonly: true, width: '' },
+      { align: 'left', display: 'Age', id: 'age', readonly: true, width: '' }
+    ];
+    const rows = ModusDataTableUtilities.convertToTRows([
+      { name: 'John', age: 32 },
+      { name: 'Joe', age: 28 }
+    ], cols);
+    expect(rows).toEqual([
+      { name: 'John', age: 32 },
+      { name: 'Joe', age: 28 }
+    ]);
+  });
+
+  it('should sort data', async () => {
+    const rows = [
+      { name: 'John', age: 32 },
+      { name: 'Bo', age: 56 },
+      { name: 'Jane', age: 16 },
+    ];
+
+    const ascRowsByName = ModusDataTableUtilities.sortData(rows, 'name', 'asc');
+    const descRowsByName = ModusDataTableUtilities.sortData(rows, 'name', 'desc');
+    expect(ascRowsByName).toEqual([{ name: 'Bo', age: 56 }, { name: 'Jane', age: 16 }, { name: 'John', age: 32 }]);
+    expect(descRowsByName).toEqual([{ name: 'John', age: 32 }, { name: 'Jane', age: 16 }, { name: 'Bo', age: 56 }]);
+
+    const ascRowsByAge = ModusDataTableUtilities.sortData(rows, 'age', 'asc');
+    const descRowsByAge = ModusDataTableUtilities.sortData(rows, 'age', 'desc');
+    expect(ascRowsByAge).toEqual([{ name: 'Jane', age: 16 }, { name: 'John', age: 32 }, { name: 'Bo', age: 56 }]);
+    expect(descRowsByAge).toEqual([{ name: 'Bo', age: 56 }, { name: 'John', age: 32 }, { name: 'Jane', age: 16 }]);
+  });
+
+  it('should convert column header to single space title case', async () => {
+    const table = new ModusDataTable();
+    const headerText = table.convertToSingleSpaceTitleCase('some   TItLe wiTh  Weird Spacing AND   CasING');
+    expect(headerText).toEqual('Some Title With Weird Spacing And Casing');
+  });
+});

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.tsx
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.tsx
@@ -1,0 +1,129 @@
+// eslint-disable-next-line
+import { Component, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
+import { ModusDataTableUtilities } from './modus-data-table.utilities';
+import { TCell, TColumn, TRow, ModusTableSortOptions, ModusDataTableSort, ModusDataTableSortEvent } from './modus-data-table.models';
+
+@Component({
+  tag: 'modus-data-table',
+  styleUrl: 'modus-data-table.scss',
+  shadow: true,
+})
+export class ModusDataTable {
+  /* (required) The columns to display in the table. */
+  @Prop({ mutable: true }) columns: string[] | TColumn[];
+
+  /* (required) The data (rows) to display in the table. */
+  @Prop({ mutable: true }) data: TCell[][] | TRow[];
+  @Watch('data') dataChanged(_, oldValue: TCell[][] | TRow[]): void {
+    this.originalData = this.originalData ?? ModusDataTableUtilities.convertToTRows(oldValue, this.columns)?.slice();
+  }
+
+  /** The size of the table. */
+  @Prop() size?: 'condensed' | 'standard' = 'standard';
+
+  /** Options for data table column sort. */
+  @Prop() sortOptions?: ModusTableSortOptions = {
+    canSort: false,
+    serverSide: false,
+  };
+
+  @Event() sort: EventEmitter<ModusDataTableSortEvent>;
+
+  @State() sortState: ModusDataTableSort = {
+    columnId: '',
+    direction: 'none'
+  };
+
+  classBySize: Map<string, string> = new Map([
+    ['condensed', 'size-condensed'],
+    ['standard', 'size-standard'],
+  ]);
+  originalData: TRow[];
+
+  componentWillLoad() {
+    this.convertColumnsAndRows();
+  }
+
+  componentDidLoad() {
+    this.originalData = (this.data as TRow[])?.slice();
+  }
+
+  componentWillUpdate() {
+    this.convertColumnsAndRows();
+  }
+
+  convertColumnsAndRows() {
+    this.columns = ModusDataTableUtilities.convertToTColumns(this.columns);
+    this.data = ModusDataTableUtilities.convertToTRows(this.data, this.columns);
+  }
+
+  convertToSingleSpaceTitleCase(title: string): string {
+    return title?.replace(/\w\S*/g, (word) => {
+      return word.charAt(0).toUpperCase() + word.substring(1).toLowerCase();
+    }).replace(/\s+/g, ' ');
+  }
+
+  handleColumnHeaderClick(columnId: string): void {
+    if (!this.sortOptions.canSort) { return; }
+
+    if (columnId === this.sortState.columnId) {
+      this.sortState = {
+        ...this.sortState,
+        direction: this.sortState.direction === 'asc' ? 'desc' : this.sortState.direction === 'desc' ? 'none' : 'asc',
+      };
+    } else {
+      this.sortState = {
+        ...this.sortState,
+        direction: 'asc',
+        columnId: columnId,
+      };
+    }
+
+    this.sort.emit({
+      columnId: this.sortState.columnId,
+      direction: this.sortState.direction,
+    });
+
+    if (!this.sortOptions.serverSide) {
+      this.data = this.sortState.direction === 'none'
+        ? this.originalData?.slice()
+        : ModusDataTableUtilities.sortData(this.data as TRow[], this.sortState.columnId, this.sortState.direction);
+    }
+  }
+
+  render(): unknown {
+    const className = `${this.classBySize.get(this.size)}`;
+
+    return (
+      <table class={className}>
+        <colgroup>
+          {(this.columns as TColumn[])?.map((column: TColumn) => <col style={{width: column.width }} />)}
+        </colgroup>
+        <thead>
+          <tr>
+            {(this.columns as TColumn[])?.map((column: TColumn) => {
+              return (
+                <th onClick={() => this.handleColumnHeaderClick(column.id)}>
+                  <div class={`align-${column.align}`}>
+                    {this.convertToSingleSpaceTitleCase(column.display)}
+                  </div>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {this.data?.map((row) => (
+            <tr>
+              {(this.columns as TColumn[])?.map((column: TColumn) => (
+                <td class={`align-${column.align} ${column.readonly ? 'readonly' : ''}`}>
+                  {row[column.id].toString()}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  }
+}

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.utilities.ts
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.utilities.ts
@@ -1,0 +1,37 @@
+import { TCell, TColumn, TRow } from './modus-data-table.models';
+
+export class ModusDataTableUtilities {
+  static convertToTColumns(columns: string[] | TColumn[]): TColumn[] {
+    return columns?.map((column) => {
+      return {
+        align: column.align ?? 'left',
+        display: column.display ?? column,
+        id: column.id ?? column.display?.toLocaleLowerCase() ?? column.toLocaleLowerCase(),
+        readonly: column.readonly ?? true,
+        width: column.width ?? ''
+      };
+    });
+  }
+
+  static convertToTRows(data: TCell[][] | TRow[], columns: string[] | TColumn[]): TRow[] {
+    if (data?.length && !Array.isArray(data[0])) { return data as TRow[]; }
+
+    return data?.map((row) => {
+      const tRows = {};
+      row.forEach((cell, rowIndex) => {
+        tRows[(columns[rowIndex] as TColumn).id] = cell;
+      });
+
+      return tRows;
+    });
+  }
+
+  static sortData(data: TRow[], columnId: string, direction: 'asc' | 'desc' | 'none'): TRow[] {
+    const dataCopy = data.slice();
+    if (direction === 'asc') {
+      return dataCopy.sort((row1, row2) => (row1[columnId] > row2[columnId] ? 1 : -1 ));
+    } else {
+      return dataCopy.sort((row1, row2) => (row1[columnId] > row2[columnId] ? -1 : 1 ));
+    }
+  }
+}

--- a/stencil-workspace/src/components/modus-data-table/readme.md
+++ b/stencil-workspace/src/components/modus-data-table/readme.md
@@ -1,0 +1,27 @@
+# modus-data-table
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property      | Attribute | Description                         | Type                        | Default                                            |
+| ------------- | --------- | ----------------------------------- | --------------------------- | -------------------------------------------------- |
+| `columns`     | --        |                                     | `TColumn[] \| string[]`     | `undefined`                                        |
+| `data`        | --        |                                     | `TCell[][] \| TRow[]`       | `undefined`                                        |
+| `size`        | `size`    | The size of the table.              | `"condensed" \| "standard"` | `'standard'`                                       |
+| `sortOptions` | --        | Options for data table column sort. | `ModusTableSortOptions`     | `{     canSort: false,     serverSide: false,   }` |
+
+
+## Events
+
+| Event  | Description | Type                                   |
+| ------ | ----------- | -------------------------------------- |
+| `sort` |             | `CustomEvent<ModusDataTableSortEvent>` |
+
+
+----------------------------------------------
+
+

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -20,10 +20,6 @@
     </style>
   </head>
   <body>
-    <modus-tree-view>
-      <modus-tree-view-item node-id="1" label="Node one">
-      </modus-tree-view-item>
-    </modus-tree-view>
-  </body>
 
+  </body>
 </html>

--- a/stencil-workspace/src/interfaces.d.ts
+++ b/stencil-workspace/src/interfaces.d.ts
@@ -1,2 +1,3 @@
 export { Components, JSX } from './components';
 export { Crumb } from './components/modus-breadcrumb/modus-breadcrumb';
+export * from './components/modus-data-table/modus-data-table.models';

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
@@ -23,7 +23,7 @@ A new TypeScript typing has been provided named Crumb defined as:
 
 ### Default
 
-<Story id="components-breadcrumb--default" />
+<Story id="components-breadcrumb--default" height={'72px'}/>
 
 ```html
 <modus-breadcrumb></modus-breadcrumb>

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'Components/Breadcrumb',
   parameters: {
     docs: {
+      inlineStories: false,
       page: docs,
     },
     controls: {

--- a/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table-storybook-docs.mdx
@@ -1,0 +1,106 @@
+import { Story } from "@storybook/addon-docs";
+
+# Data Table
+
+---
+
+[Modus Data Table](https://modus.trimble.com/components/tables/) web components are wrappers around the HTML table element.
+They organize information in a way that’s easy to scan, so that users can look for patterns and insights.
+They are referenced using the `<modus-data-table>` custom HTML element.
+
+### Default
+
+<Story id="components-data-table--default" height={'250px'}/>
+
+```html
+<modus-data-table />
+<script>
+    document.querySelector('modus-data-table').columns = ['Name', 'Age', 'Contacted'];
+    document.querySelector('modus-data-table').data = [
+        ['John', 25, false],
+        ['Jane', 26, false],
+        ['Joe', 27, true]
+    ];
+</script>
+```
+
+### Implementation Details
+- The table `columns` property accepts an array of strings, or an array of objects.
+  - Defining the columns with objects allows you to define extra properties on the column/column cells.
+- The table `data` property accepts either a 2D array of primitive types (`string`, `number`, or `boolean`) or an array of objects.
+  - Note: the objects in `data` get their property names mapped to each column `id`.
+- The table needs a unique `id` for each column that maps to each cell in that column. If it is not provided, the table will generate a unique id for each column.
+
+
+### Inputs
+Refer to the **Default** example above to see how to define simple `columns` and `data` in the table.
+
+To define columns and data in the table *using objects*:
+```html
+<modus-data-table />
+<script>
+    document.querySelector('modus-data-table').columns = [
+        { display: 'Name', id: 'name', width: '50%' },
+        { display: 'Age', id: 'age', align: 'right' },
+        { display: 'Contacted', id: 'contacted' }
+    ];
+
+    const john = { name: 'John', age: 25, contacted: false };
+    const jane = { name: 'Jane', age: 26, contacted: false };
+    const joe = { name: 'Joe', age: 27, contacted: true };
+    document.querySelector('modus-data-table').data = [john, jane, joe];
+</script>
+```
+
+### Sorting
+- The table uses a tri-state for its sorting:
+  - `none`: no sorting is applied
+  - `asc`: ascending sort
+  - `desc`: descending sort
+- The table sorting options can be set with the optional `sortOptions` property. The property accepts a `ModusTableSortOptions` object.
+  - The object defines whether the table can be sorted on header click, and if the sort is done on the client or server-side.
+- If the table is sortable, it will output the `sort` event on header click. This event's detail is a `ModusDataTableSort` object.
+- If the table's `serverSide` sort option is `false`, it will sort the columns on the client-side. Otherwise, it is up to the consumer to update the table's `data` property with the sorted data.
+
+### Types
+```ts
+type TCell = number | string | boolean;
+type TRow = { [key: string]: TCell };
+
+interface TColumn {
+  align?: 'left' | 'right';
+  display: string;
+  id?: string;
+  readonly?: boolean;
+  width?: string;
+}
+
+interface ModusDataTableSort {
+  columnId: string;
+  direction: 'asc' | 'desc' | 'none';
+}
+
+interface ModusDataTableSortEvent extends ModusDataTableSort {}
+
+interface ModusTableSortOptions {
+  canSort: boolean;
+  serverSide: boolean;
+}
+```
+
+### Properties
+
+| Property      | Attribute | Description                         | Type                        | Default                                            |
+| ------------- | --------- | ----------------------------------- | --------------------------- | -------------------------------------------------- |
+| `columns`     | --        |                                     | `TColumn[], string[]`     | `undefined`                                        |
+| `data`        | --        |                                     | `TCell[][], TRow[]`       | `undefined`                                        |
+| `size`        | `size`    | The size of the table.              | `'condensed', 'standard'` | `'standard'`                                       |
+| `sortOptions` | --        | Options for data table column sort. | `ModusTableSortOptions`     | `{     canSort: false,     serverSide: false,   }` |
+
+
+### Events
+
+| Event  | Description                         | Type                                   |
+| ------ | ----------------------------------- | -------------------------------------- |
+| `sort` | An event that fires on column sort. | `CustomEvent<ModusDataTableSortEvent>` |
+

--- a/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table.stories.tsx
@@ -1,0 +1,38 @@
+import { html } from 'lit-html';
+// @ts-ignore: JSX/MDX with Stencil
+import docs from './modus-data-table-storybook-docs.mdx';
+
+export default {
+  title: 'Components/Data Table',
+  argTypes: {
+
+  },
+  parameters: {
+    controls: { disabled: true, expanded: true, sort: 'alpha' },
+    actions: {},
+    docs: {
+      inlineStories: false,
+      page: docs,
+    },
+    options: {
+      isToolshown: true,
+    },
+  },
+};
+
+export const Default = () => html`
+  <modus-data-table />
+  ${setDataTable()}
+`;
+
+// The <script> tag cannot be used in the MDX file, so we use this method to
+// set the data table data for the default story.
+const setDataTable = () => {
+  const tag = document.createElement('script');
+  tag.innerHTML = `
+    document.querySelector('modus-data-table').columns = ['Name', 'Age', 'Contacted'];
+    document.querySelector('modus-data-table').data = [['John', 25, false], ['Jane', 26, false], ['Joe', 27, true]];
+  `;
+
+  return tag;
+}

--- a/stencil-workspace/storybook/stories/components/modus-modal/modus-modal-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-modal/modus-modal-storybook-docs.mdx
@@ -10,7 +10,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
 
 ### Default
 
-<Story id="components-modal--default" />
+<Story id="components-modal--default" height={'400px'}/>
 
 ```html
 <modus-button id="btn-modal" color="primary">Open modal</modus-button>

--- a/stencil-workspace/storybook/stories/components/modus-modal/modus-modal.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-modal/modus-modal.stories.tsx
@@ -9,6 +9,7 @@ export default {
       handles: ['closed'],
     },
     docs: {
+      inlineStories: false,
       page: docs,
     },
     options: {

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -27,7 +27,7 @@ A new TypeScript typing has been provided named App defined as:
 
 ### Default
 
-<Story id="components-navbar--default" />
+<Story id="components-navbar--default" height={'300px'}/>
 
 ```html
 <modus-navbar show-apps-menu show-help-menu show-main-menu show-notifications>

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'Components/Navbar',
   parameters: {
     docs: {
+      inlineStories: false,
       page: docs,
     },
     options: {

--- a/stencil-workspace/storybook/stories/components/modus-radio-group/modus-radio-group-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-radio-group/modus-radio-group-storybook-docs.mdx
@@ -19,7 +19,7 @@ A new TypeScript typing has been provided named RadioButton defined as:
 
 ### Default
 
-<Story id="components-radio-group--default" />
+<Story id="components-radio-group--default" height={'150px'}/>
 
 ```html
 <modus-radio-group checked-id="1" name="my-group"></modus-radio-group>

--- a/stencil-workspace/storybook/stories/components/modus-radio-group/modus-radio-group.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-radio-group/modus-radio-group.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'Components/Radio Group',
   parameters: {
     docs: {
+      inlineStories: false,
       page: docs,
     },
     options: {

--- a/stencil-workspace/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
@@ -10,7 +10,7 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 ### Default
 
-<Story id="user-inputs-select--default" />
+<Story id="user-inputs-select--default" height={'325px'}/>
 
 ```html
 <!-- Without preset value -->

--- a/stencil-workspace/storybook/stories/components/modus-select/modus-select.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-select/modus-select.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'User Inputs/Select',
   parameters: {
     docs: {
+      inlineStories: false,
       page: docs,
     },
     options: {

--- a/stencil-workspace/storybook/stories/components/modus-tabs/modus-tabs-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-tabs/modus-tabs-storybook-docs.mdx
@@ -18,7 +18,7 @@ A new TypeScript typing has been provided named Tab defined as:
 
 ### Default
 
-<Story id="components-tabs--default" />
+<Story id="components-tabs--default" height={'125px'}/>
 
 ```html
 <modus-tabs></modus-tabs>

--- a/stencil-workspace/storybook/stories/components/modus-tabs/modus-tabs.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-tabs/modus-tabs.stories.tsx
@@ -6,6 +6,7 @@ export default {
   title: 'Components/Tabs',
   parameters: {
     docs: {
+      inlineStories: false,
       page: docs,
     },
     options: {


### PR DESCRIPTION
## Description

Table reference: https://modus.trimble.com/components/tables/

This PR includes the implementation of the barebones Data Table Stencil component, tests, and additional Storybook docs/bug fixes. 

The Data Table is currently a basic implementation that takes columns, data, size, and sort options. For more information refer to the Data Table docs in this PR's site deployment: [docs link]

Inline stories were broken for Storybook stories that needed properties set through a script tag, I set those stories' `inlineStories` to false.

References #166 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## How Has This Been Tested?

Manually, unit, and e2e.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
