### PR TITLE
Fix Chip padding issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+## 0.1.29 - 2023-01-06
+
+### Fixed
+
+- Fixed a padding issue for the case when the Chip contained a close icon but no left-hand icon
+
 ### Added
 
 - Added password text toggle feature to `modus-text-input` component.

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.20.0"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-chip/modus-chip.scss
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.scss
@@ -15,16 +15,12 @@
   padding: $rem-2px $rem-4px;
   vertical-align: middle;
 
-  &.no-left-icon {
-    padding-left: $rem-16px;
-  }
-
-  &.no-right-icon {
-    padding-right: $rem-16px;
+  &.no-left-icon.no-right-icon {
+    padding: 0 $rem-16px;
   }
 
   &.small {
-    height: 1rem;
+    height: $rem-16px;
 
     span {
       font-size: $rem-12px;


### PR DESCRIPTION
## Description

There was too much padding being added to the left side when the Chip contained a close icon but no left-hand icon.

Solution: Only add left and right padding if neither side contains an icon. Otherwise, the icon will add the necessary width itself

Fixes #960 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested this manually through the Storybook doc site

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
