### PR TITLE
Fix Data Table ID setting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ View all releases at: https://github.com/trimble-oss/modus-web-components/releas
 
 ## Unreleased
 
+## 0.1.22 - 2022-10-18
+
+### Fixed
+
+- Fixed an issue with the Data Table where setting column ids was not working
+
 ## 0.1.21 - 2022-10-04
 
 ### Added

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.18.1"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
@@ -126,7 +126,7 @@ table {
   &.size-small {
     th,
     tr {
-      min-height: 2rem;
+      height: 2rem;
     }
   }
 }

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.spec.ts
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.spec.ts
@@ -55,6 +55,18 @@ describe('modus-data-table', () => {
     );
   });
 
+  it('should convert column prop as TColumn (with ids) array to TColumn array', async () => {
+    const cols: TColumn[] = ModusDataTableUtilities.convertToTColumns([
+      { id: 'name id', display: 'name' },
+      { id: 'age id', display: 'age' }
+    ]);
+    expect(cols).toEqual([
+        { align: 'left', display: 'name', id: 'name id', readonly: false, width: '' },
+        { align: 'left', display: 'age', id: 'age id', readonly: false, width: '' }
+      ]
+    );
+  });
+
   it('should convert row prop as string array to TRow array', async () => {
     const cols: TColumn[] = [
       { align: 'left', display: 'Name', id: 'name', readonly: true, width: '' },

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.utilities.ts
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.utilities.ts
@@ -6,7 +6,7 @@ export class ModusDataTableUtilities {
       return {
         align: column.align ?? 'left',
         display: column.display ?? column,
-        id: column._id ?? column.display?.toLocaleLowerCase() ?? column.toLocaleLowerCase(),
+        id: column.id ?? column.display?.toLocaleLowerCase() ?? column.toLocaleLowerCase(),
         readonly: column.readonly ?? false,
         width: column.width ?? ''
       };


### PR DESCRIPTION
## Description

This fixes the issue where the column props were not converting the column `id`s. This makes it so we no longer need to use the string literal for the `data` property fields

Fixes #741

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually, and unit tested.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
