### PR TITLE
Add `package.json` to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "modus-web-components",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Modus Web Components",
+  "homepage": "https://modus-web-components.trimble.com/",
+  "bugs": {
+    "url": "https://github.com/trimble-oss/modus-web-components/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/trimble-oss/modus-web-components.git"
+  },
+  "license": "MIT",
+  "author": "Trimble Inc.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
This file is needed so we can download the entire repo to the style guide site so we can re-use the markdown docs.
This doesn't needed to ne mentioned in CHANGELOG.