### PR TITLE
Create separate README files for each output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ $RECYCLE.BIN/
 Thumbs.db
 UserInterfaceState.xcuserstate
 .env
-
-stencil-workspace/README.md
-stencil-workspace/SUPPORT.md

--- a/react-workspace/README.md
+++ b/react-workspace/README.md
@@ -16,14 +16,7 @@
 
 The [Trimble Modus Design System](https://modus.trimble.com/) describes the UX that Trimble wants to provide in its UI across its many applications. The benefits of using Modus include rapid prototyping, development efficiency, and UX consistency.
 
-Modus includes:
-
-- Typography
-- Colors
-- Rules
-- Elements (components)
-
-This library provides Modus Elements as web components. Web components are reusable, encapsulated UI elements that are framework agnostic (can be implemented in any site). The modus-web-components library was built using the latest UX specs from Figma. Releases follow the [semantic versioning 2.0.0](https://semver.org/) spec.
+Modus Web Components are reusable, encapsulated UI elements that are framework agnostic (can be implemented in any site). The modus-web-components library was built using the latest UX specs from Figma. Releases follow the [semantic versioning 2.0.0](https://semver.org/) spec.
 
 # Looking for documentation?
 
@@ -31,7 +24,7 @@ You can check out <https://modus-web-components.trimble.com> for the library's l
 
 # Installing Modus Web Components
 
-Check out the Storybook site's [Getting Started page](https://modus-web-components.trimble.com/?path=/docs/introduction-getting-started--page).
+Check out the [Getting Started page](https://modus-web-components.trimble.com/?path=/docs/introduction-getting-started--page).
 
 # Contributing
 

--- a/react-workspace/package.json
+++ b/react-workspace/package.json
@@ -17,8 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",
-    "../README.md",
-    "../SUPPORT.md"
+    "README.md"
   ],
   "scripts": {
     "build": "npm run compile",

--- a/stencil-workspace/README.md
+++ b/stencil-workspace/README.md
@@ -16,14 +16,7 @@
 
 The [Trimble Modus Design System](https://modus.trimble.com/) describes the UX that Trimble wants to provide in its UI across its many applications. The benefits of using Modus include rapid prototyping, development efficiency, and UX consistency.
 
-Modus includes:
-
-- Typography
-- Colors
-- Rules
-- Elements (components)
-
-This library provides Modus Elements as web components. Web components are reusable, encapsulated UI elements that are framework agnostic (can be implemented in any site). The modus-web-components library was built using the latest UX specs from Figma. Releases follow the [semantic versioning 2.0.0](https://semver.org/) spec.
+Modus Web Components are reusable, encapsulated UI elements that are framework agnostic (can be implemented in any site). The modus-web-components library was built using the latest UX specs from Figma. Releases follow the [semantic versioning 2.0.0](https://semver.org/) spec.
 
 # Looking for documentation?
 
@@ -31,7 +24,7 @@ You can check out <https://modus-web-components.trimble.com> for the library's l
 
 # Installing Modus Web Components
 
-Check out the Storybook site's [Getting Started page](https://modus-web-components.trimble.com/?path=/docs/introduction-getting-started--page).
+Check out the [Getting Started page](https://modus-web-components.trimble.com/?path=/docs/introduction-getting-started--page).
 
 # Contributing
 

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -21,8 +21,7 @@
   "files": [
     "dist/",
     "loader/",
-    "README.md",
-    "SUPPORT.md"
+    "README.md"
   ],
   "scripts": {
     "build": "stencil build --docs",


### PR DESCRIPTION
These are largely the same as the root's README for now, but they can diverge in the future.

Note: The change for the URL on the root's README was to fix a markdown linting issue.
Rationale: Without angle brackets, the URL isn't converted into a link in many markdown parsers.
https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md034---bare-url-used