### PR TITLE
Add `aria-current="page"` to final breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 ## Unreleased
 
 ### Added
+
 - Barebones Modus Data Table
+- Enabled keyboard interactions for `Content Tree` components.
+- Added a prop `auto-focus-input` and a public method `focusInput` to `modus-text-input` component.
 
 ### Fixed
 
@@ -15,14 +18,7 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 - Remove unused Warning button and make Primary button the default
 - Modus Message color updates
 - Add border to Modus Modal header and footer
-
-### Added
-
-- Enabled keyboard interactions for `Content Tree` components.
-
-### Added
-
-- Added a prop `auto-focus-input` and a public method `focusInput` to `modus-text-input` component.
+- Final breadcrumb item now has `aria-current="page"`
 
 ## 0.1.11 - 2022-05-08
 

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
@@ -25,18 +25,22 @@ export class ModusBreadcrumb {
     return (
       <nav aria-label={this.ariaLabel} role="navigation">
         <ol>
-          {
-            this.crumbs.map((crumb, index) =>
-              <li key={crumb.id}>
-                {index < this.crumbs.length - 1
-                  ? <span class="crumb">
-                      <a href="src/components/modus-breadcrumb/modus-breadcrumb#" onClick={() => this.crumbClick.emit(crumb)}>{crumb.display}</a>
-                      <span class="divider">{'>'}</span>
-                    </span>
-                  : <span class="last-crumb">{crumb.display}</span>
-                }
-              </li>
-          )}
+          {this.crumbs.map((crumb, index) => (
+            <li key={crumb.id}>
+              {index < this.crumbs.length - 1 ? (
+                <span class="crumb">
+                  <a href="src/components/modus-breadcrumb/modus-breadcrumb#" onClick={() => this.crumbClick.emit(crumb)}>
+                    {crumb.display}
+                  </a>
+                  <span class="divider">{'>'}</span>
+                </span>
+              ) : (
+                <span class="last-crumb" aria-current="page">
+                  {crumb.display}
+                </span>
+              )}
+            </li>
+          ))}
         </ol>
       </nav>
     );


### PR DESCRIPTION
Fixes: #659

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

locally with Edge v104

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
