### PR TITLE
Add engines to `package.json`

### DIFF
--- a/stencil-workspace/storybook/package-lock.json
+++ b/stencil-workspace/storybook/package-lock.json
@@ -28,6 +28,10 @@
         "@storybook/web-components": "^6.5.13",
         "babel-loader": "^8.2.5",
         "storybook-dark-mode": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 <17.0.0",
+        "npm": ">=8.0.0 <9.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/stencil-workspace/storybook/package.json
+++ b/stencil-workspace/storybook/package.json
@@ -26,5 +26,9 @@
     "babel-loader": "^8.2.5",
     "storybook-dark-mode": "^1.1.2"
   },
+  "engines": {
+    "npm": ">=8.0.0 <9.0.0",
+    "node": ">=16.0.0 <17.0.0"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
This acts as a warning about Node v18 compatibility in light of #898

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

`npm install` works as normal and expected with node v16.18.1

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
