### PR TITLE
Add Theme toggler for storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 ## Unreleased
 
+- Added a theme toggler to the toolbar in storybook pages to switch between `light` and `dark` themes
+
 ## 0.1.21 - 2022-10-04
 
 ### Added

--- a/stencil-workspace/storybook/.storybook/main.js
+++ b/stencil-workspace/storybook/.storybook/main.js
@@ -9,7 +9,7 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-docs",
     "@storybook/addon-essentials",
-    "storybook-dark-mode"
+    // "storybook-dark-mode"
   ],
   babel: async (options) => ({
     ...options,

--- a/stencil-workspace/storybook/.storybook/main.js
+++ b/stencil-workspace/storybook/.storybook/main.js
@@ -9,6 +9,11 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-docs",
     "@storybook/addon-essentials",
+    "storybook-dark-mode"
   ],
+  babel: async (options) => ({
+    ...options,
+    presets: [...options.presets, '@babel/preset-react'],
+  }),
   "framework": "@storybook/web-components"
 }

--- a/stencil-workspace/storybook/.storybook/preview.js
+++ b/stencil-workspace/storybook/.storybook/preview.js
@@ -23,6 +23,8 @@ export const parameters = {
     },
   },
   darkMode: {
+    // Set the initial theme
+    current: 'light',
     // Override the default dark theme
     dark: { ...themes.dark, appBg: '#252a2e' },
     stylePreview: true

--- a/stencil-workspace/storybook/.storybook/preview.js
+++ b/stencil-workspace/storybook/.storybook/preview.js
@@ -1,7 +1,18 @@
+import React from 'react';
 import { defineCustomElements } from '../../loader';
 import yourTheme from './your-theme';
+import { themes } from '@storybook/theming';
+import addons from '@storybook/addons';
+import { DocsContainer } from '@storybook/addon-docs';
+import {
+  useDarkMode
+} from 'storybook-dark-mode';
 
 defineCustomElements();
+
+// get channel to listen to event emitter
+const channel = addons.getChannel();
+
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -11,8 +22,23 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  darkMode: {
+    // Override the default dark theme
+    dark: { ...themes.dark, appBg: '#252a2e' },
+    stylePreview: true
+  },
   docs: {
     theme: yourTheme,
+    container: props => {
+      const isDark = useDarkMode();
+      React.useEffect(() => {
+        document.body.setAttribute('data-mwc-theme', isDark ? 'dark' : 'light');
+      }, [isDark]);
+
+      return (
+          <DocsContainer {...props} />
+      );
+    }
   },
   options: {
     storySort: {
@@ -29,3 +55,4 @@ export const parameters = {
     'storybook/docs/panel': { index: -1 },
   }
 }
+

--- a/stencil-workspace/storybook/package-lock.json
+++ b/stencil-workspace/storybook/package-lock.json
@@ -20,12 +20,14 @@
       },
       "devDependencies": {
         "@babel/core": "^7.19.3",
+        "@babel/preset-react": "^7.18.6",
         "@storybook/addon-a11y": "^6.5.11",
         "@storybook/addon-actions": "^6.5.11",
         "@storybook/addon-essentials": "^6.5.11",
         "@storybook/addon-links": "^6.5.11",
         "@storybook/web-components": "^6.5.11",
-        "babel-loader": "^8.2.5"
+        "babel-loader": "^8.2.5",
+        "storybook-dark-mode": "^1.1.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -282,9 +284,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -805,11 +807,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-      "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1242,11 +1244,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz",
-      "integrity": "sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
+      "integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1256,15 +1258,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-      "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
+      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-jsx": "^7.17.12",
-        "@babel/types": "^7.17.12"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1274,11 +1276,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-jsx-development": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
-      "integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
       "dependencies": {
-        "@babel/plugin-transform-react-jsx": "^7.16.7"
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1288,12 +1290,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.0.tgz",
-      "integrity": "sha512-6+0IK6ouvqDn9bmEG7mEyF/pwlJXVj5lwydybpyyH3D0A7Hftk+NCTdYjnLNZksn261xaOV5ksmp20pQEmc2RQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.6.tgz",
+      "integrity": "sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1538,16 +1540,16 @@
       }
     },
     "node_modules/@babel/preset-react": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.17.12.tgz",
-      "integrity": "sha512-h5U+rwreXtZaRBEQhW1hOJLMq8XNJBQ/9oymXiCXTuT/0uOwpbT0gUt+sXeOqoXBgNuUKI7TaObVwoEyWkpFgA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz",
+      "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-transform-react-display-name": "^7.16.7",
-        "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
-        "@babel/plugin-transform-react-pure-annotations": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-react-display-name": "^7.18.6",
+        "@babel/plugin-transform-react-jsx": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-development": "^7.18.6",
+        "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -13651,6 +13653,34 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.2.tgz",
       "integrity": "sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg=="
     },
+    "node_modules/storybook-dark-mode": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.1.2.tgz",
+      "integrity": "sha512-L5QjJN49bl+ktprM6faMkTeW+LCvuMYWQaRo8/JGSMmzomIjLT7Yo20UiTsnMgMYyYWYF5O4EK/F3OvjDNp8tQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "@storybook/api": "^6.0.0",
+        "@storybook/components": "^6.0.0",
+        "@storybook/core-events": "^6.0.0",
+        "@storybook/theming": "^6.0.0",
+        "fast-deep-equal": "^3.0.0",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "license": "MIT",
@@ -16097,9 +16127,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
-      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg=="
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
+      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.16.8",
@@ -16402,11 +16432,11 @@
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
-      "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
+      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-syntax-logical-assignment-operators": {
@@ -16628,40 +16658,40 @@
       }
     },
     "@babel/plugin-transform-react-display-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz",
-      "integrity": "sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.18.6.tgz",
+      "integrity": "sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-jsx": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz",
-      "integrity": "sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.19.0.tgz",
+      "integrity": "sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/plugin-syntax-jsx": "^7.17.12",
-        "@babel/types": "^7.17.12"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz",
-      "integrity": "sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.18.6.tgz",
+      "integrity": "sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==",
       "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.16.7"
+        "@babel/plugin-transform-react-jsx": "^7.18.6"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.0.tgz",
-      "integrity": "sha512-6+0IK6ouvqDn9bmEG7mEyF/pwlJXVj5lwydybpyyH3D0A7Hftk+NCTdYjnLNZksn261xaOV5ksmp20pQEmc2RQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.18.6.tgz",
+      "integrity": "sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -16820,16 +16850,16 @@
       }
     },
     "@babel/preset-react": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.17.12.tgz",
-      "integrity": "sha512-h5U+rwreXtZaRBEQhW1hOJLMq8XNJBQ/9oymXiCXTuT/0uOwpbT0gUt+sXeOqoXBgNuUKI7TaObVwoEyWkpFgA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.18.6.tgz",
+      "integrity": "sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-transform-react-display-name": "^7.16.7",
-        "@babel/plugin-transform-react-jsx": "^7.17.12",
-        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
-        "@babel/plugin-transform-react-pure-annotations": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-react-display-name": "^7.18.6",
+        "@babel/plugin-transform-react-jsx": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-development": "^7.18.6",
+        "@babel/plugin-transform-react-pure-annotations": "^7.18.6"
       }
     },
     "@babel/preset-typescript": {
@@ -25661,6 +25691,22 @@
       "version": "2.13.2",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.13.2.tgz",
       "integrity": "sha512-CMtO2Uneg3SAz/d6fZ/6qbqqQHi2ynq6/KzMD/26gTkiEShCcpqFfTHgOxsE0egAq6SX3FmN4CeSqn8BzXQkJg=="
+    },
+    "storybook-dark-mode": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/storybook-dark-mode/-/storybook-dark-mode-1.1.2.tgz",
+      "integrity": "sha512-L5QjJN49bl+ktprM6faMkTeW+LCvuMYWQaRo8/JGSMmzomIjLT7Yo20UiTsnMgMYyYWYF5O4EK/F3OvjDNp8tQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "@storybook/api": "^6.0.0",
+        "@storybook/components": "^6.0.0",
+        "@storybook/core-events": "^6.0.0",
+        "@storybook/theming": "^6.0.0",
+        "fast-deep-equal": "^3.0.0",
+        "global": "^4.4.0",
+        "memoizerific": "^1.11.3"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/stencil-workspace/storybook/package.json
+++ b/stencil-workspace/storybook/package.json
@@ -17,12 +17,14 @@
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",
+    "@babel/preset-react": "^7.18.6",
     "@storybook/addon-a11y": "^6.5.11",
     "@storybook/addon-actions": "^6.5.11",
     "@storybook/addon-essentials": "^6.5.11",
     "@storybook/addon-links": "^6.5.11",
     "@storybook/web-components": "^6.5.11",
-    "babel-loader": "^8.2.5"
+    "babel-loader": "^8.2.5",
+    "storybook-dark-mode": "^1.1.2"
   },
   "license": "MIT"
 }

--- a/stencil-workspace/storybook/public/storybook-styles.css
+++ b/stencil-workspace/storybook/public/storybook-styles.css
@@ -1,6 +1,43 @@
 /* https://storybook.js.org/docs/react/configure/theming */
 
-body,
+/* hide the toggler until dark mode is enabled for all the components */
+button[title="Change theme to dark mode"],
+button[title="Change theme to light mode"] {
+  opacity: 0;
+  cursor: auto;
+}
+
+body[data-mwc-theme="light"] {
+  --theme-bg-color: #fff;
+  --theme-color: #252a2e;
+  --theme-sbdocs-table-head-bg-color: #f1f1f6;
+  --theme-sbdocs-table-stripe-bg-color: #f8f8f8;
+  --theme-sbdocs-table-border-color: #b7b9c3;
+  --theme-docblock-source-color: #252a2e;
+  --theme-docblock-source-bg-color: #fff;
+  --theme-sidebar-subheading-color: #495057;
+  --theme-sbdocs-link-color: #217cbb;
+  --theme-code-color: #333;
+  --theme-code-bg-color: #f8f8f8;
+  --theme-code-border-color: #eee;
+}
+
+body[data-mwc-theme="dark"] {
+  --theme-bg-color: #252a2e;
+  --theme-color: #f1f1f6;
+  --theme-sbdocs-table-head-bg-color: #171c1e;
+  --theme-sbdocs-table-stripe-bg-color: #252a2e;
+  --theme-sbdocs-table-border-color: #464b52;
+  --theme-docblock-source-color: #f1f1f6;
+  --theme-docblock-source-bg-color: #6a6e79;
+  --theme-sidebar-subheading-color: #495057;
+  --theme-sbdocs-link-color: #217cbb;
+  --theme-code-color: #f1f1f6;
+  --theme-code-bg-color: #6a6e79;
+  --theme-code-border-color: #6a6e79;
+}
+
+body.sb-show-main,
 #docs-root,
 #docs-root p,
 .sbdocs,
@@ -9,24 +46,33 @@ body,
 .sbdocs-li,
 .sbdocs-p,
 .sbdocs-ul {
-  color: #252a2e;
+  color: var(--theme-color) !important;
+  background-color: var(--theme-bg-color) !important;
 }
 
 .sbdocs-table {
   width: 100%;
 }
 
+.sbdocs-table td {
+  color: var(--theme-color) !important;
+}
+
 .sbdocs-table thead tr th {
-  color: #252a2e;
-  background-color: #f1f1f6;
-  border: 1px solid #b7b9c3;
+  color: var(--theme-color);
+  background-color: var(--theme-sbdocs-table-head-bg-color);
+  border: 1px solid var(--theme-sbdocs-table-border-color);
   border-bottom-width: 2px;
   font-weight: 600;
   text-align: left;
 }
 
+.sbdocs-table tbody tr:nth-of-type(2n) {
+  background-color: var(--theme-sbdocs-table-stripe-bg-color);
+}
+
 .sbdocs-table tbody tr td {
-  border: 1px solid #b7b9c3;
+  border: 1px solid var(--theme-sbdocs-table-border-color);
 }
 
 .sbdocs-table tbody tr td:first-of-type {
@@ -35,11 +81,22 @@ body,
 }
 
 .docblock-source {
-  color: #252a2e;
+  color: var(--theme-docblock-source-color) !important;
+  background-color: var(--theme-docblock-source-bg-color) !important;
+}
+
+[data-mwc-theme="dark"] .docblock-source pre span,
+[data-mwc-theme="dark"] .docblock-source button {
+  color: var(--theme-docblock-source-color) !important;
+}
+
+[data-mwc-theme="dark"] .docblock-source button {
+  background-color: var(--theme-docblock-source-bg-color);
+  border-color: var(--theme-docblock-source-color);
 }
 
 .sidebar-subheading {
-  color: #495057 !important;
+  color: var(--theme-sidebar-subheading-color) !important;
 }
 
 .token.comment {
@@ -47,7 +104,7 @@ body,
 }
 
 body .sbdocs a {
-  color: #217cbb;
+  color: var(--theme-sbdocs-link-color) !important;
 }
 
 /* Fixes code block z-index issue */
@@ -55,6 +112,12 @@ pre .os-padding {
   z-index: inherit !important;
 }
 
-pre .os-content{
+pre .os-content {
   max-height: 500px;
+}
+
+code {
+  color: var(--theme-code-color) !important;
+  background-color: var(--theme-code-bg-color) !important;
+  border-color: var(--theme-code-border-color) !important;
 }

--- a/stencil-workspace/storybook/public/storybook-styles.css
+++ b/stencil-workspace/storybook/public/storybook-styles.css
@@ -1,12 +1,5 @@
 /* https://storybook.js.org/docs/react/configure/theming */
 
-/* hide the toggler until dark mode is enabled for all the components */
-button[title="Change theme to dark mode"],
-button[title="Change theme to light mode"] {
-  opacity: 0;
-  cursor: auto;
-}
-
 body[data-mwc-theme="light"] {
   --theme-bg-color: #fff;
   --theme-color: #252a2e;


### PR DESCRIPTION
Added a theme toggler using a [addon](https://storybook.js.org/addons/storybook-dark-mode) that uses local storage to retain the theme selection and also checks for user preference.
Also added some styles in the storybook for dark mode.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #787 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
