### PR TITLE
Remove unused href from Breadcrumb anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+## 0.1.33 - 2021-02-16
+
+### Fixed
+
+- Fixed an issue where the breadcrumbs were pushing '#' to the route when clicked
+
 ### Added
 
 - Added support for Angular Reactive Forms 🎉

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.20.0"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.scss
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.scss
@@ -17,6 +17,7 @@ nav {
       .crumb {
         a {
           color: $modus-breadcrumb-item-color;
+          cursor: pointer;
           text-decoration: none;
 
           &:hover {

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
@@ -29,7 +29,7 @@ export class ModusBreadcrumb {
             <li key={crumb.id}>
               {index < this.crumbs.length - 1 ? (
                 <span class="crumb">
-                  <a href="#" onClick={() => this.crumbClick.emit(crumb)}>
+                  <a onClick={() => this.crumbClick.emit(crumb)}>
                     {crumb.display}
                   </a>
                   <span class="divider">{'>'}</span>

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
@@ -12,14 +12,12 @@ A new TypeScript typing has been provided named Crumb defined as:
 {
   id: string; // required, must be unique.
   display: string; // required.
-  route?: string; // optional, leave undefined to handle routing externally.
 }
 ```
 
 #### Implementation Details
 
 - Crumb id values must be unique within the crumbs collection.
-- To handle routing outside of the breadcrumbs, leave the route value undefined and listen to the crumbClick DOM event.
 
 ### Default
 


### PR DESCRIPTION
## Description

There's a bug where the breadcrumbs push to the route when there was no route specified for that breadcrumb.

Fixes #1015 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

## How Has This Been Tested?

Manually tested

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
