### PR TITLE
Text inputs clear input accessibility issue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 - Added small Modus Chip variant
 
+### Fixed
+
+- Improved accessibility for clear input buttons for Modus text Inputs
+
 ### Removed
 
 - Removed large Modus Chip variant

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -71,6 +71,7 @@
 
       &.clear {
         cursor: pointer;
+        min-height: 1.5rem;
 
         &:hover svg path {
           fill: $col_gray_6;

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -120,7 +120,7 @@ export class ModusTextInput {
             autofocus={this.autoFocusInput}
           />
           {this.clearable && !this.readOnly && !!this.value ? (
-            <span class="icons clear">
+            <span class="icons clear" role="button" aria-label="Clear entry">
               <IconClose onClick={() => this.handleClear()} size="16" />
             </span>
           ) : (


### PR DESCRIPTION
- clear button is now taller for improved accessibility as a tap target (by adding CSS min-height: 1.5rem)
- button was actually just a span with no semantic markup. so we added `role="button"`
- Add `aria-label="Clear entry"` to describe what the button does.

Fixes #671

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

locally with Edge v104

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
