### PR TITLE
Explicitly set aria disabled values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+### Fixed
+
+- Fixed inexplicitly set aria-disabled values
+
 ## 0.1.24 - 2022-11-17
 
 ### Added

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
@@ -56,7 +56,7 @@ export class ModusAccordionItem {
     const bodyClass = `body ${sizeClass} ${this.expanded ? 'expanded' : ''}`;
 
     return (
-      <div aria-disabled={this.disabled} aria-expanded={this.expanded} class="accordion-item">
+      <div aria-disabled={this.disabled ? 'true' : undefined} aria-expanded={this.expanded} class="accordion-item">
         <div class={`header ${sizeClass} ${disabledClass}`} onClick={() => this.handleHeaderClick()} onKeyDown={(event) => this.handleKeydown(event)} tabIndex={0}>
           <span class="title">{this.headerText}</span>
           {this.expanded ? <IconChevronUpThick size={iconSize}></IconChevronUpThick> : <IconChevronDownThick size={iconSize}></IconChevronDownThick>}

--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
@@ -84,7 +84,7 @@ export class ModusCheckbox {
         </div>
         <input
           aria-checked={this.checked}
-          aria-disabled={this.disabled}
+          aria-disabled={this.disabled ? 'true' : undefined}
           aria-label={this.ariaLabel}
           checked={this.checked}
           disabled={this.disabled}

--- a/stencil-workspace/src/components/modus-chip/modus-chip.tsx
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.tsx
@@ -97,7 +97,7 @@ export class ModusChip {
     `;
 
     return (
-      <div aria-disabled={this.disabled} aria-label={this.ariaLabel} class={chipClass} onClick={this.disabled ? null : (event) => this.onChipClick(event)} tabIndex={0}>
+      <div aria-disabled={this.disabled ? 'true' : undefined} aria-label={this.ariaLabel} class={chipClass} onClick={this.disabled ? null : (event) => this.onChipClick(event)} tabIndex={0}>
         {this.imageUrl ? <img src={this.imageUrl} alt="" /> : this.showCheckmark ? <IconCheck size={'24'}></IconCheck> : null}
         <span>{this.value}</span>
         {this.showClose ? <IconRemove onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'24'}></IconRemove> : null}

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
@@ -79,7 +79,7 @@ export class ModusNumberInput {
 
     return (
       <div
-        aria-disabled={this.disabled}
+        aria-disabled={this.disabled ? 'true' : undefined}
         aria-label={this.ariaLabel}
         aria-placeholder={this.placeholder}
         aria-invalid={!!this.errorText}

--- a/stencil-workspace/src/components/modus-select/modus-select.tsx
+++ b/stencil-workspace/src/components/modus-select/modus-select.tsx
@@ -126,7 +126,7 @@ export class ModusSelect {
     const inputContainerClass = `input-container ${this.visible ? 'dropdown-visible' : ''}`;
 
     return (
-      <div role="listbox" aria-disabled={this.disabled} aria-label={this.ariaLabel} aria-required={this.required}>
+      <div role="listbox" aria-disabled={this.disabled ? 'true' : undefined} aria-label={this.ariaLabel} aria-required={this.required}>
         {this.label || this.required
           ? <div class={'label-container'}>
               {this.label ? <label>{this.label}</label> : null}

--- a/stencil-workspace/src/components/modus-slider/modus-slider.tsx
+++ b/stencil-workspace/src/components/modus-slider/modus-slider.tsx
@@ -48,7 +48,7 @@ export class ModusSlider {
 
     return (
       <div
-        aria-disabled={this.disabled}
+        aria-disabled={this.disabled ? 'true' : undefined}
         aria-label={this.ariaLabel}
         aria-valuemax={this.maxValue}
         aria-valuemin={this.minValue}

--- a/stencil-workspace/src/components/modus-switch/modus-switch.tsx
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.tsx
@@ -65,7 +65,7 @@ export class ModusSwitch {
         </div>
         <input
           aria-checked={this.checked}
-          aria-disabled={this.disabled}
+          aria-disabled={this.disabled ? 'true' : undefined}
           aria-label={this.ariaLabel}
           checked={this.checked}
           disabled={this.disabled}

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -103,7 +103,7 @@ export class ModusTextInput {
 
     return (
       <div
-        aria-disabled={this.disabled}
+        aria-disabled={this.disabled ? 'true' : undefined}
         aria-invalid={!!this.errorText}
         aria-label={this.ariaLabel}
         aria-readonly={this.readOnly}


### PR DESCRIPTION
## Description

These values were not getting set explicitly so only the attribute would get set in the DOM, which did not include the `=""`.

Fixes #569 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually in the dev env and Storybook

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
