### PR TITLE
Fix Eslint issue with `.eslintrc.js`

### DIFF
--- a/stencil-workspace/.eslintrc.js
+++ b/stencil-workspace/.eslintrc.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-undef
 module.exports = {
   'root': true,
   'env': {


### PR DESCRIPTION
Adding this to the top of the `.eslintrc.js` file fixes a linting issue with ESLint itself:

```js
// eslint-disable-next-line no-undef
```

![image](https://user-images.githubusercontent.com/1212885/191220229-d0e377fd-c2c0-40f7-9cba-1ef7a2651f5d.png)
