### PR TITLE
fix for Spinners spacing issue in loading button example

### DIFF
--- a/stencil-workspace/src/components/modus-spinner/modus-spinner.scss
+++ b/stencil-workspace/src/components/modus-spinner/modus-spinner.scss
@@ -1,11 +1,15 @@
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 div.spinner {
-  animation: spin .75s linear infinite;
-  border: .25em solid $col_trimble_blue;
+  animation: spin 0.75s linear infinite;
+  border: 0.25em solid $col_trimble_blue;
   border-radius: 50%;
   border-right-color: transparent;
   display: inline-flex;

--- a/stencil-workspace/storybook/stories/components/modus-spinner/modus-spinner-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-spinner/modus-spinner-storybook-docs.mdx
@@ -8,9 +8,9 @@
 
 <modus-spinner></modus-spinner>
 
-<modus-button color="primary">
+<modus-button color="primary" disabled>
   <modus-spinner color="white" size=".5rem"></modus-spinner>
-  Loading...
+  &nbsp;Loading...
 </modus-button>
 
 ```html
@@ -18,9 +18,9 @@
 <modus-spinner></modus-spinner>
 
 <!-- Render in another element with different color and size -->
-<modus-button color="primary">
+<modus-button color="primary" disabled>
   <modus-spinner color="white" size=".5rem"></modus-spinner>
-  Loading...
+   &nbsp;Loading...
 </modus-button>
 ```
 


### PR DESCRIPTION
Fixes: #642

Note: I didn't update CHANGELOG - maybe not needed for minor docs updates?

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

locally with Edge v104

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
