### PR TITLE
Fix headings underline color in dark mode

### DIFF
--- a/stencil-workspace/storybook/public/storybook-styles.css
+++ b/stencil-workspace/storybook/public/storybook-styles.css
@@ -13,6 +13,7 @@ body[data-mwc-theme="light"] {
   --theme-code-color: #333;
   --theme-code-bg-color: #f8f8f8;
   --theme-code-border-color: #eee;
+  --theme-header-underline-color: rgba(0,0,0,.1);
 }
 
 body[data-mwc-theme="dark"] {
@@ -28,6 +29,7 @@ body[data-mwc-theme="dark"] {
   --theme-code-color: #f1f1f6;
   --theme-code-bg-color: #6a6e79;
   --theme-code-border-color: #6a6e79;
+  --theme-header-underline-color: rgba(255,255,255,.2);
 }
 
 body.sb-show-main,
@@ -40,6 +42,12 @@ body.sb-show-main,
 .sbdocs-ul {
   color: var(--theme-color) !important;
   background-color: var(--theme-bg-color) !important;
+}
+
+.sbdocs-h1 + h2:not(.sbdocs-h2),
+.sbdocs-h2,
+hr {
+  border-color: var(--theme-header-underline-color) !important;
 }
 
 .sbdocs-table {


### PR DESCRIPTION
H1, H2 headings underline color is not so bright in dark mode, fixed it.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
