### PR TITLE
Formatting with Prettier

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,13 @@
 # CODEOWNERS
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Folders
+## Folders
 
 *                    @ryan-henness-trimble
 /react-workspace/    @msankaran0712
 /stencil-workspace/  @ryan-henness-trimble
 
-# File Types
+## File Types
 
 .cspell.json              @coliff
 *.css                     @coliff

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,8 +3,6 @@ name: Bug report
 about: Create a report to help improve Modus Web Components
 title: "[BUG] Issue Title"
 labels: bug
-assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +10,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,8 +23,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
+
+- OS: [e.g. iOS 16]
+- Browser [e.g. Chrome, Safari]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ Fixes # (issue)
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
-## Checklist:
+## Checklist
 
 - [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -32,13 +32,13 @@ jobs:
           JAVASCRIPT_DEFAULT_STYLE: prettier
           LINTER_RULES_PATH: /
           LOG_LEVEL: NOTICE
+          MARKDOWN_CONFIG_FILE: .markdownlint.json
           SUPPRESS_POSSUM: true
           VALIDATE_ALL_CODEBASE: false
           VALIDATE_CSS: false
           VALIDATE_EDITORCONFIG: false
           VALIDATE_GITLEAKS: false
           VALIDATE_HTML: false
-          VALIDATE_MARKDOWN: false
           VALIDATE_NATURAL_LANGUAGE: false
           VALIDATE_YAML: false
           VALIDATE_TYPESCRIPT_ES: false

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD024": false,
+  "MD033": false,
+  "MD041": false
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,4 @@
 {
   "bracketSameLine": true,
-  "printWidth": 220,
   "singleQuote": true
 }

--- a/stencil-workspace/storybook/stories/components/modus-card/modus-card-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-card/modus-card-storybook-docs.mdx
@@ -25,18 +25,18 @@ This component utilizes the slot element, allowing you to render your own HTML i
 
 ### Properties
 
-| Property            | Attribute              | Description                                                                            | Type      | Default     | Required     | 
-| ------------------- | ---------------------- | -------------------------------------------------------------------------------------- | --------- | ----------- | -----------  |
-| `ariaLabel`         | `aria-label`           | (optional) The card's aria-label.                                                      | `string`  | `undefined` |              |
-| `backgroundColor`   | `background-color`     | (optional) The color of the card.                                                      | `string`  | `undefined` |              |
-| `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `undefined` |              |
-| `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `'269px'`   |              |
-| `showCardBorder`    | `show-card-border`     | (optional) A flag that controls the display of border.                                 | `boolean` | `true`      |              |
-| `showShadowOnHover` | `show-shadow-on-hover` | (optional) A flag that controls the display of shadow box when the element is hovered. | `boolean` | `true`      |              |
-| `width`             | `width`                | (optional) The width of the card.                                                      | `string`  | `'240px'`   |              |
+| Property            | Attribute              | Description                                                                            | Type      | Default     | Required |
+| ------------------- | ---------------------- | -------------------------------------------------------------------------------------- | --------- | ----------- | -------- |
+| `ariaLabel`         | `aria-label`           | (optional) The card's aria-label.                                                      | `string`  | `undefined` |          |
+| `backgroundColor`   | `background-color`     | (optional) The color of the card.                                                      | `string`  | `undefined` |          |
+| `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `undefined` |          |
+| `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `'269px'`   |          |
+| `showCardBorder`    | `show-card-border`     | (optional) A flag that controls the display of border.                                 | `boolean` | `true`      |          |
+| `showShadowOnHover` | `show-shadow-on-hover` | (optional) A flag that controls the display of shadow box when the element is hovered. | `boolean` | `true`      |          |
+| `width`             | `width`                | (optional) The width of the card.                                                      | `string`  | `'240px'`   |          |
 
+---
 
-----------------------------------------------
 ### Accessibility
 
 - Card gets an `aria-label` provided by the `aria-label` property input.

--- a/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table-storybook-docs.mdx
@@ -111,21 +111,21 @@ To define columns and data in the table _using objects_:
 - When a row action is clicked, a `ModusDataTableRowActionClickEvent` is fired with the relevant `actionId`, and `rowId`.
   - Each row action takes an `_id` (which will be emitted in the event detail), and a `display` object that sets the `text` and optional `icon`.
     ```ts
-      document.querySelector('modus-data-table').rowActions = [
-          {
-              _id: '0',
-              display: {
-                  text: 'Delete',
-                  icon: 'delete'
-              }
-          },
-          {
-              _id: '1',
-              display: {
-                  text: 'Edit'
-              }
-          }
-      ];
+    document.querySelector('modus-data-table').rowActions = [
+      {
+        _id: '0',
+        display: {
+          text: 'Delete',
+          icon: 'delete',
+        },
+      },
+      {
+        _id: '1',
+        display: {
+          text: 'Edit',
+        },
+      },
+    ];
     ```
 
 ### Cell Types
@@ -201,8 +201,8 @@ interface ModusDataTableSort {
 
 interface ModusDataTableSortEvent extends ModusDataTableSort {}
 interface ModusDataTableRowActionClickEvent {
-  actionId: string,
-  rowId: string
+  actionId: string;
+  rowId: string;
 }
 
 interface ModusDataTableDisplayOptions {
@@ -234,15 +234,14 @@ interface ModusTableSortOptions {
 
 ### Properties
 
-| Property               | Attribute | Description                                | Type                           | Default                                                                                                                               |
-| ---------------------- | --------- | ------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `columns` _(required)_ | --        |                                            | `TColumn[], string[]`        | `undefined`                                                                                                                           |
-| `data` _(required)_    | --        |                                            | `TCell[][], TRow[]`          | `undefined`                                                                                                                           |
-| `displayOptions`       | --        | Options for data table display.            | `ModusDataTableDisplayOptions` | `{     animateRowActionsDropdown: false,     borderless: true,     cellBorderless: true,     rowStripe: false,     size: 'large'   }` |
-| `rowActions`           | --        | Actions that can be performed on each row. | `ModusDataTableRowAction[]`    | `[]`                                                                                                                                  |
-| `selectionOptions`     | --        | Options for data table item selection.     | `ModusTableSelectionOptions`   | `{     canSelect: false,     checkboxSelection: false,   }`                                                                           |
-| `sortOptions`          | --        | Options for data table column sort.        | `ModusTableSortOptions`        | `{     canSort: false,     serverSide: false,   }`                                                                                    |
-
+| Property               | Attribute | Description                                | Type                           | Default                                                                                                         |
+| ---------------------- | --------- | ------------------------------------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `columns` _(required)_ | --        |                                            | `TColumn[], string[]`          | `undefined`                                                                                                     |
+| `data` _(required)_    | --        |                                            | `TCell[][], TRow[]`            | `undefined`                                                                                                     |
+| `displayOptions`       | --        | Options for data table display.            | `ModusDataTableDisplayOptions` | `{ animateRowActionsDropdown: false, borderless: true, cellBorderless: true, rowStripe: false, size: 'large' }` |
+| `rowActions`           | --        | Actions that can be performed on each row. | `ModusDataTableRowAction[]`    | `[]`                                                                                                            |
+| `selectionOptions`     | --        | Options for data table item selection.     | `ModusTableSelectionOptions`   | `{ canSelect: false, checkboxSelection: false, }`                                                               |
+| `sortOptions`          | --        | Options for data table column sort.        | `ModusTableSortOptions`        | `{ canSort: false, serverSide: false, }`                                                                        |
 
 ### Events
 

--- a/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table.stories.tsx
@@ -13,7 +13,7 @@ export default {
         'rowDoubleClick',
         'selection',
         'sort',
-        'rowActionClick'
+        'rowActionClick',
       ],
     },
     docs: {

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
@@ -46,7 +46,6 @@
 | `placement`       | `placement`         | (optional) The placement of the dropdown in related to the toggleElement.                        | `"bottom", "left", "right", "top"`                                  | `'bottom'`  |
 | `toggleElementId` | `toggle-element-id` | (required) The element id that the list renders near and that triggers the toggling of the list. | `string`                                                            | `undefined` |
 
-
 ### Events
 
 | Event           | Description                            | Type               |

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -19,6 +19,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <Story id="components-navbar--default" height={'300px'} />
 
 ### Failed Avatar (Initials Fallback)
+
 <Story id="components-navbar--failed-avatar" height={'300px'} />
 
 ```html

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -20,7 +20,12 @@ export default {
 };
 
 const Template = () => html`
-  <modus-navbar id="working" show-apps-menu show-help-menu show-main-menu show-notifications>
+  <modus-navbar
+    id="working"
+    show-apps-menu
+    show-help-menu
+    show-main-menu
+    show-notifications>
     <div slot="main">Render your own main menu.</div>
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>
@@ -29,7 +34,12 @@ const Template = () => html`
 export const Default = Template.bind({});
 
 const FailedToLoadAvatarTemplate = () => html`
-  <modus-navbar id="broken" show-apps-menu show-help-menu show-main-menu show-notifications>
+  <modus-navbar
+    id="broken"
+    show-apps-menu
+    show-help-menu
+    show-main-menu
+    show-notifications>
     <div slot="main">Render your own main menu.</div>
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>

--- a/stencil-workspace/storybook/stories/components/modus-tabs/modus-tabs-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-tabs/modus-tabs-storybook-docs.mdx
@@ -41,12 +41,12 @@ A new TypeScript typing has been provided named Tab defined as:
 
 ### Properties
 
-| Name         | Description          | Type     | Options          | Default Value | Required |
-| ------------ | -------------------- | -------- | ---------------- | ------------- | -------- |
-| `tabs`       | The tabs' tabs       | `Tab[]`  |                  |               | ✔        |
-| `aria-label` | The tabs' aria-label | `string` |                  |               |          |
-| `size`       | The tabs' size       | `string` | 'medium', 'small | 'medium'      |          |
-| `full-width` | The tabs' width      | `boolean`|  true, false     |  false        |          |
+| Name         | Description          | Type      | Options          | Default Value | Required |
+| ------------ | -------------------- | --------- | ---------------- | ------------- | -------- |
+| `tabs`       | The tabs' tabs       | `Tab[]`   |                  |               | ✔        |
+| `aria-label` | The tabs' aria-label | `string`  |                  |               |          |
+| `size`       | The tabs' size       | `string`  | 'medium', 'small | 'medium'      |          |
+| `full-width` | The tabs' width      | `boolean` | true, false      | false         |          |
 
 ### DOM Events
 
@@ -58,4 +58,4 @@ A new TypeScript typing has been provided named Tab defined as:
 
 - Tabs gets an `aria-label` provided by the `aria-label` property input.
 - When a Tab has focus, **Enter** activates the Tab, and emits the `tabChange` event.
-- Set `full-width` on `true` for Tab component in order to make it resizable inside a parent. 
+- Set `full-width` on `true` for Tab component in order to make it resizable inside a parent.


### PR DESCRIPTION
## Description

The `.prettierrc` config was not setup to match the formatting of the stencil-workspace directory. This PR removes the `printWidth` rule and runs Prettier on the folder. The Markdownlint config is added so any future PRs are linted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
