### PR TITLE
Adds  a simple 404 page

### DIFF
--- a/stencil-workspace/storybook/public/404/index.html
+++ b/stencil-workspace/storybook/public/404/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en" class="no-js">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>404: Not Found</title>
+  <meta name="description" content="404">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=fallback">
+  <link rel="stylesheet" href="https://modus-web-components.trimble.com/storybook-styles.css">
+  <meta name="theme-color" content="#fafafa">
+</head>
+<body>
+  <style>body {
+      font-family: 'Open Sans', sans-serif;
+      margin-top: 11%;
+      text-align: center;
+    }</style>
+  <h1>404: Not Found</h1>
+<p>We couldn’t find that page, please check the URL and try again.</p>
+<p>Found a broken link? <a href="https://github.com/trimble-oss/modus-web-components/issues">Report an issue</a></p>
+</body>
+</html>

--- a/stencil-workspace/storybook/public/staticwebapp.config.json
+++ b/stencil-workspace/storybook/public/staticwebapp.config.json
@@ -1,0 +1,24 @@
+{
+  "globalHeaders": {
+    "Content-Security-Policy": "upgrade-insecure-requests",
+    "Permissions-Policy": "autoplay=()",
+    "Referrer-Policy": "no-referrer-when-downgrade",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-XSS-Protection": "0"
+  },
+  "responseOverrides": {
+    "404": {
+      "rewrite": "/404/",
+      "statusCode": 404
+    }
+  },
+  "routes": [
+    {
+      "route": "/favicon.*",
+      "headers": {
+        "cache-control": "public, max-age=15770000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Fixes: #288
This is to avoid the Microsoft Azure branding on 404 page... and adds a link if users need to report a broken link from somewhere.

This PR also addresses some minor HTTP security header issues:
https://securityheaders.com/?q=https%3A%2F%2Fmodus-web-components.trimble.com%2F&hide=on&followRedirects=on

**With this merged the site will score A+**:
https://securityheaders.com/?q=https%3A%2F%2Ficy-ground-0374a1310-833.centralus.1.azurestaticapps.net%2F&hide=on&followRedirects=on

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

With Azure Deploy Preview

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
