### PR TITLE
Issue 1061: Updated modus-modal default backdrop color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+## 0.1.35 - 2023-03-03
+
 ### Added
 
 - Added Modus Time Picker component
 - Added Modus Date Input(`<modus-date-input>`) and Modus Date Picker(`<modus-date-picker>`) components.
+- Updated Modus Modal to have a default (non themed) color consistent with the default theme.
 
 ## 0.1.34 - 2023-02-23
 

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.20.0"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-modal/modus-modal.e2e.ts
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.e2e.ts
@@ -129,4 +129,30 @@ describe('modus-modal', () => {
     await page.waitForChanges();
     expect(closed).toHaveReceivedEvent();
   });
+
+  it('has a default overlay background color', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<modus-modal secondary-button-text="Secondary Text"></modus-modal>'
+    );
+    const modal = await page.find('modus-modal');
+    await modal.callMethod('open');
+
+    // Computed overlay color is returned from page.evaluate()
+
+    const backgroundColor = await page.evaluate(async (): Promise<string> => {
+      const overlay = document
+        .querySelector('modus-modal')
+        .shadowRoot.querySelector('.overlay');
+      overlay.scrollIntoView({ block: 'center', inline: 'center' });
+
+      const styles = window.getComputedStyle(overlay);
+      return styles.backgroundColor;
+    });
+
+    await page.waitForChanges();
+    console.error(backgroundColor);
+    expect(backgroundColor).toBe('rgba(37, 42, 46, 0.75)');
+  });
+
 });

--- a/stencil-workspace/src/components/modus-modal/modus-modal.vars.scss
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.vars.scss
@@ -1,4 +1,4 @@
-$modus-modal-backdrop-bg: var(--modus-modal-backdrop-bg, #252a2e) !default;
+$modus-modal-backdrop-bg: var(--modus-modal-backdrop-bg, #252a2ebf) !default;
 $modus-modal-bg: var(--modus-modal-bg, #fff) !default;
 $modus-modal-border-color: var(--modus-modal-border-color, rgba(0, 0, 0, 0.2)) !default;
 $modus-modal-color: var(--modus-modal-color, #252a2e) !default;


### PR DESCRIPTION
## Description

This PR updates the default modus-modal backdrop color to be consistent with the default theme color. For existing users of modus-web-components they will now get consistent default UX when upgrading to the latest version.

Prior to this fix, when upgrading to the latest version the default backdrop color for the modus-modal was completely opaque.

Fixes #1061 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
 - Tested manually by using the component inside the test index.html page with and without the global themes applied in stencil.config.json
 - Added an e2e test to ensure that the styles are being applied correctly from the theme however I was unable to write an e2e test that covers the styles when themes are not applied. There is still a gap there for "default" component behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
