### PR TITLE
Center Navbar buttons vertically, add open events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+## 0.1.32 - 2023-01-27
+
+### Fixed
+
 - Removed `tertiary` variant from Modus Toasts
+- Fixed `modus-navbar` button centering
+
+### Added
+
+- Events to know when the `modus-navbar` is opening links and menus
 
 ## 0.1.31 - 2023-01-19
 

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -490,8 +490,28 @@ export class ModusModal {
   }
 }
 
-
+import type { ModusNavbarApp as IModusNavbarModusNavbarApp } from '@trimble-oss/modus-web-components';
 export declare interface ModusNavbar extends Components.ModusNavbar {
+  /**
+   * An event that fires when the apps menu opens. 
+   */
+  appsMenuOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires when an apps menu app opens. 
+   */
+  appsMenuAppOpen: EventEmitter<CustomEvent<IModusNavbarModusNavbarApp>>;
+  /**
+   * An event that fires when the notifications menu opens. 
+   */
+  notificationsMenuOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires when the help link opens. 
+   */
+  helpOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires when the profile menu opens. 
+   */
+  profileMenuOpen: EventEmitter<CustomEvent<void>>;
   /**
    * An event that fires on main menu click. 
    */
@@ -527,12 +547,18 @@ export class ModusNavbar {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
-    proxyOutputs(this, this.el, ['mainMenuClick', 'productLogoClick', 'profileMenuLinkClick', 'profileMenuSignOutClick']);
+    proxyOutputs(this, this.el, ['appsMenuOpen', 'appsMenuAppOpen', 'notificationsMenuOpen', 'helpOpen', 'profileMenuOpen', 'mainMenuClick', 'productLogoClick', 'profileMenuLinkClick', 'profileMenuSignOutClick']);
   }
 }
 
+import type { ModusNavbarApp as IModusNavbarAppsMenuModusNavbarApp } from '@trimble-oss/modus-web-components';
+export declare interface ModusNavbarAppsMenu extends Components.ModusNavbarAppsMenu {
+  /**
+   *  
+   */
+  appOpen: EventEmitter<CustomEvent<IModusNavbarAppsMenuModusNavbarApp>>;
 
-export declare interface ModusNavbarAppsMenu extends Components.ModusNavbarAppsMenu {}
+}
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
@@ -549,6 +575,7 @@ export class ModusNavbarAppsMenu {
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['appOpen']);
   }
 }
 

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.20.0"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1031,6 +1031,10 @@ export interface ModusNavbarCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusNavbarElement;
 }
+export interface ModusNavbarAppsMenuCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusNavbarAppsMenuElement;
+}
 export interface ModusNavbarProfileMenuCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusNavbarProfileMenuElement;
@@ -1853,9 +1857,25 @@ declare namespace LocalJSX {
          */
         "helpUrl"?: string;
         /**
+          * An event that fires when an apps menu app opens.
+         */
+        "onAppsMenuAppOpen"?: (event: ModusNavbarCustomEvent<ModusNavbarApp>) => void;
+        /**
+          * An event that fires when the apps menu opens.
+         */
+        "onAppsMenuOpen"?: (event: ModusNavbarCustomEvent<void>) => void;
+        /**
+          * An event that fires when the help link opens.
+         */
+        "onHelpOpen"?: (event: ModusNavbarCustomEvent<void>) => void;
+        /**
           * An event that fires on main menu click.
          */
         "onMainMenuClick"?: (event: ModusNavbarCustomEvent<KeyboardEvent | MouseEvent>) => void;
+        /**
+          * An event that fires when the notifications menu opens.
+         */
+        "onNotificationsMenuOpen"?: (event: ModusNavbarCustomEvent<void>) => void;
         /**
           * An event that fires on product logo click.
          */
@@ -1864,6 +1884,10 @@ declare namespace LocalJSX {
           * An event that fires on profile menu link click.
          */
         "onProfileMenuLinkClick"?: (event: ModusNavbarCustomEvent<string>) => void;
+        /**
+          * An event that fires when the profile menu opens.
+         */
+        "onProfileMenuOpen"?: (event: ModusNavbarCustomEvent<void>) => void;
         /**
           * An event that fires on profile menu sign out click.
          */
@@ -1917,6 +1941,7 @@ declare namespace LocalJSX {
     }
     interface ModusNavbarAppsMenu {
         "apps"?: ModusNavbarApp[];
+        "onAppOpen"?: (event: ModusNavbarAppsMenuCustomEvent<ModusNavbarApp>) => void;
         "reverse"?: boolean;
     }
     interface ModusNavbarMainMenu {

--- a/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.tsx
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Prop, h, EventEmitter, Event } from '@stencil/core';
 
 export interface ModusNavbarApp {
   description?: string;
@@ -19,8 +19,11 @@ export class ModusNavbarAppsMenu {
   @Prop() apps: ModusNavbarApp[];
   @Prop() reverse: boolean;
 
+  @Event() appOpen: EventEmitter<ModusNavbarApp>;
+
   clickAppHandler(app: ModusNavbarApp): void {
     window.open(app.url, '_blank');
+    this.appOpen.emit(app);
   }
 
   render(): unknown {

--- a/stencil-workspace/src/components/modus-navbar/apps-menu/readme.md
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/readme.md
@@ -13,6 +13,13 @@
 | `reverse` | `reverse` |             | `boolean`          | `undefined` |
 
 
+## Events
+
+| Event     | Description | Type                          |
+| --------- | ----------- | ----------------------------- |
+| `appOpen` |             | `CustomEvent<ModusNavbarApp>` |
+
+
 ## Dependencies
 
 ### Used by

--- a/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
@@ -12,6 +12,6 @@
   max-width: 616px;
   min-width: 248px;
   padding: 0;
-  top: 54px;
+  top: 52px;
   width: max-content;
 }

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.e2e.ts
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.e2e.ts
@@ -24,4 +24,82 @@ describe('modus-navbar', () => {
     const element = await page.find('modus-navbar >>> nav');
     expect(element).not.toHaveClass('shadow');
   });
+
+  it('emits appsMenuOpen when apps menu opens', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-navbar show-apps-menu></modus-navbar>');
+
+    const appsMenuOpen = await page.spyOnEvent('appsMenuOpen');
+    await page.waitForChanges();
+    const appsMenuButton = await page.find('modus-navbar >>> [data-test-id="apps-menu"]');
+    await appsMenuButton.click({ clickCount: 2 });
+    await page.waitForChanges();
+    expect(appsMenuOpen).toHaveReceivedEventTimes(1);
+  });
+
+  it('emits appsMenuAppOpen with app id', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-navbar show-apps-menu></modus-navbar>');
+    await page.waitForChanges();
+    const navbar = await page.find('modus-navbar');
+    navbar.setProperty('apps', [{
+      logoUrl: '',
+      name: 'App 1',
+      url: '',
+      category: '',
+      showCategory: false
+    }])
+    await page.waitForChanges();
+    const appsMenuAppOpen = await page.spyOnEvent('appsMenuAppOpen');
+    const appsMenu = await page.find('modus-navbar >>> [data-test-id="apps-menu"]');
+    await appsMenu.click();
+    await page.waitForChanges();
+    const appsMenuApp = await appsMenu.find('modus-navbar-apps-menu >>> .app');
+    await appsMenuApp.click();
+    await page.waitForChanges();
+    expect(appsMenuAppOpen).toHaveReceivedEventTimes(1);
+    expect(appsMenuAppOpen).toHaveReceivedEventDetail({
+      logoUrl: '',
+      name: 'App 1',
+      url: '',
+      category: '',
+      showCategory: false
+    });
+  });
+
+  it('emits notificationsMenuOpen', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-navbar show-notifications></modus-navbar>');
+
+    const notificationsMenuOpen = await page.spyOnEvent('notificationsMenuOpen');
+    await page.waitForChanges();
+    const notificationsMenuButton = await page.find('modus-navbar >>> [data-test-id="notifications-menu"]');
+    await notificationsMenuButton.click({ clickCount: 2 });
+    await page.waitForChanges();
+    expect(notificationsMenuOpen).toHaveReceivedEventTimes(1);
+  });
+
+  it('emits helpOpen', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-navbar show-help></modus-navbar>');
+
+    const helpOpen = await page.spyOnEvent('helpOpen');
+    await page.waitForChanges();
+    const helpButton = await page.find('modus-navbar >>> [data-test-id="help-menu"]');
+    await helpButton.click();
+    await page.waitForChanges();
+    expect(helpOpen).toHaveReceivedEventTimes(1);
+  });
+
+  it('emits profileMenuOpen', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-navbar show-notifications></modus-navbar>');
+
+    const profileMenuOpen = await page.spyOnEvent('profileMenuOpen');
+    await page.waitForChanges();
+    const profileMenuButton = await page.find('modus-navbar >>> .profile-menu');
+    await profileMenuButton.click({ clickCount: 2 });
+    await page.waitForChanges();
+    expect(profileMenuOpen).toHaveReceivedEventTimes(1);
+  });
 });

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -92,11 +92,16 @@ nav {
     &:hover {
       cursor: pointer;
     }
+
+    .navbar-button-icon {
+      display: flex;
+    }
   }
 
   .left {
     align-items: center;
     display: inline-flex;
+    height: 100%;
 
     &.reverse {
       flex-direction: row-reverse;
@@ -112,6 +117,7 @@ nav {
   .right {
     align-items: center;
     display: inline-flex;
+    height: 100%;
     margin-left: auto;
     padding: 0 $rem-16px;
 

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
@@ -72,14 +72,29 @@ export class ModusNavbar {
   /** (optional) Help URL. */
   @Prop() helpUrl: string;
 
+  /** An event that fires when the apps menu opens. */
+  @Event() appsMenuOpen: EventEmitter<void>;
+
+  /** An event that fires when an apps menu app opens. */
+  @Event() appsMenuAppOpen: EventEmitter<ModusNavbarApp>;
+
+  /** An event that fires when the help link opens. */
+  @Event() helpOpen: EventEmitter<void>;
+
   /** An event that fires on main menu click. */
   @Event() mainMenuClick: EventEmitter<KeyboardEvent | MouseEvent>;
+
+  /** An event that fires when the notifications menu opens. */
+  @Event() notificationsMenuOpen: EventEmitter<void>;
 
   /** An event that fires on product logo click. */
   @Event() productLogoClick: EventEmitter<MouseEvent>;
 
   /** An event that fires on profile menu link click. */
   @Event() profileMenuLinkClick: EventEmitter<string>;
+
+  /** An event that fires when the profile menu opens. */
+  @Event() profileMenuOpen: EventEmitter<void>;
 
   /** An event that fires on profile menu sign out click. */
   @Event() profileMenuSignOutClick: EventEmitter<MouseEvent>;
@@ -158,7 +173,13 @@ export class ModusNavbar {
     } else {
       this.hideMenus();
       this.appsMenuVisible = true;
+      this.appsMenuOpen.emit();
     }
+  }
+
+  handleAppsMenuAppOpen(event: CustomEvent<ModusNavbarApp>) {
+    event.stopPropagation();
+    this.appsMenuAppOpen.emit(event.detail);
   }
 
   mainMenuClickHandler(event: MouseEvent): void {
@@ -204,6 +225,7 @@ export class ModusNavbar {
     } else {
       this.hideMenus();
       this.notificationsMenuVisible = true;
+      this.notificationsMenuOpen.emit();
     }
   }
 
@@ -225,6 +247,7 @@ export class ModusNavbar {
     } else {
       this.hideMenus();
       this.profileMenuVisible = true;
+      this.profileMenuOpen.emit();
     }
   }
 
@@ -238,6 +261,7 @@ export class ModusNavbar {
   helpMenuClickHandler(event: MouseEvent): void {
     event.preventDefault();
     window.open(this.helpUrl, '_blank');
+    this.helpOpen.emit();
   }
 
   render(): unknown {
@@ -249,6 +273,7 @@ export class ModusNavbar {
           {this.showMainMenu && (
             <div class="navbar-button main-menu">
               <span
+                class="navbar-button-icon"
                 onKeyDown={(event) => this.mainMenuKeydownHandler(event)}
                 tabIndex={0}>
                 <IconMenu
@@ -275,12 +300,15 @@ export class ModusNavbar {
         <div class={`right ${direction}`}>
           {this.showSearch && (
             <div class="navbar-button search">
-              <IconSearch size="24" />
+              <span class="navbar-button-icon">
+                <IconSearch size="24" />
+              </span>
             </div>
           )}
           {this.showNotifications && (
-            <div class="navbar-button">
+            <div class="navbar-button" data-test-id="notifications-menu">
               <span
+                class="navbar-button-icon"
                 onKeyDown={(event) =>
                   this.notificationsMenuKeydownHandler(event)
                 }
@@ -299,16 +327,19 @@ export class ModusNavbar {
           )}
           {this.showPendoPlaceholder && <div class={'pendo-placeholder'} />}
           {this.showHelp && (
-            <div class="navbar-button">
-              <IconHelp
-                size="24"
-                onClick={(event) => this.helpMenuClickHandler(event)}
-              />
+            <div class="navbar-button" data-test-id="help-menu">
+              <span class="navbar-button-icon">
+                <IconHelp
+                  size="24"
+                  onClick={(event) => this.helpMenuClickHandler(event)}
+                />
+              </span>
             </div>
           )}
           {this.showAppsMenu && (
-            <div class="navbar-button">
+            <div class="navbar-button" data-test-id="apps-menu">
               <span
+                class="navbar-button-icon"
                 onKeyDown={(event) => this.appsMenuKeydownHandler(event)}
                 tabIndex={0}>
                 <IconApps
@@ -321,6 +352,7 @@ export class ModusNavbar {
                 <modus-navbar-apps-menu
                   apps={this.apps}
                   reverse={this.reverse}
+                  onAppOpen={(event) => this.handleAppsMenuAppOpen(event)}
                 />
               )}
             </div>

--- a/stencil-workspace/src/components/modus-navbar/readme.md
+++ b/stencil-workspace/src/components/modus-navbar/readme.md
@@ -25,12 +25,17 @@
 
 ## Events
 
-| Event                     | Description                                         | Type                                       |
-| ------------------------- | --------------------------------------------------- | ------------------------------------------ |
-| `mainMenuClick`           | An event that fires on main menu click.             | `CustomEvent<KeyboardEvent \| MouseEvent>` |
-| `productLogoClick`        | An event that fires on product logo click.          | `CustomEvent<MouseEvent>`                  |
-| `profileMenuLinkClick`    | An event that fires on profile menu link click.     | `CustomEvent<string>`                      |
-| `profileMenuSignOutClick` | An event that fires on profile menu sign out click. | `CustomEvent<MouseEvent>`                  |
+| Event                     | Description                                            | Type                                       |
+| ------------------------- | ------------------------------------------------------ | ------------------------------------------ |
+| `appsMenuAppOpen`         | An event that fires when an apps menu app opens.       | `CustomEvent<ModusNavbarApp>`              |
+| `appsMenuOpen`            | An event that fires when the apps menu opens.          | `CustomEvent<void>`                        |
+| `helpOpen`                | An event that fires when the help link opens.          | `CustomEvent<void>`                        |
+| `mainMenuClick`           | An event that fires on main menu click.                | `CustomEvent<KeyboardEvent \| MouseEvent>` |
+| `notificationsMenuOpen`   | An event that fires when the notifications menu opens. | `CustomEvent<void>`                        |
+| `productLogoClick`        | An event that fires on product logo click.             | `CustomEvent<MouseEvent>`                  |
+| `profileMenuLinkClick`    | An event that fires on profile menu link click.        | `CustomEvent<string>`                      |
+| `profileMenuOpen`         | An event that fires when the profile menu opens.       | `CustomEvent<void>`                        |
+| `profileMenuSignOutClick` | An event that fires on profile menu sign out click.    | `CustomEvent<MouseEvent>`                  |
 
 
 ## Methods

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -18,5 +18,4 @@
   <body>
     <!-- Test components here -->
   </body>
-
 </html>

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -88,11 +88,17 @@ interface ModusNavbarProfileMenuLink {
 
 ### DOM Events
 
-| Event                     | Description                                         | Type                      |
-| ------------------------- | --------------------------------------------------- | ------------------------- |
-| `productLogoClick`        | An event that fires on product logo click.          | `CustomEvent<MouseEvent>` |
-| `profileMenuLinkClick`    | An event that fires on profile menu link click.     | `CustomEvent<string>`     |
-| `profileMenuSignOutClick` | An event that fires on profile menu sign out click. | `CustomEvent<MouseEvent>` |
+| Event                     | Description                                            | Type                                       |
+| ------------------------- | ------------------------------------------------------ | ------------------------------------------ |
+| `appsMenuAppOpen`         | An event that fires when an apps menu app opens.       | `CustomEvent<ModusNavbarApp>`              |
+| `appsMenuOpen`            | An event that fires when the apps menu opens.          | `CustomEvent<void>`                        |
+| `helpOpen`                | An event that fires when the help link opens.          | `CustomEvent<void>`                        |
+| `mainMenuClick`           | An event that fires on main menu click.                | `CustomEvent<KeyboardEvent | MouseEvent>`  |
+| `notificationsMenuOpen`   | An event that fires when the notifications menu opens. | `CustomEvent<void>`                        |
+| `productLogoClick`        | An event that fires on product logo click.             | `CustomEvent<MouseEvent>`                  |
+| `profileMenuLinkClick`    | An event that fires on profile menu link click.        | `CustomEvent<string>`                      |
+| `profileMenuOpen`         | An event that fires when the profile menu opens.       | `CustomEvent<void>`                        |
+| `profileMenuSignOutClick` | An event that fires on profile menu sign out click.    | `CustomEvent<MouseEvent>`                  |
 
 ### Methods
 


### PR DESCRIPTION
## Description

Center the navbar buttons and output some new events to let applications know when the menus are opening, and when apps/links are opened

Fixes #985 
Fixes #986 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## How Has This Been Tested?

E2e and manually tested

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
