### PR TITLE
Making ariaLabel nullable

### DIFF
--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -19,7 +19,7 @@ export namespace Components {
         /**
           * (optional) The accordion's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
     }
     interface ModusAccordionItem {
         /**
@@ -43,7 +43,7 @@ export namespace Components {
         /**
           * (optional) The alert's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the alert has a dismiss button
          */
@@ -61,7 +61,7 @@ export namespace Components {
         /**
           * (optional) The badge's aria-label
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The color of the badge
          */
@@ -79,7 +79,7 @@ export namespace Components {
         /**
           * The breadcrumb's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * The breadcrumbs to render.
          */
@@ -89,7 +89,7 @@ export namespace Components {
         /**
           * (optional) The button's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The style of the button
          */
@@ -111,7 +111,7 @@ export namespace Components {
         /**
           * (optional) The card's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The color of the card.
          */
@@ -141,7 +141,7 @@ export namespace Components {
         /**
           * (optional) The checkbox's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the checkbox is checked.
          */
@@ -163,7 +163,7 @@ export namespace Components {
         /**
           * (optional) The chip's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The chip's style.
          */
@@ -225,7 +225,7 @@ export namespace Components {
         /**
           * (optional) The dropdown's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Determines custom dropdown placement offset.
          */
@@ -256,7 +256,7 @@ export namespace Components {
         /**
           * (optional) The dropzone's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The dropzone's description text.
          */
@@ -330,7 +330,7 @@ export namespace Components {
         /**
           * (optional) The message's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The message's icon.
          */
@@ -344,7 +344,7 @@ export namespace Components {
         /**
           * (optional) The modal's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         "close": () => Promise<void>;
         /**
           * (optional) The modal's primary button text.
@@ -442,7 +442,7 @@ export namespace Components {
         /**
           * (optional) The input's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the input is disabled.
          */
@@ -498,7 +498,7 @@ export namespace Components {
     }
     interface ModusPagination {
         "activePage": number;
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         "maxPage": number;
         "minPage": number;
         "size": 'large' | 'medium' | 'small';
@@ -507,7 +507,7 @@ export namespace Components {
         /**
           * (optional) The progress bar's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The progress bar's background color.
          */
@@ -545,7 +545,7 @@ export namespace Components {
         /**
           * The radio group's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * The ID of the checked radio button.
          */
@@ -563,7 +563,7 @@ export namespace Components {
         /**
           * (optional) The select's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the input is disabled.
          */
@@ -609,7 +609,7 @@ export namespace Components {
         /**
           * (optional) The slider's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the slider is disabled. *
          */
@@ -645,7 +645,7 @@ export namespace Components {
         /**
           * (optional) The switch's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the switch is checked.
          */
@@ -660,7 +660,7 @@ export namespace Components {
         "label": string;
     }
     interface ModusTabs {
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         "fullWidth": boolean;
         "size": 'medium' | 'small';
         /**
@@ -672,7 +672,7 @@ export namespace Components {
         /**
           * (optional) The input's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Sets autofocus on the input.
          */
@@ -756,7 +756,7 @@ export namespace Components {
         /**
           * (optional) The toast's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) Whether the toast has a dismiss button.
          */
@@ -774,7 +774,7 @@ export namespace Components {
         /**
           * (optional) The tooltip's aria-label.
          */
-        "ariaLabel": string;
+        "ariaLabel": string | null;
         /**
           * (optional) The tooltip's position relative to its content.
          */
@@ -1190,7 +1190,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The accordion's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
     }
     interface ModusAccordionItem {
         /**
@@ -1222,7 +1222,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The alert's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the alert has a dismiss button
          */
@@ -1244,7 +1244,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The badge's aria-label
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The color of the badge
          */
@@ -1262,7 +1262,7 @@ declare namespace LocalJSX {
         /**
           * The breadcrumb's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * The breadcrumbs to render.
          */
@@ -1276,7 +1276,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The button's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The style of the button
          */
@@ -1302,7 +1302,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The card's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The color of the card.
          */
@@ -1332,7 +1332,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The checkbox's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the checkbox is checked.
          */
@@ -1358,7 +1358,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The chip's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The chip's style.
          */
@@ -1448,7 +1448,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The dropdown's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Determines custom dropdown placement offset.
          */
@@ -1479,7 +1479,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The dropzone's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The dropzone's description text.
          */
@@ -1549,7 +1549,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The message's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The message's icon.
          */
@@ -1563,7 +1563,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The modal's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The modal's primary button text.
          */
@@ -1688,7 +1688,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The input's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the input is disabled.
          */
@@ -1748,7 +1748,7 @@ declare namespace LocalJSX {
     }
     interface ModusPagination {
         "activePage"?: number;
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         "maxPage"?: number;
         "minPage"?: number;
         /**
@@ -1761,7 +1761,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The progress bar's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The progress bar's background color.
          */
@@ -1799,7 +1799,7 @@ declare namespace LocalJSX {
         /**
           * The radio group's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * The ID of the checked radio button.
          */
@@ -1821,7 +1821,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The select's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the input is disabled.
          */
@@ -1871,7 +1871,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The slider's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the slider is disabled. *
          */
@@ -1915,7 +1915,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The switch's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the switch is checked.
          */
@@ -1934,7 +1934,7 @@ declare namespace LocalJSX {
         "onSwitchClick"?: (event: ModusSwitchCustomEvent<boolean>) => void;
     }
     interface ModusTabs {
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         "fullWidth"?: boolean;
         /**
           * An event that fires on tab change.
@@ -1950,7 +1950,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The input's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Sets autofocus on the input.
          */
@@ -2034,7 +2034,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The toast's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) Whether the toast has a dismiss button.
          */
@@ -2056,7 +2056,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The tooltip's aria-label.
          */
-        "ariaLabel"?: string;
+        "ariaLabel"?: string | null;
         /**
           * (optional) The tooltip's position relative to its content.
          */

--- a/stencil-workspace/src/components/modus-accordion/modus-accordion.tsx
+++ b/stencil-workspace/src/components/modus-accordion/modus-accordion.tsx
@@ -9,7 +9,7 @@ import { Component, h, Prop } from '@stencil/core';
 
 export class ModusAccordion {
   /** (optional) The accordion's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   render(): unknown {
     return (

--- a/stencil-workspace/src/components/modus-alert/modus-alert.tsx
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.tsx
@@ -13,7 +13,7 @@ import { IconInfo } from '../icons/icon-info';
 })
 export class ModusAlert {
   /** (optional) The alert's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the alert has a dismiss button */
   @Prop() dismissible: boolean;

--- a/stencil-workspace/src/components/modus-badge/modus-badge.tsx
+++ b/stencil-workspace/src/components/modus-badge/modus-badge.tsx
@@ -8,7 +8,7 @@ import { Component, Prop, h } from '@stencil/core';
 })
 export class ModusBadge {
   /** (optional) The badge's aria-label */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The color of the badge */
   @Prop() color: 'danger' | 'dark' | 'primary' | 'secondary' | 'success' | 'tertiary' | 'warning' = 'primary';

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
@@ -13,7 +13,7 @@ export interface Crumb {
 })
 export class ModusBreadcrumb {
   /** The breadcrumb's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** The breadcrumbs to render. */
   @Prop() crumbs: Crumb[] = [];

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -8,7 +8,7 @@ import { Component, Prop, h, Event, EventEmitter, Element, State, Listen } from 
 })
 export class ModusButton {
   /** (optional) The button's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The style of the button */
   @Prop() buttonStyle: 'borderless' | 'fill' | 'outline' = 'fill';

--- a/stencil-workspace/src/components/modus-card/modus-card.tsx
+++ b/stencil-workspace/src/components/modus-card/modus-card.tsx
@@ -8,7 +8,7 @@ import { Component, Prop, h } from '@stencil/core';
 })
 export class ModusCard {
   /** (optional) The card's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The height of the card. */
   @Prop() height = '269px';

--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
@@ -10,7 +10,7 @@ import { IconIndeterminate } from '../icons/icon-indeterminate';
 })
 export class ModusCheckbox {
   /** (optional) The checkbox's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the checkbox is checked. */
   @Prop({ mutable: true }) checked: boolean;

--- a/stencil-workspace/src/components/modus-chip/modus-chip.tsx
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.tsx
@@ -10,7 +10,7 @@ import { IconCheck } from '../icons/icon-check';
 })
 export class ModusChip {
   /** (optional) The chip's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The chip's style. */
   @Prop() chipStyle: 'outline' | 'solid' = 'solid';

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
@@ -14,7 +14,7 @@ export class ModusDropdown {
   @Prop() animateList = false;
 
   /** (optional) The dropdown's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Determines custom dropdown placement offset. */
   @Prop() customPlacement: {

--- a/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.tsx
+++ b/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.tsx
@@ -14,7 +14,7 @@ export class ModusFileDropzone {
   @State() fileDraggedOver = false;
 
   /** (optional) The dropzone's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The dropzone's description text. */
   @Prop() description: string;

--- a/stencil-workspace/src/components/modus-message/modus-message.tsx
+++ b/stencil-workspace/src/components/modus-message/modus-message.tsx
@@ -11,7 +11,7 @@ import { IconMap } from '../icons/IconMap';
 })
 export class ModusMessage {
   /** (optional) The message's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The message's icon. */
   @Prop() icon?: string;

--- a/stencil-workspace/src/components/modus-modal/modus-modal.tsx
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.tsx
@@ -9,7 +9,7 @@ import { IconClose } from '../icons/icon-close';
 })
 export class ModusModal {
   /** (optional) The modal's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The modal's primary button text. */
   @Prop() headerText: string;

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
@@ -8,7 +8,7 @@ import { Component, Event, EventEmitter, h, Prop, Watch } from '@stencil/core';
 })
 export class ModusNumberInput {
   /** (optional) The input's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the input is disabled. */
   @Prop() disabled: boolean;

--- a/stencil-workspace/src/components/modus-pagination/modus-pagination.tsx
+++ b/stencil-workspace/src/components/modus-pagination/modus-pagination.tsx
@@ -10,7 +10,7 @@ import { IconChevronRightThick } from '../icons/icon-chevron-right-thick';
 })
 export class ModusPagination {
   /* (optional) The pagination's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /* The active page. */
   @Prop() activePage: number;

--- a/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.tsx
+++ b/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.tsx
@@ -9,7 +9,7 @@ import { Component, Prop, h, Host } from '@stencil/core';
 
 export class ModusProgressBar {
   /** (optional) The progress bar's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The progress bar's background color. */
   @Prop() backgroundColor: string;

--- a/stencil-workspace/src/components/modus-radio-group/modus-radio-group.tsx
+++ b/stencil-workspace/src/components/modus-radio-group/modus-radio-group.tsx
@@ -9,7 +9,7 @@ import { ModusRadioButton, RadioButton } from './modus-radio-button';
 })
 export class ModusRadioGroup {
   /** The radio group's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** The ID of the checked radio button. */
   @Prop({ mutable: true }) checkedId: string;

--- a/stencil-workspace/src/components/modus-select/modus-select.tsx
+++ b/stencil-workspace/src/components/modus-select/modus-select.tsx
@@ -13,7 +13,7 @@ export class ModusSelect {
   // @Prop() autofocus: boolean;
 
   /** (optional) The select's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the input is disabled. */
   @Prop() disabled: boolean;

--- a/stencil-workspace/src/components/modus-slider/modus-slider.tsx
+++ b/stencil-workspace/src/components/modus-slider/modus-slider.tsx
@@ -8,7 +8,7 @@ import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';
 })
 export class ModusSlider {
   /** (optional) The slider's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the slider is disabled. **/
   @Prop() disabled = false;

--- a/stencil-workspace/src/components/modus-switch/modus-switch.tsx
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.tsx
@@ -8,7 +8,7 @@ import { Component, Prop, h, Event, EventEmitter, Listen } from '@stencil/core';
 })
 export class ModusSwitch {
   /** (optional) The switch's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the switch is checked. */
   @Prop({ mutable: true }) checked: boolean;

--- a/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
+++ b/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
@@ -17,7 +17,7 @@ export class ModusTabs {
   @Prop() fullWidth = false;
 
   /* (optional) The tabs' aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /* (optional) The tabs' size. */
   @Prop() size: 'medium' | 'small' = 'medium';

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -10,7 +10,7 @@ import { IconClose } from '../icons/icon-close';
 })
 export class ModusTextInput {
   /** (optional) The input's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Sets autofocus on the input. */
   @Prop() autoFocusInput: boolean;

--- a/stencil-workspace/src/components/modus-toast/modus-toast.tsx
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.tsx
@@ -14,7 +14,7 @@ import { IconClose } from '../icons/icon-close';
 })
 export class ModusToast {
   /** (optional) The toast's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) Whether the toast has a dismiss button. */
   @Prop() dismissible: boolean;

--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.tsx
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.tsx
@@ -8,7 +8,7 @@ import { Component, h, Prop } from '@stencil/core';
 })
 export class ModusTooltip {
   /** (optional) The tooltip's aria-label. */
-  @Prop() ariaLabel: string;
+  @Prop() ariaLabel: string | null;
 
   /** (optional) The tooltip's position relative to its content. */
   @Prop() position: 'bottom' | 'left' | 'right' | 'top' = 'top';


### PR DESCRIPTION
## Description

Making ariaLabel nullabe.

Was using this npm package on my angular project and was confronted with an error when compiling:
```
Error: node_modules/@trimble-oss/modus-web-components/dist/types/components.d.ts:1115:15 - error TS2320:
Interface 'HTMLModusTooltipElement' cannot simultaneously extend types 'ModusTooltip' and 'HTMLStencilElement'.
  Named property 'ariaLabel' of types 'ModusTooltip' and 'HTMLStencilElement' are not identical.

1115     interface HTMLModusTooltipElement extends Components.ModusTooltip, HTMLStencilElement {
```

`HTMLStencilElement` extends `HTMLElement` that extends `Element` that extends `ARIAMixin` that has the property:
```
interface ARIAMixin {
    ...
    ariaLabel: string | null;
    ...
}
```

Fixes # (issue) Didn't create issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

ran `npm run test` and all tests passed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
