### PR TITLE
Dark mode for Content tree and Chip

### DIFF
--- a/stencil-workspace/.stylelintrc.json
+++ b/stencil-workspace/.stylelintrc.json
@@ -3,7 +3,6 @@
   "rules": {
     "alpha-value-notation": null,
     "color-function-notation": null,
-    "custom-property-no-missing-var-function": null,
     "max-line-length": null,
     "no-descending-specificity": null,
     "number-leading-zero": null,

--- a/stencil-workspace/.stylelintrc.json
+++ b/stencil-workspace/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "alpha-value-notation": null,
     "color-function-notation": null,
+    "custom-property-no-missing-var-function": null,
     "max-line-length": null,
     "no-descending-specificity": null,
     "number-leading-zero": null,

--- a/stencil-workspace/src/components/modus-button/modus-button.vars.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.vars.scss
@@ -49,13 +49,10 @@ $btn-borderless-active: (
     'color': #004470,
   ),
 );
-
 $modus-btn-borderless-bg: var(--modus-btn-bg, transparent) !default;
 $modus-btn-borderless-color: var(--modus-btn-color, map-get($theme-colors, 'primary')) !default;
-
 $modus-btn-borderless-hover-bg: var(--modus-btn-hover-bg, map-get($btn-borderless-hover, 'primary', 'bg')) !default;
 $modus-btn-borderless-hover-color: var(--modus-btn-hover-color, map-get($btn-borderless-hover, 'primary', 'color')) !default;
-
 $modus-btn-borderless-active-bg: var(--modus-btn-active-bg, map-get($btn-borderless-active, 'primary', 'bg')) !default;
 $modus-btn-borderless-active-color: var(--modus-btn-active-color, map-get($btn-borderless-active, 'primary', 'color')) !default;
 

--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item.vars.scss
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item.vars.scss
@@ -1,0 +1,23 @@
+$modus-tree-view-item-selected-indicator: var(--modus-tree-view-item-selected-indicator-color, #217cbb) !default;
+$modus-tree-view-item-drag-allow: var(--modus-tree-view-item-drag-border-color, #217cbb) !default;
+$modus-tree-view-item-drag-error: var(--modus-tree-view-item-drag-error-border-color, #da212c) !default;
+
+// Content Tree
+$modus-tree-view-item-bg: var(--modus-tree-view-item-bg, #fff) !default;
+$modus-tree-view-item-border-color: var(--modus-tree-view-item-border-color, #e0e1e9) !default;
+$modus-tree-view-item-color: var(--modus-tree-view-item-color, #252a2e) !default;
+
+// Hover
+$modus-tree-view-item-hover-bg: var(--modus-tree-view-item-hover-bg, #e0e1e9) !default;
+$modus-tree-view-item-hover-border-color: var(--modus-tree-view-item-hover-border-color, #e0e1e9) !default;
+$modus-tree-view-item-hover-color: var(--modus-tree-view-item-hover-color, #252a2e) !default;
+
+// Selected
+$modus-tree-view-item-selected-bg: var(--modus-tree-view-item-selected-bg, #dcedf9) !default;
+$modus-tree-view-item-selected-border-color: var(--modus-tree-view-item-selected-border-color, #dcedf9) !default;
+$modus-tree-view-item-selected-color: var(--modus-tree-view-item-selected-color, #252a2e);
+
+// Disabled
+$modus-tree-view-item-disabled-bg: var(--modus-tree-view-item-disabled-bg, #fff) !default;
+$modus-tree-view-item-disabled-border-color: var(--modus-tree-view-item-disabled-border-color, #e0e1e9) !default;
+$modus-tree-view-item-disabled-color: var(--modus-tree-view-item-color, #b7b9c3) !default;

--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item/modus-tree-view-item.scss
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item/modus-tree-view-item.scss
@@ -1,27 +1,41 @@
+@import './../modus-tree-view-item.vars';
+
 .tree-item {
   align-items: center;
-  background-color: $col_white;
-  border: $rem-1px solid $col_gray_0;
+  background-color: $modus-tree-view-item-bg;
+  border: $rem-1px solid $modus-tree-view-item-border-color;
+  color: $modus-tree-view-item-color;
   cursor: pointer;
   display: flex;
+  fill: $modus-tree-view-item-color;
   font-family: $primary-font;
   font-size: $rem-16px;
   min-height: $list-group-item-height;
   width: 100%;
 
+  svg path {
+    fill: $modus-tree-view-item-color;
+  }
+
   &.disabled {
-    background-color: $col_gray_1 !important;
-    border-color: $col_gray_1 !important;
+    background-color: $modus-tree-view-item-disabled-bg !important;
+    border-color: $modus-tree-view-item-disabled-border-color !important;
+    color: $modus-tree-view-item-disabled-color !important;
+    fill: $modus-tree-view-item-disabled-color !important;
     opacity: 0.7 !important;
     cursor: default !important;
+
+    svg path {
+      fill: $modus-tree-view-item-disabled-color !important;
+    }
   }
 
   &.drop-allow {
-    box-shadow: 0 -2px 0 $col_blue !important;
+    box-shadow: 0 -2px 0 $modus-tree-view-item-drag-allow !important;
   }
 
   &.drop-block {
-    box-shadow: 0 -2px 0 $col_red_light !important;
+    box-shadow: 0 -2px 0 $modus-tree-view-item-drag-error !important;
   }
 
   .hidden {
@@ -29,7 +43,14 @@
   }
 
   &:hover {
-    background-color: $col_gray_0;
+    background-color: $modus-tree-view-item-hover-bg;
+    color: $modus-tree-view-item-hover-color;
+    fill: $modus-tree-view-item-hover-color;
+    border-color: $modus-tree-view-item-hover-border-color;
+
+    svg path {
+      fill: $modus-tree-view-item-hover-color;
+    }
   }
 
   .icon-slot {
@@ -66,8 +87,14 @@
   }
 
   &.selected {
-    background-color: $col_blue_pale;
-    border-color: $col_blue_pale;
+    background-color: $modus-tree-view-item-selected-bg;
+    border-color: $modus-tree-view-item-selected-border-color;
+    color: $modus-tree-view-item-selected-color;
+    fill: $modus-tree-view-item-selected-color;
+
+    svg path {
+      fill: $modus-tree-view-item-selected-color;
+    }
   }
 
   &.small {
@@ -87,7 +114,7 @@
   position: relative;
 
   &.selected-indicator::before {
-    box-shadow: inset 0.3rem 0 0 0 $col_blue_light;
+    box-shadow: inset 0.3rem 0 0 0 $modus-tree-view-item-selected-indicator;
     content: '';
     height: 100%;
     left: 0;

--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view/modus-tree-view.scss
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view/modus-tree-view.scss
@@ -1,3 +1,5 @@
+@import './../modus-tree-view-item.vars';
+
 .drag-content {
   cursor: grabbing !important;
   left: 0;
@@ -7,17 +9,18 @@
   z-index: 99999;
 
   &.drop-allow {
-    outline: 2px dashed $col_blue !important;
+    outline: 2px dashed $modus-tree-view-item-drag-allow !important;
   }
 
   &.drop-block {
-    outline: 2px dashed $col_red_light !important;
+    outline: 2px dashed $modus-tree-view-item-drag-error !important;
   }
 
   .tree-item {
     align-items: center;
-    background-color: $col_white;
-    border: $rem-1px solid $col_gray_0;
+    background-color: $modus-tree-view-item-bg;
+    border: $rem-1px solid $modus-tree-view-item-border-color;
+    color: $modus-tree-view-item-color;
     display: flex;
     font-family: $primary-font;
     font-size: $rem-16px;

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -4,7 +4,7 @@
   --modus-black: #000;
   --modus-white: #fff;
   --modus-link-color: #217cbb;
-  --modus-highlight-blue:#217cbb;
+  --modus-highlight-blue: #217cbb;
 
   // Variants
   --modus-primary: #0063a3;
@@ -127,26 +127,26 @@
   // Content Tree
   --modus-tree-view-item-bg: var(--modus-white);
   --modus-tree-view-item-border-color: #e0e1e9;
-  --modus-tree-view-item-color:#252a2e;
+  --modus-tree-view-item-color: #252a2e;
 
   // Hover
   --modus-tree-view-item-hover-bg: #e0e1e9;
   --modus-tree-view-item-hover-border-color: var(--modus-tree-view-item-hover-bg);
-  --modus-tree-view-item-hover-color:var(--modus-tree-view-item-color);
+  --modus-tree-view-item-hover-color: var(--modus-tree-view-item-color);
 
   // Selected
-  --modus-tree-view-item-selected-bg: #dcedf9
+  --modus-tree-view-item-selected-bg: #dcedf9;
   --modus-tree-view-item-selected-border-color: var(--modus-tree-view-item-selected-bg);
-  --modus-tree-view-item-selected-color:var(--modus-tree-view-item-color);
+  --modus-tree-view-item-selected-color: var(--modus-tree-view-item-color);
 
   // Disabled
   --modus-tree-view-item-disabled-bg: var(--modus-tree-view-item-bg);
   --modus-tree-view-item-disabled-border-color: var(--modus-tree-view-item-border);
-  --modus-tree-view-item-disabled-color:#b7b9c3;
+  --modus-tree-view-item-disabled-color: #b7b9c3;
 }
 
 [data-mwc-theme='dark'] {
-  --modus-highlight-blue:#019aeb;
+  --modus-highlight-blue: #019aeb;
 
   // Variants
   --modus-primary: #019aeb;
@@ -263,22 +263,22 @@
   // Content Tree
   --modus-tree-view-item-bg: #171c1e;
   --modus-tree-view-item-border-color: #464b52;
-  --modus-tree-view-item-color:var(--modus-white);
+  --modus-tree-view-item-color: var(--modus-white);
 
   // Hover
   --modus-tree-view-item-hover-bg: #464b52;
   --modus-tree-view-item-hover-border-color: var(--modus-tree-view-item-hover-bg);
-  --modus-tree-view-item-hover-color:var(--modus-tree-view-item-color);
+  --modus-tree-view-item-hover-color: var(--modus-tree-view-item-color);
 
   // Selected
   --modus-tree-view-item-selected-bg: #1a4c67;
   --modus-tree-view-item-selected-border-color: #019aeb;
-  --modus-tree-view-item-selected-color:var(--modus-tree-view-item-color);
+  --modus-tree-view-item-selected-color: var(--modus-tree-view-item-color);
 
   // Disabled
   --modus-tree-view-item-disabled-bg: #171c1e;
   --modus-tree-view-item-disabled-border-color: var(--modus-tree-view-item-border);
-  --modus-tree-view-item-disabled-color:rgba(241,241,246,.3);
+  --modus-tree-view-item-disabled-color: rgba(241, 241, 246, 0.3);
 }
 
 modus-accordion-item {
@@ -465,7 +465,7 @@ modus-chip {
 }
 
 modus-tree-view,
-modus-tree-view-item{
+modus-tree-view-item {
   // Indicator
   --modus-tree-view-item-selected-indicator-color: var(--modus-highlight-blue);
   --modus-tree-view-item-drag-border-color: var(--modus-highlight-blue);

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -4,6 +4,7 @@
   --modus-black: #000;
   --modus-white: #fff;
   --modus-link-color: #217cbb;
+  --modus-highlight-blue:#217cbb;
 
   // Variants
   --modus-primary: #0063a3;
@@ -122,9 +123,31 @@
   --modus-chip-outline-active-bg: #dcedf9;
   --modus-chip-outline-active-color: #252a2e;
   --modus-chip-outline-active-border-color: #217cbb;
+
+  // Content Tree
+  --modus-tree-view-item-bg: var(--modus-white);
+  --modus-tree-view-item-border-color: #e0e1e9;
+  --modus-tree-view-item-color:#252a2e;
+
+  // Hover
+  --modus-tree-view-item-hover-bg: #e0e1e9;
+  --modus-tree-view-item-hover-border-color: var(--modus-tree-view-item-hover-bg);
+  --modus-tree-view-item-hover-color:var(--modus-tree-view-item-color);
+
+  // Selected
+  --modus-tree-view-item-selected-bg: #dcedf9
+  --modus-tree-view-item-selected-border-color: var(--modus-tree-view-item-selected-bg);
+  --modus-tree-view-item-selected-color:var(--modus-tree-view-item-color);
+
+  // Disabled
+  --modus-tree-view-item-disabled-bg: var(--modus-tree-view-item-bg);
+  --modus-tree-view-item-disabled-border-color: var(--modus-tree-view-item-border);
+  --modus-tree-view-item-disabled-color:#b7b9c3;
 }
 
 [data-mwc-theme='dark'] {
+  --modus-highlight-blue:#019aeb;
+
   // Variants
   --modus-primary: #019aeb;
   --modus-secondary: #6a6e79;
@@ -236,6 +259,26 @@
   --modus-chip-outline-active-bg: rgba(0, 79, 131, 0.5);
   --modus-chip-outline-active-border-color: #019aeb;
   --modus-chip-outline-active-color: #cbcdd6;
+
+  // Content Tree
+  --modus-tree-view-item-bg: #171c1e;
+  --modus-tree-view-item-border-color: #464b52;
+  --modus-tree-view-item-color:var(--modus-white);
+
+  // Hover
+  --modus-tree-view-item-hover-bg: #464b52;
+  --modus-tree-view-item-hover-border-color: var(--modus-tree-view-item-hover-bg);
+  --modus-tree-view-item-hover-color:var(--modus-tree-view-item-color);
+
+  // Selected
+  --modus-tree-view-item-selected-bg: #1a4c67;
+  --modus-tree-view-item-selected-border-color: #019aeb;
+  --modus-tree-view-item-selected-color:var(--modus-tree-view-item-color);
+
+  // Disabled
+  --modus-tree-view-item-disabled-bg: #171c1e;
+  --modus-tree-view-item-disabled-border-color: var(--modus-tree-view-item-border);
+  --modus-tree-view-item-disabled-color:rgba(241,241,246,.3);
 }
 
 modus-accordion-item {
@@ -345,7 +388,18 @@ modus-button[button-style='borderless'] {
   --modus-btn-active-bg: var(--modus-btn-outline-primary-hover-bg);
 }
 
-modus-checkbox {
+modus-card {
+  --modus-card-bg: var(--modus-body-bg);
+  --modus-card-color: var(--modus-body-color);
+  --modus-card-border-color: var(--modus-border-color);
+}
+
+// Note:
+// CSS variables defined in component selectors ex: 'modus-checkbox {...}' won't work well if the component is nested inside another component, ex: checkbox in content tree
+// Possible workarounds: Add CSS variables at the root or add it to the respective component css file, ex: components/modus-checkbox/modus-checkbox.vars.scss
+:root,
+[data-mwc-theme='light'],
+[data-mwc-theme='dark'] {
   --modus-checkbox-bg: var(--modus-custom-control-bg);
   --modus-checkbox-focus-border-color: var(--modus-checkbox-active-color);
   --modus-checkbox-border-color: #90939f;
@@ -361,21 +415,10 @@ modus-checkbox {
   --modus-checkbox-indeterminate-border-color: var(--modus-checkbox-active-color);
 }
 
-modus-card {
-  --modus-card-bg: var(--modus-body-bg);
-  --modus-card-color: var(--modus-body-color);
-  --modus-card-border-color: var(--modus-border-color);
-}
-
 modus-chip {
   --modus-chip-bg: var(--modus-tertiary);
   --modus-chip-border-color: var(--modus-tertiary);
   --modus-chip-color: #353a40;
-
-  // Hover
-  --modus-chip-hover-bg: #dbdce2;
-  --modus-chip-hover-border-color: #dbdce2;
-  --modus-chip-hover-color: var(--modus-chip-color);
 
   // Hover
   --modus-chip-hover-bg: #dbdce2;
@@ -419,4 +462,12 @@ modus-chip {
     --modus-chip-active-border-color: var(--modus-chip-outline-active-border-color);
     --modus-chip-active-color: var(--modus-chip-outline-active-color);
   }
+}
+
+modus-tree-view,
+modus-tree-view-item{
+  // Indicator
+  --modus-tree-view-item-selected-indicator-color: var(--modus-highlight-blue);
+  --modus-tree-view-item-drag-border-color: var(--modus-highlight-blue);
+  --modus-tree-view-item-drag-error-border-color: var(--modus-danger);
 }

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -21,19 +21,27 @@
             display: block;
             margin-top: 30px;
         }
-        /* :root{
-        --modus-body-bg: black;
-        --modus-body-color: white;
+        /* :root,
+[data-mwc-theme='light'],
+[data-mwc-theme='dark'],
+modus-checkbox{
+          --modus-checkbox-bg:green !important;
         } */
+
+        body{
+          --modus-checkbox-bg:yellow !important;
+
+        }
 
     </style>
   </head>
   <body>
 <div style="padding:10px;">
-  <modus-button color="primary" style="position: sticky;top:5;" id="toggle">Toggle theme</modus-button>
+  <modus-button color="primary" style="position: sticky;top:0;z-index:1000; padding: 10px;" id="toggle">Toggle theme</modus-button>
+  <modus-button color="primary" style="position: sticky;top:0;z-index:1000; padding: 10px;" id="reset">Reset theme</modus-button>
 
   <div>
-    <modus-button color="primary" id="toggle_accordion-item">Toggle Accordion theme</modus-button>
+    <modus-button color="primary" style="padding: 10px;" id="toggle_accordion-item">Toggle Accordion theme</modus-button>
   </div>
   <div>
     <modus-accordion >
@@ -46,7 +54,7 @@
   </div>
 
   <div>
-    <modus-button color="primary" id="toggle_alert">Toggle Alerts theme</modus-button>
+    <modus-button color="primary" style="padding: 10px;" id="toggle_alert">Toggle Alerts theme</modus-button>
   </div>
   <div>
     <modus-alert message="Info alert (default)"></modus-alert>
@@ -58,7 +66,7 @@
     <modus-alert message="Warning alert" type="warning"></modus-alert>
   </div>
   <div>
-    <modus-button color="primary" id="toggle_badge">Toggle Badges theme</modus-button>
+    <modus-button color="primary" id="toggle_badge" style="padding: 10px;">Toggle Badges theme</modus-button>
   </div>
   <div>
     <modus-badge>Default</modus-badge>
@@ -79,14 +87,14 @@
   </div>
 
   <div>
-    <modus-button color="primary" id="toggle_breadcrumb">Toggle Buttons theme</modus-button>
+    <modus-button color="primary" id="toggle_breadcrumb" style="padding: 10px;">Toggle Buttons theme</modus-button>
   </div>
   <div>
     <modus-breadcrumb></modus-breadcrumb>
   </div>
 
   <div>
-    <modus-button color="primary" id="toggle_button">Toggle Buttons theme</modus-button>
+    <modus-button color="primary" id="toggle_button" style="padding: 10px;">Toggle Buttons theme</modus-button>
   </div>
   <div>
     <modus-button color="primary">Primary</modus-button>
@@ -106,7 +114,7 @@
   </div>
 
   <div>
-    <modus-button color="primary" id="toggle_checkbox">Toggle Checkbox theme</modus-button>
+    <modus-button color="primary" id="toggle_checkbox" style="padding: 10px;">Toggle Checkbox theme</modus-button>
   </div>
   <div>
     <modus-checkbox></modus-checkbox>
@@ -118,7 +126,7 @@
   </div>
 
   <div>
-    <modus-button color="primary" id="toggle_card">Toggle Card theme</modus-button>
+    <modus-button color="primary" id="toggle_card" style="padding: 10px;">Toggle Card theme</modus-button>
   </div>
   <div>
     <modus-card>
@@ -131,7 +139,7 @@
     </modus-card>
   </div>
   <div>
-    <modus-button color="primary" id="toggle_chip">Toggle Chip theme</modus-button>
+    <modus-button color="primary" id="toggle_chip" style="padding: 10px;">Toggle Chip theme</modus-button>
   </div>
   <div>
     <modus-chip
@@ -169,6 +177,43 @@
 
     <modus-chip show-checkmark size="small" value="Pets OK"></modus-chip>
   </div>
+
+  <div>
+    <modus-button color="primary" id="toggle_tree-view--tree-view-item" style="padding: 10px;">Toggle Content tree theme</modus-button>
+  </div>
+  <div>
+    <modus-tree-view style="width:400px;"
+    checkbox-selection="true" class="hydrated">
+      <modus-tree-view-item node-id="1" label="Inbox" class="hydrated">
+        <svg
+          slot="itemIcon"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="currentColor"
+          height="16"
+          width="16"
+          viewBox="0 0 32 32">
+          <path
+            d="M28.79 12.39A1 1 0 0 0 28 12h-2V9c0-.55-.45-1-1-1h-9.59l-1.7-1.71C13.52 6.11 13.27 6 13 6H4c-.55 0-1 .45-1 1v17c0 .04.02.07.02.11.01.05.02.11.04.16.02.09.06.17.1.25.02.03.02.06.05.09.01.01.03.02.04.03.07.08.15.14.23.19.04.03.06.05.1.07.13.06.27.1.42.1h21c.13 0 .25-.03.36-.07.04-.02.07-.04.1-.06.07-.04.14-.08.2-.13.03-.03.06-.06.09-.1.05-.05.09-.11.12-.18a.31.31 0 0 0 .06-.13c.01-.02.03-.04.03-.07l3-11c.09-.3.02-.62-.17-.87zM5 8h7.59l1.7 1.71c.19.18.44.29.71.29h9v2H7c-.45 0-.85.3-.96.74L5 16.53V8z"></path>
+        </svg>
+        <modus-tree-view-item
+          node-id="2"
+          label="Personal"
+          class="hydrated" draggable-item droppable-item></modus-tree-view-item>
+        <modus-tree-view-item
+          node-id="3"
+          label="Work"
+          class="hydrated" draggable-item droppable-item></modus-tree-view-item>
+        <modus-tree-view-item
+          node-id="4"
+          label="Social"
+          class="hydrated" draggable-item droppable-item></modus-tree-view-item>
+        <modus-tree-view-item
+          node-id="5"
+          label="More ..."
+          class="hydrated" draggable-item droppable-item></modus-tree-view-item>
+      </modus-tree-view-item>
+    </modus-tree-view>
+  </div>
 </div>
   </body>
   <script>
@@ -176,15 +221,30 @@
         document.body.setAttribute('data-mwc-theme',  document.body.getAttribute('data-mwc-theme') === 'dark' ? 'light' : 'dark');
     });
 
+    document.querySelector('#reset').addEventListener('buttonClick', () => {
+        document.body.removeAttribute('data-mwc-theme');
+    });
+
+    function updateTheme(c){
+    Array.from(document.querySelectorAll(`modus-${c}`)).map(i => {
+          i.setAttribute('data-mwc-theme',  i.getAttribute('data-mwc-theme') === 'dark' ? 'light' : 'dark');
+        });
+    }
+
     Array.from(document.querySelectorAll('modus-button'))
     .filter(b => b.id !== 'toggle' && b.id.startsWith('toggle'))
     .map(b => b.id.split('_')[1])
     .forEach((c) => {
       document.querySelector(`#toggle_${c}`).addEventListener('buttonClick', () => {
-        Array.from(document.querySelectorAll(`modus-${c}`)).map(i => {
-          i.setAttribute('data-mwc-theme',  i.getAttribute('data-mwc-theme') === 'dark' ? 'light' : 'dark');
-        });
-    });
+        if(c.includes('--')){
+          c.split('--').forEach(d => {
+            updateTheme(d);
+          });
+        }
+        else
+            updateTheme(c);
+      });
+
     });
 
     const modusBreadcrumb = document.querySelector('modus-breadcrumb');


### PR DESCRIPTION
Note:
CSS variables defined inside component selectors ex: `modus-checkbox { --modus-checkbox-bg: white; }` won't work if the component is nested inside another component, ex: checkbox in a content tree item
As a workaround, we have added all the checkbox specific variables at the root. 

discussed with @coliff and decided to go this way, for now, @ryan-henness-trimble if you have any ideas do let us know.


Fixes #800 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
