### PR TITLE
Don't lint CSS and HTML with super-linter GitHub Action

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -28,7 +28,9 @@ jobs:
           LOG_LEVEL: NOTICE
           SUPPRESS_POSSUM: true
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_CSS: false
           VALIDATE_EDITORCONFIG: false
+          VALIDATE_HTML: false
           VALIDATE_MARKDOWN: false
           VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_YAML: false


### PR DESCRIPTION
We shouldn't lint CSS with Super Linter because it uses a preset which is incompatible with out library. HTML should only be linted if we add a `.htmlhintrc` to the root (maybe we'll do this in the future).

This PR removes linting for those to avoid linting issues.

This is a dev-only change so no need to mention in CHANGELOG.