### PR TITLE
Time picker improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+### Added
+
+- Added Modus Time Picker component
+
 ## 0.1.33 - 2021-02-16
 
 ### Fixed

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -983,6 +983,39 @@ export class ModusTextInput {
   }
 }
 
+import type { TimeInputEventData as IModusTimePickerTimeInputEventData } from '@trimble-oss/modus-web-components';
+export declare interface ModusTimePicker extends Components.ModusTimePicker {
+  /**
+   * An event that fires on input value out of focus. 
+   */
+  timeInputBlur: EventEmitter<CustomEvent<IModusTimePickerTimeInputEventData>>;
+  /**
+   * An event that fires on input value change. 
+   */
+  valueChange: EventEmitter<CustomEvent<IModusTimePickerTimeInputEventData>>;
+
+}
+
+@ProxyCmp({
+  defineCustomElementFn: undefined,
+  inputs: ['ampm', 'ariaLabel', 'autoFocusInput', 'disableValidation', 'disabled', 'errorText', 'helperText', 'label', 'maxLength', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value'],
+  methods: ['focusInput']
+})
+@Component({
+  selector: 'modus-time-picker',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  inputs: ['ampm', 'ariaLabel', 'autoFocusInput', 'disableValidation', 'disabled', 'errorText', 'helperText', 'label', 'maxLength', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value']
+})
+export class ModusTimePicker {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+    proxyOutputs(this, this.el, ['timeInputBlur', 'valueChange']);
+  }
+}
+
 
 export declare interface ModusToast extends Components.ModusToast {
   /**

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
@@ -36,6 +36,7 @@ export const DIRECTIVES = [
   d.ModusSwitch,
   d.ModusTabs,
   d.ModusTextInput,
+  d.ModusTimePicker,
   d.ModusToast,
   d.ModusTooltip,
   d.ModusTreeView,

--- a/react-workspace/src/components/stencil-generated/index.ts
+++ b/react-workspace/src/components/stencil-generated/index.ts
@@ -42,6 +42,7 @@ export const ModusSpinner = /*@__PURE__*/createReactComponent<JSX.ModusSpinner, 
 export const ModusSwitch = /*@__PURE__*/createReactComponent<JSX.ModusSwitch, HTMLModusSwitchElement>('modus-switch');
 export const ModusTabs = /*@__PURE__*/createReactComponent<JSX.ModusTabs, HTMLModusTabsElement>('modus-tabs');
 export const ModusTextInput = /*@__PURE__*/createReactComponent<JSX.ModusTextInput, HTMLModusTextInputElement>('modus-text-input');
+export const ModusTimePicker = /*@__PURE__*/createReactComponent<JSX.ModusTimePicker, HTMLModusTimePickerElement>('modus-time-picker');
 export const ModusToast = /*@__PURE__*/createReactComponent<JSX.ModusToast, HTMLModusToastElement>('modus-toast');
 export const ModusTooltip = /*@__PURE__*/createReactComponent<JSX.ModusTooltip, HTMLModusTooltipElement>('modus-tooltip');
 export const ModusTreeView = /*@__PURE__*/createReactComponent<JSX.ModusTreeView, HTMLModusTreeViewElement>('modus-tree-view');

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -15,6 +15,7 @@ import { ModusNavbarProfileMenuLink as ModusNavbarProfileMenuLink1 } from "./com
 import { RadioButton } from "./components/modus-radio-group/modus-radio-button";
 import { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/modus-side-navigation.types";
 import { Tab } from "./components/modus-tabs/modus-tabs";
+import { TimeInputEventData } from "./components/modus-time-input/modus-time-picker.types";
 import { TreeViewItemOptions } from "./components/modus-content-tree/modus-content-tree.types";
 export namespace Components {
     interface ModusAccordion {
@@ -881,6 +882,72 @@ export namespace Components {
          */
         "value": string;
     }
+    interface ModusTimePicker {
+        /**
+          * (optional) Sets 12/24 hour format for the input string.
+         */
+        "ampm": boolean;
+        /**
+          * (optional) The input's aria-label.
+         */
+        "ariaLabel": string | null;
+        /**
+          * (optional) Sets autofocus on the input.
+         */
+        "autoFocusInput": boolean;
+        /**
+          * (optional) Disables default validation for the time input.
+         */
+        "disableValidation": boolean;
+        /**
+          * (optional) Whether the input is disabled.
+         */
+        "disabled": boolean;
+        /**
+          * (optional) Custom error text displayed for the input.
+         */
+        "errorText": string;
+        /**
+          * Focus the input.
+         */
+        "focusInput": () => Promise<void>;
+        /**
+          * (optional) Custom helper text displayed below the input.
+         */
+        "helperText": any;
+        /**
+          * (optional) The input's label.
+         */
+        "label": string;
+        /**
+          * (optional) The input's maximum length. Default is 10.
+         */
+        "maxLength": number;
+        /**
+          * (optional) The input's placeholder text.
+         */
+        "placeholder": string;
+        /**
+          * (optional) Whether the input's content is read-only
+         */
+        "readOnly": boolean;
+        /**
+          * (optional) Whether the input is required.
+         */
+        "required": boolean;
+        /**
+          * (optional) The input's size.
+         */
+        "size": 'medium' | 'large';
+        /**
+          * (optional) The input's valid state text.
+         */
+        "validText": string;
+        /**
+          * (optional) Value of the time entered into the input.
+         */
+        "value": string;
+    }
     interface ModusToast {
         /**
           * (optional) The toast's aria-label.
@@ -1078,6 +1145,10 @@ export interface ModusTabsCustomEvent<T> extends CustomEvent<T> {
 export interface ModusTextInputCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusTextInputElement;
+}
+export interface ModusTimePickerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusTimePickerElement;
 }
 export interface ModusToastCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -1292,6 +1363,12 @@ declare global {
         prototype: HTMLModusTextInputElement;
         new (): HTMLModusTextInputElement;
     };
+    interface HTMLModusTimePickerElement extends Components.ModusTimePicker, HTMLStencilElement {
+    }
+    var HTMLModusTimePickerElement: {
+        prototype: HTMLModusTimePickerElement;
+        new (): HTMLModusTimePickerElement;
+    };
     interface HTMLModusToastElement extends Components.ModusToast, HTMLStencilElement {
     }
     var HTMLModusToastElement: {
@@ -1351,6 +1428,7 @@ declare global {
         "modus-switch": HTMLModusSwitchElement;
         "modus-tabs": HTMLModusTabsElement;
         "modus-text-input": HTMLModusTextInputElement;
+        "modus-time-picker": HTMLModusTimePickerElement;
         "modus-toast": HTMLModusToastElement;
         "modus-tooltip": HTMLModusTooltipElement;
         "modus-tree-view": HTMLModusTreeViewElement;
@@ -2375,6 +2453,76 @@ declare namespace LocalJSX {
          */
         "value"?: string;
     }
+    interface ModusTimePicker {
+        /**
+          * (optional) Sets 12/24 hour format for the input string.
+         */
+        "ampm"?: boolean;
+        /**
+          * (optional) The input's aria-label.
+         */
+        "ariaLabel"?: string | null;
+        /**
+          * (optional) Sets autofocus on the input.
+         */
+        "autoFocusInput"?: boolean;
+        /**
+          * (optional) Disables default validation for the time input.
+         */
+        "disableValidation"?: boolean;
+        /**
+          * (optional) Whether the input is disabled.
+         */
+        "disabled"?: boolean;
+        /**
+          * (optional) Custom error text displayed for the input.
+         */
+        "errorText"?: string;
+        /**
+          * (optional) Custom helper text displayed below the input.
+         */
+        "helperText"?: any;
+        /**
+          * (optional) The input's label.
+         */
+        "label"?: string;
+        /**
+          * (optional) The input's maximum length. Default is 10.
+         */
+        "maxLength"?: number;
+        /**
+          * An event that fires on input value out of focus.
+         */
+        "onTimeInputBlur"?: (event: ModusTimePickerCustomEvent<TimeInputEventData>) => void;
+        /**
+          * An event that fires on input value change.
+         */
+        "onValueChange"?: (event: ModusTimePickerCustomEvent<TimeInputEventData>) => void;
+        /**
+          * (optional) The input's placeholder text.
+         */
+        "placeholder"?: string;
+        /**
+          * (optional) Whether the input's content is read-only
+         */
+        "readOnly"?: boolean;
+        /**
+          * (optional) Whether the input is required.
+         */
+        "required"?: boolean;
+        /**
+          * (optional) The input's size.
+         */
+        "size"?: 'medium' | 'large';
+        /**
+          * (optional) The input's valid state text.
+         */
+        "validText"?: string;
+        /**
+          * (optional) Value of the time entered into the input.
+         */
+        "value"?: string;
+    }
     interface ModusToast {
         /**
           * (optional) The toast's aria-label.
@@ -2521,6 +2669,7 @@ declare namespace LocalJSX {
         "modus-switch": ModusSwitch;
         "modus-tabs": ModusTabs;
         "modus-text-input": ModusTextInput;
+        "modus-time-picker": ModusTimePicker;
         "modus-toast": ModusToast;
         "modus-tooltip": ModusTooltip;
         "modus-tree-view": ModusTreeView;
@@ -2565,6 +2714,7 @@ declare module "@stencil/core" {
             "modus-switch": LocalJSX.ModusSwitch & JSXBase.HTMLAttributes<HTMLModusSwitchElement>;
             "modus-tabs": LocalJSX.ModusTabs & JSXBase.HTMLAttributes<HTMLModusTabsElement>;
             "modus-text-input": LocalJSX.ModusTextInput & JSXBase.HTMLAttributes<HTMLModusTextInputElement>;
+            "modus-time-picker": LocalJSX.ModusTimePicker & JSXBase.HTMLAttributes<HTMLModusTimePickerElement>;
             "modus-toast": LocalJSX.ModusToast & JSXBase.HTMLAttributes<HTMLModusToastElement>;
             "modus-tooltip": LocalJSX.ModusTooltip & JSXBase.HTMLAttributes<HTMLModusTooltipElement>;
             "modus-tree-view": LocalJSX.ModusTreeView & JSXBase.HTMLAttributes<HTMLModusTreeViewElement>;

--- a/stencil-workspace/src/components/modus-select/modus-select.tsx
+++ b/stencil-workspace/src/components/modus-select/modus-select.tsx
@@ -145,6 +145,7 @@ export class ModusSelect {
           <div class={dropdownListClass}>
             {this.options.map((option, index) => (
               <div
+                role="option"
                 aria-selected={index === this.activeItemIndex}
                 aria-label={option[this.optionsDisplayProp]}
                 class={`dropdown-list-item ${index === this.activeItemIndex ? 'active' : ''}`}

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.e2e.ts
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.e2e.ts
@@ -1,0 +1,242 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('modus-time-picker', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const element = await page.find('modus-time-picker');
+    expect(element).toHaveClass('hydrated');
+  });
+
+
+  it('renders changes to disabled', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    const input = await page.find('modus-time-picker >>> input');
+
+    expect(textInput).not.toHaveClass('disabled');
+    expect(await input.getProperty('disabled')).toBeFalsy();
+
+    textInput.setProperty('disabled', 'true');
+    await page.waitForChanges();
+
+    expect(await input.getProperty('disabled')).toBeTruthy();
+  });
+
+  it('renders changes to errorText', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('errorText', 'Error.');
+    await page.waitForChanges();
+
+    const inputContainer = await page.find('modus-time-picker >>> .input-container');
+    expect(inputContainer).toHaveClass('error');
+
+    const errorLabel = await page.find('modus-time-picker >>> label.error');
+    expect(errorLabel).not.toBeNull();
+  });
+
+  it('renders changes to validText', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('validText', 'Valid.');
+    await page.waitForChanges();
+
+    const inputContainer = await page.find('modus-time-picker >>> .input-container');
+    expect(inputContainer).toHaveClass('valid');
+
+    const validLabel = await page.find('modus-time-picker >>> label.valid');
+    expect(validLabel).not.toBeNull();
+  });
+
+  it('renders changes to helperText', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('helperText', 'Helper.');
+    await page.waitForChanges();
+
+    const helperLabel = await page.find('modus-time-picker >>> label.helper');
+    expect(helperLabel).not.toBeNull();
+  });
+
+  it('renders changes to label', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('label', 'Hello Label');
+    await page.waitForChanges();
+
+    const label = await page.find('modus-time-picker >>> .label-container label');
+    expect(label.textContent).toEqual('Hello Label');
+  });
+
+  it('renders changes to placeholder', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('placeholder', 'Placeholder');
+    await page.waitForChanges();
+
+    const input = await page.find('modus-time-picker >>> input');
+    expect(await input.getProperty('placeholder')).toEqual('Placeholder');
+  });
+
+  it('renders changes to required', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('required', 'true');
+    await page.waitForChanges();
+
+    const required = await page.find('modus-time-picker >>> span.required');
+    expect(required).not.toBeNull();
+  });
+
+  it('renders changes to value', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const textInput = await page.find('modus-time-picker');
+    textInput.setProperty('value', '12:00');
+    await page.waitForChanges();
+
+    const input = await page.find('modus-time-picker >>> input');
+    expect(await input.getProperty('value')).toEqual('12:00');
+  });
+
+  it('renders changes to autoFocusInput', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker auto-focus-input="true"></modus-time-picker>');
+    await page.waitForChanges();
+
+    const input = await page.find('modus-time-picker >>> input');
+    expect(await input.getProperty('autofocus')).toBeTruthy();
+  });
+
+  it('renders changes to disableValidation', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    // Input an invalid time
+    const component = await page.find('modus-time-picker');
+    component.setProperty('disableValidation', true);
+    await page.waitForChanges();
+
+    const input = await page.find('modus-time-picker >>> input');
+    await input.type('121', { delay: 20 });
+    await page.waitForChanges();
+
+    const body = await page.find('body');
+    await body.click();
+    await page.waitForChanges();
+
+    const inputContainer = await page.find('modus-time-picker >>> .input-container');
+    expect(inputContainer).not.toHaveClass('error');
+
+    const errorLabel = await page.find('modus-time-picker >>> label.error');
+    expect(errorLabel).toBeNull();
+  });
+
+
+  // Verifies 12 hour clock as input
+  it('renders changes to ampm', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+
+    const input = await page.find('modus-time-picker >>> input');
+    await input.type('12:00 AM', { delay: 20 });
+    await page.waitForChanges();
+
+    const body = await page.find('body');
+    await body.click();
+    await page.waitForChanges();
+
+    const component = await page.find('modus-time-picker');
+    expect(await component.getProperty('value')).toEqual('12:00');
+
+    // Input an invalid time
+    component.setProperty('ampm', true);
+    await page.waitForChanges();
+
+    await input.type(' AM', { delay: 20 });
+    await page.waitForChanges();
+
+    await body.click();
+    await page.waitForChanges();
+
+    const container = await page.find('modus-time-picker >>> .input-container');
+    expect(container).not.toHaveClass('error');
+  });
+
+  it('checks validation', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-time-picker label="Time"></modus-time-picker>');
+
+    // Input an invalid time
+    const input = await page.find('modus-time-picker >>> input');
+    await input.type('121', { delay: 20 });
+    await page.waitForChanges();
+
+    const label = await page.find('modus-time-picker >>> .label-container');
+    await label.click();
+    await page.waitForChanges();
+
+    const inputContainer = await page.find('modus-time-picker >>> .input-container');
+    expect(await input.getProperty('value')).toEqual('121');
+    expect(inputContainer).toHaveClass('error');
+
+    const errorLabel = await page.find('modus-time-picker >>> label.error');
+    expect(errorLabel.innerHTML).toContain('Invalid time');
+  });
+
+  it('emits valueChange event', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker></modus-time-picker>');
+    const valueChange = await page.spyOnEvent('valueChange');
+    const element = await page.find('modus-time-picker >>> input');
+    await page.waitForChanges();
+
+    await element.type('12', { delay: 20 });
+    await page.waitForChanges();
+    expect(valueChange).toHaveReceivedEvent();
+  });
+
+  it('emits timeInputBlur event', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-time-picker label="Time"></modus-time-picker>');
+    const timeInputBlur = await page.spyOnEvent('timeInputBlur');
+
+    const input = await page.find('modus-time-picker >>> input');
+    await input.type('12', { delay: 20 });
+    await page.waitForChanges();
+
+    const label = await page.find('modus-time-picker >>> .label-container');
+    await label.click();
+    await page.waitForChanges();
+
+    expect(timeInputBlur).toHaveReceivedEvent();
+  });
+});

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.helpers.tsx
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.helpers.tsx
@@ -1,0 +1,111 @@
+const TIME_12_HOUR_CLOCK_REGEX = /^(1[0-2]|0?[1-9]):([0-5][0-9]) ([AaPp][Mm])$/;
+const TIME_24_HOUR_CLOCK_REGEX = /^(2[0-3]|[01]?[0-9]):([0-5]?[0-9])$/;
+
+// eslint-disable-next-line no-useless-escape
+const TIME_12_HOUR_CLOCK_ALLOWED_CHARS_REGEX = /[0-9APM:\s]+/;
+const TIME_24_HOUR_CLOCK_ALLOWED_CHARS_REGEX = /[0-9:]+/;
+
+export function formatTime(val: string, hasAmPm: boolean): string {
+  if (!val) return null;
+
+  const parse = executeTimeRegex(val, TIME_24_HOUR_CLOCK_REGEX);
+  if (parse) {
+    if (hasAmPm) {
+      const hours = parseInt(parse[0]);
+      const minutes = parseInt(parse[1]);
+
+      return to12HourTimeString(hours, minutes);
+    } else return val;
+  }
+
+  return null;
+}
+
+export function keyIsValidTimeCharacter(
+  key: string,
+  hasAmPm: boolean
+): boolean {
+  const allowedKeysRegex = new RegExp(
+    hasAmPm
+      ? TIME_12_HOUR_CLOCK_ALLOWED_CHARS_REGEX
+      : TIME_24_HOUR_CLOCK_ALLOWED_CHARS_REGEX
+  );
+  if (allowedKeysRegex.test(key)) {
+    return true;
+  }
+  return false;
+}
+
+export function parseTime(val: string, hasAmPm: boolean): string {
+  if (!val) return null;
+
+  const parse = executeTimeRegex(
+    val,
+    hasAmPm ? TIME_12_HOUR_CLOCK_REGEX : TIME_24_HOUR_CLOCK_REGEX
+  );
+
+  if (parse) {
+    if (hasAmPm) {
+      const hours = parseInt(parse[0]);
+      const minutes = parseInt(parse[1]);
+      const ampm = parse[2]?.toUpperCase() as 'AM' | 'PM';
+
+      return from12HourTimeString(hours, minutes, ampm);
+    } else {
+      return val;
+    }
+  }
+
+  return null;
+}
+
+function executeTimeRegex(val: string, exp: RegExp): string[] | null {
+  const timeFormatRegex = new RegExp(exp);
+  const parse = timeFormatRegex.exec(val);
+
+  if (parse?.length > 1) {
+    parse.shift();
+    return parse;
+  }
+  return null;
+}
+
+function from12HourTimeString(
+  hours: number,
+  minutes: number,
+  ampm: string
+): string | null {
+  let editedHours = hours;
+
+  // Subtract 12 hours for 12:00 AM or midnight to 12:59 AM
+  if (ampm === 'AM') {
+    editedHours = hours - hours === 12 ? 12 : 0;
+  }
+  // Add 12 hours for 1:00 PM to 11:59 PM
+  else if (ampm === 'PM') {
+    editedHours = hours + hours !== 12 ? 12 : 0;
+  }
+  if (editedHours >= 0 && editedHours <= 23 && (minutes === 0 || minutes > 0))
+    return `${editedHours}:${minutes}`;
+
+  return null;
+}
+
+function to12HourTimeString(hours: number, minutes: number): string | null {
+  let ampm = 'AM';
+  let editedHours = hours;
+
+  if (hours === 0) {
+    editedHours = hours + 12;
+  } else if (hours === 12) {
+    ampm = 'PM';
+  } else if (hours > 12) {
+    editedHours = hours - 12;
+    ampm = 'PM';
+  }
+
+  if (editedHours && editedHours <= 12 && (minutes === 0 || minutes > 0))
+    return `${editedHours}:${minutes} ${ampm}`;
+
+  return null;
+}

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.scss
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.scss
@@ -1,0 +1,153 @@
+@import './modus-time-picker.vars';
+
+.modus-time-picker {
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-direction: row;
+  font-family: $primary-font;
+  position: relative;
+  width: 100%;
+
+  .time-input-wrapper {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  button {
+    background: 0;
+    border: 0;
+    cursor: pointer;
+    margin: 0;
+    padding: 0;
+  }
+
+  label {
+    color: $modus-input-label-color;
+    margin-bottom: $rem-4px;
+  }
+
+  .label-container {
+    display: flex;
+
+    label {
+      font-size: $rem-12px;
+    }
+
+    span {
+      &.required {
+        bottom: $rem-1px;
+        color: $modus-input-validation-error-color;
+        margin-left: $rem-4px;
+        position: relative;
+      }
+    }
+  }
+
+  .input-container {
+    align-items: center;
+    background-color: $modus-input-bg;
+    border: $rem-1px solid $modus-input-border-color;
+    border-bottom-color: $modus-input-bottom-line-color;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: row;
+    height: 2rem;
+    position: relative;
+    width: 100%;
+
+    input {
+      background-color: transparent;
+      background-position: right calc(0.375em + 0.1875rem) center;
+      background-repeat: no-repeat;
+      background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+      border: none;
+      color: $modus-input-color;
+      font-size: $rem-12px;
+      outline: none;
+      padding: 0 $rem-8px;
+      padding-right: calc(1.5em + 0.75rem);
+      width: 100%;
+
+      &::placeholder {
+        color: $modus-input-hint-text-color;
+      }
+    }
+
+    &:hover {
+      cursor: text;
+    }
+
+    &:focus-within,
+    &.error,
+    &.valid {
+      border-bottom-width: $rem-2px;
+      height: 1.9375rem; // Counteract bottom border width.
+    }
+
+    &:focus-within {
+      border-bottom-color: $modus-input-bottom-line-active-color;
+    }
+
+    &.error {
+      border-bottom-color: $modus-input-validation-error-color;
+    }
+
+    &.valid {
+      border-bottom-color: $modus-input-validation-success-color;
+    }
+
+    &.large {
+      height: 3rem;
+
+      input {
+        font-size: $rem-14px;
+      }
+
+      &:focus-within,
+      &.error,
+      &.valid {
+        height: 2.9375rem; // Counteract bottom border width.
+      }
+    }
+  }
+
+  .sub-text {
+    font-size: $rem-10px;
+    margin-top: $rem-4px;
+
+    &.helper {
+      color: $modus-input-label-color;
+    }
+
+    &.error {
+      color: $modus-input-validation-error-color;
+    }
+
+    &.valid {
+      color: $modus-input-validation-success-color;
+    }
+  }
+
+  &.large {
+    font-size: $rem-14px;
+    height: 48px;
+  }
+
+  &.disabled {
+    pointer-events: none;
+
+    .input-container {
+      background-color: $modus-input-disabled-bg;
+      border: $rem-1px solid $modus-input-disabled-border-color;
+      border-bottom-color: $modus-input-disabled-bottom-line-color;
+
+      input {
+        background-color: transparent;
+        border-radius: 0;
+        color: $modus-input-disabled-color;
+        height: 100%;
+      }
+    }
+  }
+}

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.spec.tsx
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.spec.tsx
@@ -1,0 +1,86 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusTimePicker } from './modus-time-picker';
+
+describe('modus-time-picker', () => {
+  it('renders default', async () => {
+    const page = await newSpecPage({
+      components: [ModusTimePicker],
+      html: '<modus-time-picker></modus-time-picker>',
+    });
+    expect(page.root).toEqualHtml(`
+    <modus-time-picker>
+      <mock:shadow-root>
+        <div class="modus-time-picker">
+            <div class="time-input-wrapper">
+              <div class="input-container medium"><input id="time-input" inputmode="text" tabindex="0" type="text" maxlength="8"></div>
+            </div>
+            <div class="time-zone-wrapper">
+              <slot name="timeZone"></slot>
+            </div>
+        </div>
+      </mock:shadow-root>
+  </modus-time-picker>
+    `);
+  });
+
+  it('should get the correct class by size', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    const className = modusTimeInput.classBySize.get(modusTimeInput.size);
+    expect(className).toEqual('medium');
+  });
+
+  it('should default to enabled', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.disabled).toBeFalsy();
+  });
+
+  it('should default to no error text', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.errorText).toBeFalsy();
+  });
+
+  it('should default to no valid text', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.validText).toBeFalsy();
+  });
+
+  it('should default to no helper text', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.helperText).toBeFalsy();
+  });
+
+  it('should default to size medium', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.size).toEqual('medium');
+  });
+
+  it('should default with no label', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.label).toBeFalsy();
+  });
+
+  it('should default with no placeholder', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.placeholder).toBeFalsy();
+  });
+
+  it('should default to not required', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.required).toBeFalsy();
+  });
+
+  it('should default with no value', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.value).toBeFalsy();
+  });
+
+  it('should default with maximum length validation', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.maxLength).toEqual(8);
+  });
+
+  it('should default with no ampm set true', async () => {
+    const modusTimeInput = new ModusTimePicker();
+    expect(modusTimeInput.ampm).toBeFalsy();
+  });
+});

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.tsx
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.tsx
@@ -1,0 +1,230 @@
+import {
+  h, // eslint-disable-line @typescript-eslint/no-unused-vars
+  Component,
+  Prop,
+  Event,
+  EventEmitter,
+  Method,
+  Element,
+  Watch,
+} from '@stencil/core';
+import {
+  formatTime,
+  keyIsValidTimeCharacter,
+  parseTime,
+} from './modus-time-picker.helpers';
+import { TimeInputEventData } from './modus-time-picker.types';
+
+/**
+ * @slot timeZone - Slot for a Time Zone dropdown
+ */
+@Component({
+  tag: 'modus-time-picker',
+  styleUrl: 'modus-time-picker.scss',
+  shadow: true,
+})
+export class ModusTimePicker {
+  @Element() element: HTMLElement;
+  /** (optional) The input's aria-label. */
+  @Prop() ariaLabel: string | null;
+
+  /** (optional) Sets 12/24 hour format for the input string. */
+  @Prop() ampm: boolean;
+
+  /** (optional) Sets autofocus on the input. */
+  @Prop() autoFocusInput: boolean;
+
+  /** (optional) Whether the input is disabled. */
+  @Prop() disabled: boolean;
+
+  /** (optional) Disables default validation for the time input. */
+  @Prop() disableValidation: boolean;
+
+  /** (optional) Custom error text displayed for the input. */
+  @Prop() errorText: string;
+
+  /** (optional) Custom helper text displayed below the input. */
+  @Prop() helperText;
+
+  /** (optional) The input's label. */
+  @Prop() label: string;
+
+  /** (optional) The input's maximum length. Default is 10. */
+  @Prop() maxLength = 8;
+
+  /** (optional) The input's placeholder text. */
+  @Prop() placeholder: string;
+
+  /** (optional) Whether the input's content is read-only */
+  @Prop() readOnly: boolean;
+
+  /** (optional) Whether the input is required. */
+  @Prop() required: boolean;
+
+  /** (optional) The input's size. */
+  @Prop() size: 'medium' | 'large' = 'medium';
+
+  /** (optional) The input's valid state text. */
+  @Prop() validText: string;
+
+  /** (optional) Value of the time entered into the input. */
+  @Prop() value: string;
+  @Watch('value')
+  handleValueChange(val: string): void {
+    this.displayString = this.isEditing
+      ? this.displayString
+      : formatTime(val, this.ampm);
+    this.valueChange.emit({
+      value: val,
+      inputString: this.displayString,
+    });
+  }
+
+  /** An event that fires on input value out of focus. */
+  @Event() timeInputBlur: EventEmitter<TimeInputEventData>;
+
+  /** An event that fires on input value change. */
+  @Event() valueChange: EventEmitter<TimeInputEventData>;
+
+  readonly classBySize: Map<string, string> = new Map([
+    ['medium', 'medium'],
+    ['large', 'large'],
+  ]);
+
+  private displayString: string;
+  private isEditing: boolean;
+  private textInput: HTMLInputElement;
+
+  componentWillLoad() {
+    this.displayString = formatTime(this.value, this.ampm);
+  }
+
+  /** Methods */
+  /** Focus the input. */
+  @Method()
+  async focusInput(): Promise<void> {
+    this.textInput.focus();
+  }
+
+  handleBlur(): void {
+    this.isEditing = false;
+    const inputString = this.textInput?.value;
+    this.validateInput(inputString);
+    this.timeInputBlur.emit({
+      value: this.value,
+      inputString,
+    });
+  }
+
+  handleDefaultKeyDown(e: KeyboardEvent, callback: () => void) {
+    const code = e.code.toUpperCase();
+    if (code === 'ENTER' || code === 'SPACE') callback();
+  }
+
+  handleInputChange(event: Event): void {
+    event.stopPropagation();
+    event.preventDefault();
+    this.isEditing = true;
+    this.value = parseTime(
+      (event.currentTarget as HTMLInputElement)?.value,
+      this.ampm
+    );
+  }
+
+  handleInputKeyPress(event: KeyboardEvent): boolean {
+    const key = event.key;
+    const keyIsValid = keyIsValidTimeCharacter(key, this.ampm);
+    if (!keyIsValid) {
+      event.preventDefault();
+    }
+    return keyIsValid;
+  }
+
+  // Helpers
+  clearValidation(): void {
+    this.errorText = null;
+  }
+
+  getAriaControls(): { [key: string]: boolean | string } {
+    return {
+      'aria-disabled': this.disabled ? 'true' : undefined,
+      'aria-invalid': !!this.errorText,
+      'aria-label': this.ariaLabel,
+      'aria-readonly': this.readOnly,
+      'aria-required': this.required,
+    };
+  }
+
+  validateInput(inputString: string | null): void {
+    if (this.disableValidation) return;
+
+    if (!inputString) {
+      if (this.required) this.errorText = 'Required';
+      else this.clearValidation();
+    } else if (!this.value) this.errorText = 'Invalid time';
+    else this.clearValidation();
+  }
+
+  private renderTimeInput() {
+    return (
+      <input
+        id="time-input"
+        aria-label={this.label ? null : this.ariaLabel}
+        aria-placeholder={this.placeholder}
+        disabled={this.disabled}
+        inputmode="text"
+        onInput={(event) => this.handleInputChange(event)}
+        placeholder={this.placeholder}
+        readonly={this.readOnly}
+        ref={(el) => (this.textInput = el as HTMLInputElement)}
+        tabIndex={0}
+        type="text"
+        value={this.displayString}
+        autofocus={this.autoFocusInput}
+        onBlur={() => this.handleBlur()}
+        maxLength={this.maxLength}
+        onKeyPress={(e) => this.handleInputKeyPress(e)}
+      />
+    );
+  }
+
+  private renderSubText() {
+    return this.errorText ? (
+      <label class="sub-text error">{this.errorText}</label>
+    ) : this.validText ? (
+      <label class="sub-text valid">{this.validText}</label>
+    ) : this.helperText ? (
+      <label class="sub-text helper">{this.helperText}</label>
+    ) : null;
+  }
+
+  render() {
+    const ariaControls = this.getAriaControls();
+    return (
+      <div
+        {...ariaControls}
+        class={{ 'modus-time-picker': true, disabled: this.disabled }}>
+        <div class="time-input-wrapper">
+          {this.label || this.required ? (
+            <div class={'label-container'}>
+              {this.label ? (
+                <label htmlFor="time-input">{this.label}</label>
+              ) : null}
+              {this.required ? <span class="required">*</span> : null}
+            </div>
+          ) : null}
+          <div
+            class={`input-container ${
+              this.errorText ? 'error' : this.validText ? 'valid' : ''
+            } ${this.classBySize.get(this.size)}`}>
+            {this.renderTimeInput()}
+          </div>
+          {this.renderSubText()}
+        </div>
+        <div class="time-zone-wrapper">
+          <slot name="timeZone"></slot>
+        </div>
+      </div>
+    );
+  }
+}

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.types.tsx
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.types.tsx
@@ -1,0 +1,10 @@
+export type TimeParts = {
+  hours: number;
+  minutes: number;
+  ampm: string;
+};
+
+export type TimeInputEventData = {
+  value: string;
+  inputString: string;
+};

--- a/stencil-workspace/src/components/modus-time-input/modus-time-picker.vars.scss
+++ b/stencil-workspace/src/components/modus-time-input/modus-time-picker.vars.scss
@@ -1,0 +1,42 @@
+// Light/Dark Theme variables
+$modus-input-bg: var(--modus-input-bg, #fff) !default;
+$modus-input-color: var(--modus-input-color, #252a2e) !default;
+$modus-input-border-color: var(--modus-input-border-color, #e0e1e9) !default;
+$modus-input-bottom-line-color: var(
+  --modus-input-bottom-line-color,
+  #6a6e79
+) !default;
+$modus-input-bottom-line-active-color: var(
+  --modus-input-bottom-line-active-color,
+  #217cbb
+) !default;
+$modus-input-hint-text-color: var(
+  --modus-input-hint-text-color,
+  #a3a6b1
+) !default;
+$modus-input-label-color: var(--modus-input-label-color, #464b52) !default;
+
+// Validation
+$modus-input-validation-success-color: var(
+  --modus-input-validation-success-color,
+  #006638
+) !default;
+$modus-input-validation-error-color: var(
+  --modus-input-validation-error-color,
+  #da212c
+) !default;
+
+// Disabled
+$modus-input-disabled-bg: var(--modus-input-disabled-bg, #e0e1e9) !default;
+$modus-input-disabled-border-color: var(
+  --modus-input-disabled-border-color,
+  #e0e1e9
+) !default;
+$modus-input-disabled-bottom-line-color: var(
+  --modus-input-disabled-bottom-line-color,
+  #a3a6b1
+) !default;
+$modus-input-disabled-color: var(
+  --modus-input-disabled-color,
+  #a3a6b1
+) !default;

--- a/stencil-workspace/src/components/modus-time-input/readme.md
+++ b/stencil-workspace/src/components/modus-time-input/readme.md
@@ -1,0 +1,59 @@
+# modus-time-picker
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property            | Attribute            | Description                                                | Type                  | Default     |
+| ------------------- | -------------------- | ---------------------------------------------------------- | --------------------- | ----------- |
+| `ampm`              | `ampm`               | (optional) Sets 12/24 hour format for the input string.    | `boolean`             | `undefined` |
+| `ariaLabel`         | `aria-label`         | (optional) The input's aria-label.                         | `string`              | `undefined` |
+| `autoFocusInput`    | `auto-focus-input`   | (optional) Sets autofocus on the input.                    | `boolean`             | `undefined` |
+| `disableValidation` | `disable-validation` | (optional) Disables default validation for the time input. | `boolean`             | `undefined` |
+| `disabled`          | `disabled`           | (optional) Whether the input is disabled.                  | `boolean`             | `undefined` |
+| `errorText`         | `error-text`         | (optional) Custom error text displayed for the input.      | `string`              | `undefined` |
+| `helperText`        | `helper-text`        | (optional) Custom helper text displayed below the input.   | `any`                 | `undefined` |
+| `label`             | `label`              | (optional) The input's label.                              | `string`              | `undefined` |
+| `maxLength`         | `max-length`         | (optional) The input's maximum length. Default is 10.      | `number`              | `8`         |
+| `placeholder`       | `placeholder`        | (optional) The input's placeholder text.                   | `string`              | `undefined` |
+| `readOnly`          | `read-only`          | (optional) Whether the input's content is read-only        | `boolean`             | `undefined` |
+| `required`          | `required`           | (optional) Whether the input is required.                  | `boolean`             | `undefined` |
+| `size`              | `size`               | (optional) The input's size.                               | `"large" \| "medium"` | `'medium'`  |
+| `validText`         | `valid-text`         | (optional) The input's valid state text.                   | `string`              | `undefined` |
+| `value`             | `value`              | (optional) Value of the time entered into the input.       | `string`              | `undefined` |
+
+
+## Events
+
+| Event           | Description                                      | Type                                                   |
+| --------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| `timeInputBlur` | An event that fires on input value out of focus. | `CustomEvent<{ value: string; inputString: string; }>` |
+| `valueChange`   | An event that fires on input value change.       | `CustomEvent<{ value: string; inputString: string; }>` |
+
+
+## Methods
+
+### `focusInput() => Promise<void>`
+
+Focus the input.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Slots
+
+| Slot         | Description                   |
+| ------------ | ----------------------------- |
+| `"timeZone"` | Slot for a Time Zone dropdown |
+
+
+----------------------------------------------
+
+

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -16,6 +16,22 @@
 
   </head>
   <body>
-    <!-- Test components here -->
+    <modus-time-picker label="Time" placeholder="12:39 PM" ampm="true">
+      <div style="width: 300px;padding-left: 0.5rem;" slot="timeZone">
+        <modus-select
+        id="select-demo-1"
+        label="Time Zone"
+        options-display-prop="display"></modus-select></div>
+    </modus-time-picker>
+
+    <modus-time-picker  label="Time"></modus-time-picker>
   </body>
+  <script>
+    const modusSelect = document.querySelector('#select-demo-1');
+    modusSelect.options = [
+      { display: 'Alpha Time Zone' },
+      { display: 'Australian Central Daylight Time' },
+      { display: 'Atlantic Daylight Time' },
+    ];
+  </script>
 </html>

--- a/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker-storybook-docs.mdx
@@ -1,0 +1,109 @@
+import { Story } from '@storybook/addon-docs';
+
+# Time Picker
+
+---
+
+[Modus Time Picker](https://modus.trimble.com/components/web/date-time-picker/styles/#time-picker) web component is a wrapper around native `<input type="text">` element used to input the time. It is referenced using the `<modus-time-picker>` custom HTML element.
+
+#### Implementation details
+
+- Modus Time Picker accepts input in 12 or 24-hour format depending on the value provided for prop `ampm`.
+- To use it along with a time zone, slot option is provided and referenced by `slot='timeZone'`.
+- The `value` which is a string representation of the time input is always in 24-hour format that includes leading zeros: `hh:mm`, regardless of the input format which is displayed.
+
+#### Validation
+
+- Modus Time Picker by default validates for an invalid time input string based on the 12/24 hour format and the validation is triggered on a blur event.
+- If the default validation is disabled, using props `errorText`, `invalid` the error state can also be set manually.
+- Modus Time picker allows only the character keys part of the format.
+
+### Default
+
+#### 24 Hour Format
+
+<modus-time-picker label="Time" placeholder="23:39" helper-text="hh:mm"></modus-time-picker>
+
+```html
+<modus-time-picker
+  label="Time"
+  placeholder="23:39"
+  helper-text="hh:mm"></modus-time-picker>
+```
+
+#### 12 Hour Format
+
+<modus-time-picker label="Time" ampm="true" placeholder="12:39 PM" helper-text="hh:mm (A/P)M"></modus-time-picker>
+
+```html
+<modus-time-picker
+  label="Time"
+  ampm="true"
+  placeholder="12:39 PM"
+  helper-text="hh:mm (A/P)M"></modus-time-picker>
+```
+
+### Time Picker with Time Zone
+
+<Story id="user-inputs-time-picker--with-time-zone" />
+
+```html
+<modus-time-picker label="Time" placeholder="12:39 PM">
+  <div style="width: 300px;padding-left: 0.5rem;" slot="timeZone">
+    <modus-select
+      id="select-demo-1"
+      label="Time Zone"
+      options-display-prop="display"></modus-select>
+  </div>
+</modus-time-picker>
+<script>
+  const modusSelect = document.querySelector('#select-demo-1');
+  modusSelect.options = [
+    { display: 'Alpha Time Zone' },
+    { display: 'Australian Central Daylight Time' },
+    { display: 'Atlantic Daylight Time' },
+  ];
+</script>
+```
+
+### Properties
+
+| Property            | Attribute            | Description                                                | Type                  | Default     |
+| ------------------- | -------------------- | ---------------------------------------------------------- | --------------------- | ----------- |
+| `ampm`              | `ampm`               | (optional) Sets 12/24 hour format for the input string.    | `boolean`             | `undefined` |
+| `ariaLabel`         | `aria-label`         | (optional) The input's aria-label.                         | `string`              | `undefined` |
+| `autoFocusInput`    | `auto-focus-input`   | (optional) Sets autofocus on the input.                    | `boolean`             | `undefined` |
+| `disableValidation` | `disable-validation` | (optional) Disables default validation for the time input. | `boolean`             | `undefined` |
+| `disabled`          | `disabled`           | (optional) Whether the input is disabled.                  | `boolean`             | `undefined` |
+| `errorText`         | `error-text`         | (optional) Custom error text displayed for the input.      | `string`              | `undefined` |
+| `helperText`        | `helper-text`        | (optional) Custom helper text displayed below the input.   | `any`                 | `undefined` |
+| `label`             | `label`              | (optional) The input's label.                              | `string`              | `undefined` |
+| `maxLength`         | `max-length`         | (optional) The input's maximum length. Default is 10.      | `number`              | `8`         |
+| `placeholder`       | `placeholder`        | (optional) The input's placeholder text.                   | `string`              | `undefined` |
+| `readOnly`          | `read-only`          | (optional) Whether the input's content is read-only        | `boolean`             | `undefined` |
+| `required`          | `required`           | (optional) Whether the input is required.                  | `boolean`             | `undefined` |
+| `size`              | `size`               | (optional) The input's size.                               | `"large" \| "medium"` | `'medium'`  |
+| `validText`         | `valid-text`         | (optional) The input's valid state text.                   | `string`              | `undefined` |
+| `value`             | `value`              | (optional) Value of the time entered into the input.       | `string`              | `undefined` |
+
+### DOM Events
+
+| Name            | Description                                      | Emits                                                  |
+| --------------- | ------------------------------------------------ | ------------------------------------------------------ |
+| `timeInputBlur` | An event that fires on input value out of focus. | `CustomEvent<{ value: string; inputString: string; }>` |
+| `valueChange`   | An event that fires on input value change.       | `CustomEvent<{ value: string; inputString: string; }>` |
+
+### Methods
+
+| Method name  | Description     | Parameter | Return          |
+| ------------ | --------------- | --------- | --------------- |
+| `focusInput` | Focus the input |           | `Promise<void>` |
+
+### Accessibility
+
+- Time Input gets an `aria-label` provided by the `aria-label` property input.
+- Time Input gets an `aria-disabled` provided by the `disabled` property input.
+- Time Input gets an `aria-placeholder` provided by the `placeholder` property input.
+- Time Input gets an `aria-invalid` from `invalid` property input.
+- Time Input gets an `aria-readonly` from `readonly` property input.
+- Time Input gets an `aria-required` from `required` property input.

--- a/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker.stories.tsx
@@ -1,0 +1,262 @@
+// @ts-ignore: JSX/MDX with Stencil
+import docs from './modus-time-picker-storybook-docs.mdx';
+import { html } from 'lit-html';
+
+export default {
+  title: 'User Inputs/Time Picker',
+  argTypes: {
+    ampm: {
+      name: 'ampm',
+      description: 'Sets 12/24 hour format for the input string.',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    ariaLabel: {
+      name: 'aria-label',
+      description: "The input's aria-label",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    autoFocusInput: {
+      name: 'auto-focus-input',
+      description: 'Sets autofocus for the input',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    disabled: {
+      description: 'Whether the text input is disabled',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
+    disableValidation: {
+      name: 'disable-validation',
+      description: 'Disables default validation for the time input',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
+    errorText: {
+      name: 'error-text',
+      description: "The input's error text",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    helperText: {
+      name: 'helper-text',
+      description: "The input's helper text",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    label: {
+      description: "The input's label",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    maxLength: {
+      name: 'max-length',
+      description: "The input's maximum length",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    placeholder: {
+      description: "The input's placeholder text",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    readOnly: {
+      name: 'read-only',
+      description: 'Whether the input is read-only',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
+    required: {
+      description: 'Whether the input is required',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
+    size: {
+      control: {
+        options: ['medium', 'large'],
+        type: 'select',
+      },
+      description: 'The size of the input',
+      table: {
+        defaultValue: { summary: "'medium'" },
+        type: { summary: "'medium' | 'large'" },
+      },
+    },
+    validText: {
+      name: 'valid-text',
+      description: "The input's valid text",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    value: {
+      description: "The input's value",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+  },
+  parameters: {
+    actions: {
+      handles: ['valueChange', 'timeInputBlur'],
+    },
+    controls: { expanded: true, sort: 'requiredFirst' },
+    docs: {
+      page: docs,
+    },
+    options: {
+      isToolshown: true,
+      enableShortcuts: false,
+    },
+  },
+};
+
+const Template = ({
+  ampm,
+  ariaLabel,
+  autoFocusInput,
+  disabled,
+  disableValidation,
+  errorText,
+  helperText,
+  label,
+  maxLength,
+  placeholder,
+  readOnly,
+  required,
+  size,
+  validText,
+  value,
+}) => html`
+  <modus-time-picker
+    ampm=${ampm}
+    aria-label=${ariaLabel}
+    auto-focus-input=${autoFocusInput}
+    disable-validation=${disableValidation}
+    disabled=${disabled}
+    error-text=${errorText}
+    helper-text=${helperText}
+    label=${label}
+    max-length=${maxLength}
+    placeholder=${placeholder}
+    read-only=${readOnly}
+    required=${required}
+    size=${size}
+    valid-text=${validText}
+    value=${value}></modus-time-picker>
+`;
+
+export const Default = Template.bind({});
+Default.args = {
+  ampm: false,
+  ariaLabel: '',
+  autoFocusInput: true,
+  disableValidation: false,
+  disabled: false,
+  errorText: '',
+  helperText: 'hh:mm',
+  label: 'Time',
+  maxLength: 8,
+  placeholder: '',
+  readOnly: false,
+  required: false,
+  size: 'medium',
+  type: 'text',
+  validText: '',
+  value: '23:39',
+};
+
+const WithTimeZoneTemplate = ({
+  ampm,
+  ariaLabel,
+  autoFocusInput,
+  disabled,
+  disableValidation,
+  errorText,
+  helperText,
+  label,
+  maxLength,
+  placeholder,
+  readOnly,
+  required,
+  size,
+  validText,
+  value,
+}) => html`
+  <modus-time-picker
+    ampm=${ampm}
+    aria-label=${ariaLabel}
+    auto-focus-input=${autoFocusInput}
+    disable-validation=${disableValidation}
+    disabled=${disabled}
+    error-text=${errorText}
+    helper-text=${helperText}
+    label=${label}
+    max-length=${maxLength}
+    placeholder=${placeholder}
+    read-only=${readOnly}
+    required=${required}
+    size=${size}
+    valid-text=${validText}
+    value=${value}>
+    <div style="width: 300px;padding-left: 0.5rem;" slot="timeZone">
+      <modus-select
+        id="select-demo-1"
+        label="Time Zone"
+        aria-label="Time Zone"
+        options-display-prop="display"></modus-select>
+    </div>
+  </modus-time-picker>
+  ${setSelects()}
+`;
+
+const setSelects = () => {
+  const tag = document.createElement('script');
+  tag.innerHTML = `
+  const modusSelect = document.querySelector('modus-select');
+  modusSelect.options = [
+    { display: 'Alpha Time Zone' },
+    { display: 'Australian Central Daylight Time' },
+    { display: 'Atlantic Daylight Time' },
+  ];
+  `;
+
+  return tag;
+};
+export const WithTimeZone = WithTimeZoneTemplate.bind({});
+WithTimeZone.args = {
+  ampm: false,
+  ariaLabel: '',
+  autoFocusInput: true,
+  disableValidation: false,
+  disabled: false,
+  errorText: '',
+  helperText: 'hh:mm',
+  label: 'Time',
+  maxLength: 8,
+  placeholder: '',
+  readOnly: false,
+  required: false,
+  size: 'medium',
+  type: 'text',
+  validText: '',
+  value: '23:39 PM',
+};


### PR DESCRIPTION
Added props `autoFormat` to enforce formatting while typing input, `allowedCharsRegex` to set a custom regex for allowing input keys, `min` to set minimum time, `max` to set maximum time, `minLength` to set minLength on the input field.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
