### PR TITLE
Add an ellipsis to text overflowing Modus Toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+## 0.1.36 - 2023-03-15
+
+### Fixed
+
+- Overflowing text in Modus Toast now uses an ellipsis
+
 ## 0.1.35 - 2023-03-03
 
 ### Added

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^2.20.0"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-toast/modus-toast.scss
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.scss
@@ -14,8 +14,18 @@
   height: 2.6875rem;
   padding: 0 $rem-16px;
 
+  .icon {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    min-width: $rem-18px;
+  }
+
   .text {
     margin: 0 $rem-8px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .close {

--- a/stencil-workspace/src/components/modus-toast/modus-toast.spec.ts
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.spec.ts
@@ -11,13 +11,15 @@ describe('modus-toast', () => {
 <modus-toast>
       <mock:shadow-root>
         <div class="default modus-toast" role="status">
-          <svg class="icon-info" fill="none" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
-            <path clip-rule="evenodd" d="M12 21C16.968 21 21 16.968 21 12C21 7.032 16.968 3 12 3C7.032 3 3 7.032 3 12C3 16.968 7.032 21 12 21ZM11 7H13V9H11V7ZM11 11H13L13 17H11L11 11Z" fill="#6A6976" fill-rule="evenodd"></path>
-            <mask height="18" id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" width="18" x="3" y="3">
-              <path clip-rule="evenodd" d="M12 21C16.968 21 21 16.968 21 12C21 7.032 16.968 3 12 3C7.032 3 3 7.032 3 12C3 16.968 7.032 21 12 21ZM11 7H13V9H11V7ZM11 11H13L13 17H11L11 11Z" fill="white" fill-rule="evenodd"></path>
-            </mask>
-            <g mask="url(#mask0)"></g>
-          </svg>
+          <div class="icon">
+            <svg class="icon-info" fill="none" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+              <path clip-rule="evenodd" d="M12 21C16.968 21 21 16.968 21 12C21 7.032 16.968 3 12 3C7.032 3 3 7.032 3 12C3 16.968 7.032 21 12 21ZM11 7H13V9H11V7ZM11 11H13L13 17H11L11 11Z" fill="#6A6976" fill-rule="evenodd"></path>
+              <mask height="18" id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" width="18" x="3" y="3">
+                <path clip-rule="evenodd" d="M12 21C16.968 21 21 16.968 21 12C21 7.032 16.968 3 12 3C7.032 3 3 7.032 3 12C3 16.968 7.032 21 12 21ZM11 7H13V9H11V7ZM11 11H13L13 17H11L11 11Z" fill="white" fill-rule="evenodd"></path>
+              </mask>
+              <g mask="url(#mask0)"></g>
+            </svg>
+          </div>
           <span class="text">
             <slot></slot>
           </span>

--- a/stencil-workspace/src/components/modus-toast/modus-toast.tsx
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.tsx
@@ -63,7 +63,7 @@ export class ModusToast {
 
     return (
       <div aria-label={this.ariaLabel} class={className} role="status">
-        {this.showIcon && icon}
+        {this.showIcon && <div class="icon">{icon}</div>}
         <span class={'text'}>
           <slot />
         </span>


### PR DESCRIPTION
## Description

Text overflowing the Toast was wrapping to a new line and displaying outside of the Toast

Fixes #1094

## Type of change

- [X] New feature (non-breaking change which adds functionality)
