### PR TITLE
bubbling events after chevron interactions

### DIFF
--- a/stencil-workspace/src/components/modus-pagination/modus-pagination.e2e.ts
+++ b/stencil-workspace/src/components/modus-pagination/modus-pagination.e2e.ts
@@ -35,6 +35,36 @@ describe('modus-pagination', () => {
     expect(pageChange).toHaveReceivedEvent();
   });
 
+  it('emits pageChange on chevron click', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-pagination min-page="0" max-page="100" active-page="40"></modus-pagination>');
+    const pageChange = await page.spyOnEvent('pageChange');
+    const leftChevron = await page.find('modus-pagination >>> li:first-child');
+
+    await leftChevron.click();
+    await page.waitForChanges();
+    expect(pageChange).toHaveReceivedEvent();
+
+    const rightChevron = await page.find('modus-pagination >>> li:last-child');
+
+    await rightChevron.click();
+    await page.waitForChanges();
+    expect(pageChange).toHaveReceivedEvent();
+  });
+
+  it('emits pageChange on active-page modification', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-pagination min-page="0" max-page="100" active-page="40"></modus-pagination>');
+    const pageChange = await page.spyOnEvent('pageChange');
+    const element = await page.find('modus-pagination');
+
+    element.setAttribute('active-page', 20);
+    await page.waitForChanges();
+    expect(pageChange).toHaveReceivedEvent();
+  });
+
   it('disables chevron control on minPage', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-pagination/modus-pagination.tsx
+++ b/stencil-workspace/src/components/modus-pagination/modus-pagination.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-import { Component, Event, EventEmitter, h, Prop, State } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
 import { IconChevronLeftThick } from '../icons/icon-chevron-left-thick';
 import { IconChevronRightThick } from '../icons/icon-chevron-right-thick';
 
@@ -13,7 +13,15 @@ export class ModusPagination {
   @Prop() ariaLabel: string | null;
 
   /* The active page. */
-  @Prop() activePage: number;
+  @Prop({ mutable: true }) activePage: number;
+
+  @Watch('activePage')
+  activePageWatch(newValue: number, oldValue: number) {
+    if (newValue !== oldValue) {
+      this.setPages();
+      this.pageChange.emit(newValue);
+    }
+  }
 
   /* The maximum page value. */
   @Prop() maxPage: number;
@@ -28,6 +36,10 @@ export class ModusPagination {
   @Event() pageChange: EventEmitter<number>;
 
   @State() pages: (number | string)[];
+
+  constructor() {
+    this.setPages();
+  }
 
   chevronSizeBySize: Map<string, string> = new Map([
     ['small', '16'],
@@ -100,13 +112,10 @@ export class ModusPagination {
   handlePageClick(page: number): void {
     if (!isNaN(page)) {
       this.activePage = page;
-      this.pageChange.emit(page);
     }
   }
 
   render(): unknown {
-    this.setPages();
-
     return (
       <nav aria-label={this.ariaLabel} class={`${this.classBySize.get(this.size)}`}>
         <ol>
@@ -116,14 +125,14 @@ export class ModusPagination {
               onClick={() => this.handleChevronClick('back')}
               onKeyDown={(event) => this.handleKeydownBack(event)}
               tabIndex={0}>
-            <IconChevronLeftThick size={this.chevronSizeBySize.get(this.size)} />
-          </li>}
+              <IconChevronLeftThick size={this.chevronSizeBySize.get(this.size)} />
+            </li>}
           {this.pages.map(page => {
             return (
-                <li class={`${page === this.activePage ? 'active' : ''} ${!isNaN(+page) ? 'hoverable' : ''}`} onClick={() => this.handlePageClick(+page)}>
-                  {page}
-                </li>
-              );
+              <li class={`${page === this.activePage ? 'active' : ''} ${!isNaN(+page) ? 'hoverable' : ''}`} onClick={() => this.handlePageClick(+page)}>
+                {page}
+              </li>
+            );
           })}
           {this.maxPage - this.minPage >= 7 &&
             <li
@@ -131,8 +140,8 @@ export class ModusPagination {
               onClick={() => this.handleChevronClick('forward')}
               onKeyDown={(event) => this.handleKeydownForward(event)}
               tabIndex={0}>
-            <IconChevronRightThick size={this.chevronSizeBySize.get(this.size)} />
-          </li>}
+              <IconChevronRightThick size={this.chevronSizeBySize.get(this.size)} />
+            </li>}
         </ol>
       </nav>
     );


### PR DESCRIPTION
## Description

> Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When clicking on the chevrons for the `modus-pagination` it wouldn't emit a `pageChange` event.
This feature has been added in this PR.

> Fixes # (issue)

No issue was created for this.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added e2e tests for the new feature.
Ran `npm run test` in `stencil-workplace` and all tests passed.
Did some manual testing in the `stencil-workplace/src/index.html` with the following snippet:
```html
<modus-pagination active-page="1" max-page="10" min-page="1"></modus-pagination>
<script>
  const pagination = document.querySelector('modus-pagination');
  pagination.addEventListener('pageChange', event => { 
    console.log('pageChange', event.detail);
  })
</script>
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
