### PR TITLE
Add Icon Map for dynamic icons (with usage in Message)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 - Added small Modus Chip variant
 - Added Badge cell type to Data Table
+- Added an Icon Map, and an example usage in Modus Message. It now takes an `icon` property.
 
 ### Fixed
 

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -396,13 +396,13 @@ export declare interface ModusMessage extends Components.ModusMessage {}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['ariaLabel', 'type']
+  inputs: ['ariaLabel', 'icon', 'type']
 })
 @Component({
   selector: 'modus-message',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'type']
+  inputs: ['ariaLabel', 'icon', 'type']
 })
 export class ModusMessage {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -299,11 +299,15 @@ export namespace Components {
         /**
           * (optional) The message's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel"?: string;
+        /**
+          * (optional) The message's icon.
+         */
+        "icon"?: string;
         /**
           * (optional) The message's type.
          */
-        "type": 'info' | 'question';
+        "type"?: 'info' | 'question';
     }
     interface ModusModal {
         /**
@@ -1464,6 +1468,10 @@ declare namespace LocalJSX {
           * (optional) The message's aria-label.
          */
         "ariaLabel"?: string;
+        /**
+          * (optional) The message's icon.
+         */
+        "icon"?: string;
         /**
           * (optional) The message's type.
          */

--- a/stencil-workspace/src/components/icons/icon-map.tsx
+++ b/stencil-workspace/src/components/icons/icon-map.tsx
@@ -1,0 +1,66 @@
+// eslint-disable-next-line
+import { FunctionalComponent, h } from '@stencil/core';
+import { IconApps } from './icon-apps';
+import { IconCancel } from './icon-cancel';
+import { IconCheck } from './icon-check';
+import { IconCheckCircle } from './icon-check-circle';
+import { IconCheckCircleOutline } from './icon-check-circle-outline';
+import { IconChevronDownThick } from './icon-chevron-down-thick';
+import { IconChevronRightThick } from './icon-chevron-right-thick';
+import { IconClose } from './icon-close';
+import { IconError } from './icon-error';
+import { IconFolder } from './icon-folder';
+import { IconHelp } from './icon-help';
+import { IconIndeterminate } from './icon-indeterminate';
+import { IconInfo } from './icon-info';
+import { IconInfoOutline } from './icon-info-outline';
+import { IconMenu } from './icon-menu';
+import { IconNotifications } from './icon-notifications';
+import { IconRemove } from './icon-remove';
+import { IconSearch } from './icon-search';
+import { IconSortAZ } from './icon-sort-a-z';
+import { IconSortZA } from './icon-sort-z-a';
+import { IconTriangleDown } from './icon-triangle-down';
+import { IconUploadCloud } from './icon-upload-cloud';
+import { IconWarning } from './icon-warning';
+import { IconWarningOutline } from './icon-warning-outline';
+import { IconChevronLeftThick } from './icon-chevron-left-thick';
+import { IconChevronUpThick } from './icon-chevron-up-thick';
+
+interface IconProps {
+  color?: string;
+  icon: string;
+  onClick?: () => void;
+  size?: string;
+}
+
+export const IconMap: FunctionalComponent<IconProps> = (props: IconProps) => {
+  switch (props.icon) {
+    case 'apps': return <IconApps color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'cancel': return <IconCancel color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'check': return <IconCheck color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'check-circle': return <IconCheckCircle color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'check-circle-outline': return <IconCheckCircleOutline color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'chevron-down-thick': return <IconChevronDownThick color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'chevron-left-thick': return <IconChevronLeftThick color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'chevron-right-thick': return <IconChevronRightThick color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'chevron-up-thick': return <IconChevronUpThick color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'close': return <IconClose color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'error': return <IconError color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'folder': return <IconFolder color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'help': return <IconHelp color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'indeterminate': return <IconIndeterminate color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'info': return <IconInfo color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'info-outline': return <IconInfoOutline color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'menu': return <IconMenu color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'notifications': return <IconNotifications color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'remove': return <IconRemove color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'search': return <IconSearch color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'sort-a-z': return <IconSortAZ color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'sort-z-a': return <IconSortZA color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'triangle-down': return <IconTriangleDown color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'upload-cloud': return <IconUploadCloud color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'warning': return <IconWarning color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'warning-outline': return <IconWarningOutline color={props.color} onClick={props.onClick} size={props.size} />;
+  }
+};

--- a/stencil-workspace/src/components/modus-message/modus-message.e2e.ts
+++ b/stencil-workspace/src/components/modus-message/modus-message.e2e.ts
@@ -23,4 +23,20 @@ describe('modus-message', () => {
 
     expect(message).toHaveClass('question');
   });
+
+  it('renders changes to icon', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-message></modus-message>');
+    const element = await page.find('modus-message');
+
+    await page.waitForChanges();
+
+    let icon = await page.find('modus-message >>> .icon-check');
+    expect(icon).toBeNull();
+    element.setProperty('icon', 'check');
+    await page.waitForChanges();
+    icon = await page.find('modus-message >>> .icon-check');
+    expect(icon).not.toBeNull();
+  });
 });

--- a/stencil-workspace/src/components/modus-message/modus-message.tsx
+++ b/stencil-workspace/src/components/modus-message/modus-message.tsx
@@ -2,6 +2,7 @@
 import { Component, Prop, h } from '@stencil/core';
 import { IconInfo } from '../icons/icon-info';
 import { IconHelp } from '../icons/icon-help';
+import { IconMap } from '../icons/icon-map';
 
 @Component({
   tag: 'modus-message',
@@ -10,10 +11,13 @@ import { IconHelp } from '../icons/icon-help';
 })
 export class ModusMessage {
   /** (optional) The message's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel?: string;
+
+  /** (optional) The message's icon. */
+  @Prop() icon?: string;
 
   /** (optional) The message's type. */
-  @Prop() type: 'info' | 'question' = 'info';
+  @Prop() type?: 'info' | 'question' = 'info';
 
   classByType: Map<string, string> = new Map([
     ['info', 'info'],
@@ -26,11 +30,13 @@ export class ModusMessage {
     return (
       <div aria-label={this.ariaLabel} class={className} role="note">
         <span class="icon">
-          {this.type === 'info'
-            ? <IconInfo color="#005F9E" size="18" />
-            : this.type === 'question'
-            ? <IconHelp color="#6A6976" size="18" />
-            : null
+          {this.icon
+            ? <IconMap color={`${this.type === 'info' ? '#005F9E' : '#6A6976'}`} icon={this.icon} size="18" />
+            : this.type === 'info'
+              ? <IconInfo color="#005F9E" size="18" />
+              : this.type === 'question'
+                ? <IconHelp color="#6A6976" size="18" />
+                : null
           }
         </span>
         <span class="message">

--- a/stencil-workspace/src/components/modus-message/readme.md
+++ b/stencil-workspace/src/components/modus-message/readme.md
@@ -10,6 +10,7 @@
 | Property    | Attribute    | Description                          | Type                   | Default     |
 | ----------- | ------------ | ------------------------------------ | ---------------------- | ----------- |
 | `ariaLabel` | `aria-label` | (optional) The message's aria-label. | `string`               | `undefined` |
+| `icon`      | `icon`       | (optional) The message's icon.       | `string`               | `undefined` |
 | `type`      | `type`       | (optional) The message's type.       | `"info" \| "question"` | `'info'`    |
 
 

--- a/stencil-workspace/src/components/modus-spinner/modus-spinner.scss
+++ b/stencil-workspace/src/components/modus-spinner/modus-spinner.scss
@@ -2,6 +2,7 @@
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }

--- a/stencil-workspace/storybook/stories/components/modus-message/modus-message-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-message/modus-message-storybook-docs.mdx
@@ -24,38 +24,11 @@ import { Anchor } from "@storybook/addon-docs";
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The message's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>type</td>
-        <td>The message's type</td>
-        <td>string</td>
-        <td>'info', 'question'</td>
-        <td>'info'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Property    | Attribute    | Description                          | Type                   | Default     |
+| ----------- | ------------ | ------------------------------------ | ---------------------- | ----------- |
+| `ariaLabel` | `aria-label` | (optional) The message's aria-label. | `string`               | `undefined` |
+| `icon`      | `icon`       | (optional) The message's icon.       | `string`               | `undefined` |
+| `type`      | `type`       | (optional) The message's type.       | `"info", "question"`   | `'info'`    |
 
 ### Accessibility
 

--- a/stencil-workspace/storybook/stories/components/modus-message/modus-message.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-message/modus-message.stories.tsx
@@ -12,6 +12,13 @@ export default {
         type: { summary: 'string' }
       }
     },
+    icon: {
+      name: 'icon',
+      description: 'The message\'s icon',
+      table: {
+        type: { summary: 'string' }
+      }
+    },
     type: {
       control: {
         options: ['info', 'question'],
@@ -35,20 +42,22 @@ export default {
   },
 };
 
-export const Default = ({ ariaLabel, type }) => html`
+export const Default = ({ ariaLabel, icon, type }) => html`
   <modus-message
     aria-label=${ariaLabel}
+    icon=${icon}
     type=${type}>
     Info (Default)
   </modus-message>
 `;
-Default.args = { ariaLabel: '', type: 'info' };
+Default.args = { ariaLabel: '', icon: '', type: 'info' };
 
-export const Question = ({ ariaLabel, type }) => html`
+export const Question = ({ ariaLabel, icon, type }) => html`
   <modus-message
     aria-label=${ariaLabel}
+    icon=${icon}
     type=${type}>
     Question
   </modus-message>
 `;
-Question.args = { ariaLabel: '', type: 'question' };
+Question.args = { ariaLabel: '', icon: '', type: 'question' };


### PR DESCRIPTION
## Description

Added an Icon Map to allow icon names to be passed into components as props. Added a usage to the Modus Message component. 
This map will still need to be added to applicable components.

References #587

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## How Has This Been Tested?

Manually and e2e 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
