### PR TITLE
Focus README on lib consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ $RECYCLE.BIN/
 Thumbs.db
 UserInterfaceState.xcuserstate
 .env
+
+stencil-workspace/README.md
+stencil-workspace/SUPPORT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 ---
 
+## Table of Contents
+- [Dependencies](#dependencies)
+- [Getting Started](#getting-started)
+- [Available Scripts](#available-scripts)
+- [Submitting Issues](#submitting-issues)
+- [Technologies](#technologies)
+- [Running Locally](#running-locally)
+- [Developing a Component](#developing-a-component)
+- [Styleguide](#styleguide)
+- [Testing](#testing)
+- [Making Changes and Submitting a PR](#making-changes-and-submitting-a-pr)
+- [Changelog](#changelog)
+- [Releasing Framework Outputs](#releasing-framework-outputs)
+
 ## Dependencies
 
 - Node (>= v14)
@@ -9,32 +23,23 @@
 
 _We recommend using [NVM](https://github.com/nvm-sh/nvm). It is a great tool for switching between Node versions_
 
-## Submitting Issues
+## Getting Started
 
-Whether you're contributing directly to the code or have suggestions, submitting an issue through GitHub is needed
-for referencing changes. Please submit change items as an Issue [here](https://github.com/trimble-oss/modus-web-components/issues).
+### Running the App
 
-If the issue's considered a bug, add the 'bug' label to the issue.
+If this is your first time in the project, navigate to the `./stencil-workspace` directory and run `npm install` to download 3rd party packages.
 
-Also add a priority level label to the issue. The priority options are low, medium, and high.
-If you are unsure of its priority, reach out to one of the developers for their opinion.
+Once you've installed the project's packages, run `npm start`.
+A development environment will start up with the contents of `index.html`.
+This file provides a place to render components for development and end-to-end testing.
 
-## Technologies
+All web components are located under the `./stencil-workspace/src/components` directory.
 
-### Stencil
+Global SCSS files are available to provide Modus colors, variables and functions for component styling.
 
-Stencil is a web component compiler. Web components is a suite of JavaScript technologies that let you register a component
-directly with the browser. This means that the component can be used in any web application. It comes packed with a dev server
-and live re-rendering. We are using it to build out the components.
+### Implementation
 
-### Storybook
-
-Storybook is a tool for developing components in isolation. It also provides a framework for developing component library
-documentation sites. We are using it to document our components.
-
-### npm
-
-We are hosting this package on both the @trimble-oss GitHub npm registry, and the public npm registry.
+Stencil web component implementation details can be found in their [Framework Integration Docs](https://stenciljs.com/docs/overview).
 
 ## Available Scripts
 
@@ -54,6 +59,45 @@ All npm scripts are run from the `./stencil-workspace` project directory.
 
 `npm run lint` - Run ESLint to find problems with JS, TS and SCSS code
 
+`npm run start-storybook`: Build and run the Storybook documentation site.
+Note: You will need to manually install the packages in `./stencil-workspace/storybook` before running this command
+
+## Submitting Issues
+
+Whether you're contributing directly to the code or have suggestions, submitting an issue through GitHub is needed
+for referencing changes. Please submit change items as an Issue [here](https://github.com/trimble-oss/modus-web-components/issues).
+
+If the issue's considered a bug, add the 'bug' label to the issue.
+
+Also add a priority level label to the issue. The priority options are low, medium, and high.
+If you are unsure of its priority, reach out to one of the developers for their opinion.
+
+## Technologies
+
+- [Stencil](https://stenciljs.com/)
+- [Storybook](https://storybook.js.org/)
+- [npm](https://docs.npmjs.com/getting-started)
+- [Sass](https://sass-lang.com/)
+- [ESLint](https://eslint.org/)
+- [Prettier](https://prettier.io/)
+- [Jest](https://jestjs.io/)
+- [rollup.js](https://rollupjs.org/)
+
+### Stencil
+
+Stencil is a web component compiler. Web components is a suite of JavaScript technologies that let you register a component
+directly with the browser. This means that the component can be used in any web application. It comes packed with a dev server
+and live re-rendering. We are using it to build out the components.
+
+### Storybook
+
+Storybook is a tool for developing components in isolation. It also provides a framework for developing component library
+documentation sites. We are using it to document our components.
+
+### npm
+
+We are hosting this package on both the @trimble-oss GitHub npm registry, and the public npm registry.
+
 ## Running Locally
 
 To get this application up and running, there are just two commands needed:
@@ -61,7 +105,7 @@ To get this application up and running, there are just two commands needed:
 - Run `npm install`
 - Run `npm start`
 
-> **Note:** The `./stencil-workspace` project directory is the source of truth for this component library. This is where all component changes will take place.
+> **Note:** The `./stencil-workspace` project directory is the source of truth for this component library. This is where all component changes will take place. The other directories are generated.
 
 ## Developing a Component
 
@@ -118,6 +162,39 @@ To run a specific test, run `stencil test --spec --e2e --silent [test file name]
 9. Submit your PR with your branch as the `head`, and the `@trimble-oss/modus-web-components` `main` branch as the `base`.
    - Don't forget to link your relevant issue in the PR description.
 10. Rebase and Merge the PR upon approval.
+
+## Changelog
+
+The CHANGELOG is a file that contains a curated list of chronological entries for each version of the project.
+This will enable users to quickly see precise changes between each release or version of a project.
+
+### Semantic Versioning
+
+This project uses the following semantic versioning convention for the repository and changelog entries.
+Given a version number [MAJOR.MINOR.PATCH], increment the following:
+
+1. Major: to make incompatible API changes - updates containing new dependencies.
+2. Minor: to add functionality in a backwards compatible manner.
+3. Patch: to make backwards compatible bug fixes.
+   Example: Version 1.0.0 has a function added in accordance with a minor version update. The new version will be 1.1.0.
+   See: [semver.org](https://semver.org/spec/v2.0.0.html).
+
+### Guidelines
+
+- Each version has an entry and release date.
+- Entries are ordered from newest to oldest.
+- Entries contain updates relevant to an end user and may not reflect every commit.
+
+### Update Types
+
+Each changelog entry will include one or more update types relevant to each change:
+
+- Added: New features.
+- Changed: Changes in functionality.
+- Deprecated: For soon to be removed features.
+- Removed: For removed features.
+- Fixed: For bug Fixes.
+- Security: For vulnerabilities.
 
 ## Releasing Framework Outputs
 

--- a/README.md
+++ b/README.md
@@ -25,90 +25,18 @@ Modus includes...
 
 This library provides Modus Elements as web components. Web components are reusable, encapsulated UI elements that are framework agnostic (can be implemented in any site). The modus-web-components library was built using the latest UX specs from Figma. Releases follow the [semantic versioning 2.0.0](https://semver.org/) spec.
 
-## Table of Contents
+# Looking for documentation?
 
-- [Getting Started](#getting-started)
-- [Available Scripts](#available-scripts)
-- [Technology](#technology)
-- [Components](#components)
+You can check out https://modus-web-components.trimble.com for the library's latest Storybook documentation.
 
-## Getting Started
+# Installing Modus Web Components
 
-### Contribution
+Check out the Storybook site's [Getting Started page](https://modus-web-components.trimble.com/?path=/docs/introduction-getting-started--page).
 
-If this is your first time in the project, navigate to the `./stencil-workspace` directory and run `npm install` to download 3rd party packages.
+# Contributing
 
-All web components are located under the `./stencil-workspace/src/components directory.`
+Curious about contributing? We've got a [contributing guide](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md) to help get you going.
 
-The index.html file provides a place to render components for development and end-to-end testing.
+# Contributors
 
-Global SCSS files are available to provide Modus colors, variables and functions for component styling.
-
-### Implementation
-
-Stencil web component implementation details can be found in their [Framework Integration Docs](https://stenciljs.com/docs/overview).
-
-If you need to use form input web components (eg modus-checkbox, modus-text-input, etc) there are many good examples online.
-We won't cover them here as they are often very specific to an individual SPA framework.
-
-## Available Scripts
-
-All npm scripts are run from the `./stencil-workspace` project directory.
-
-`npm install` - Install 3rd party packages
-
-`npm start` - Compile and run the Stencil development site
-
-`npm run build` - Compile the component library
-
-`npm run test` - Run the unit and e2e tests
-
-`npm run test.watch` - Run the unit and e2e tests with auto re-run on changes
-
-`npm run generate` - Start the interactive Stencil component generator
-
-`npm run lint` - Run ESLint to find problems with JS, TS and SCSS code
-
-## Technology
-
-- [ESLint](https://eslint.org/) - A JS linter to help find and fix problems in code.
-- [Jest](https://jestjs.io/) - A JS testing framework.
-- [Stencil](https://stenciljs.com/) - A toolchain for building reusable, scalable design systems and web components.
-- [Sass](https://sass-lang.com/) - The most mature, stable, and powerful professional grade CSS extension language in the world.
-- [rollup.js](https://rollupjs.org/) - A module bundler for JavaScript which compiles small pieces of code into something larger and more complex, such as a library or application.
-
-## Changelog
-
-- Changelog - A file that contains a curated list of chronological entries for each version of a project.
-- Purpose - Enable users to quickly see precise changes between each release or version of a project.
-- Uses - End users want to know how and why the software they use changes.
-
-### Semantic Versioning
-
-This project uses the following semantic versioning convention for the repository and changelog entries.
-Given a version number [MAJOR.MINOR.PATCH], increment the following:
-
-1. Major Version: to make incompatible API changes - updates containing new dependencies.
-2. Minor Version: to add functionality in a backwards compatible manner.
-3. Patch Version: to make backwards compatible bug fixes.
-   Example: Version 1.0.0 has a function added in accordance with a minor version update. The new version will be 1.1.0.
-   See: [semver.org](https://semver.org/spec/v2.0.0.html).
-
-### Guidelines
-
-- Entries are are easy to understand.
-- Each version has an entry and release date.
-- Entries have corresponding addresses linked.
-- Entries are ordered by date from newest to oldest.
-- Entries contain updates relevant to an end user and may not reflect every commit.
-
-### Update-Types
-
-Each changelog entry will include one or more update types relevant to each change:
-
-- Added: New features.
-- Changed: Changes in functionality.
-- Deprecated: For soon to be removed features.
-- Removed: For removed features.
-- Fixed: For bug Fixes.
-- Security: For vulnerabilities.
+Thanks to all of [our contributors](https://github.com/trimble-oss/modus-web-components/graphs/contributors)!

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -22,6 +22,7 @@
         "@typescript-eslint/eslint-plugin": "^5.39.0",
         "@typescript-eslint/parser": "^5.39.0",
         "autoprefixer": "^10.4.12",
+        "copyfiles": "^2.4.1",
         "eslint": "^8.24.0",
         "eslint-plugin-storybook": "^0.6.4",
         "jest": "^27.0.3",
@@ -2526,6 +2527,31 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -3928,6 +3954,12 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5017,6 +5049,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -5099,6 +5143,34 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/noms/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/noms/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -5543,6 +5615,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -6659,6 +6737,46 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6824,6 +6942,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -7075,6 +7202,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -8952,6 +9088,27 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -9996,6 +10153,12 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -10837,6 +11000,12 @@
         "kind-of": "^6.0.3"
       }
     },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
     "mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -10905,6 +11074,36 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
+    },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "dev": true
+        }
+      }
     },
     "normalize-package-data": {
       "version": "3.0.3",
@@ -11213,6 +11412,12 @@
           "dev": true
         }
       }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -12046,6 +12251,48 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -12165,6 +12412,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -12357,6 +12610,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -21,8 +21,8 @@
   "files": [
     "dist/",
     "loader/",
-    "../README.md",
-    "../SUPPORT.md"
+    "README.md",
+    "SUPPORT.md"
   ],
   "scripts": {
     "build": "stencil build --docs",
@@ -34,9 +34,10 @@
     "lint-js": "eslint src/** --no-error-on-unmatched-pattern",
     "lint-css": "stylelint src/**/*.scss",
     "prettier": "prettier --write storybook/stories/**/*.*",
-    "full": "npm ci && npm run lint-js && npm run lint-css && npm run build && npm run test && npm run ci-storybook",
+    "full": "npm ci && npm run lint && npm run copy-docs && npm run build && npm run test && npm run ci-storybook",
     "ci-storybook": "cd storybook && npm ci && npm run build-storybook",
-    "start-storybook": "npm run build && cd storybook && npm run storybook"
+    "start-storybook": "npm run build && cd storybook && npm run storybook",
+    "copy-docs": "copyfiles -f ../README.md ../SUPPORT.md ./"
   },
   "dependencies": {
     "@stencil/core": "^2.18.1"
@@ -52,6 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
     "autoprefixer": "^10.4.12",
+    "copyfiles": "^2.4.1",
     "eslint": "^8.24.0",
     "eslint-plugin-storybook": "^0.6.4",
     "jest": "^27.0.3",


### PR DESCRIPTION
## Description

I've updated the `README.md` to be consumer-focused. Anything that had to do with contributing is moved over to the `CONTRIBUTING.md` doc. 

I've added a script to copy the markdown files that we want included in the package.

Fixes #551

## Type of change

- [X] Documentation update

## How Has This Been Tested?

I installed this package manually to confirm that the `README.md` and `SUPPORT.md` exist