### PR TITLE
Reduce Switch input animation from .2s to .1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ View all releases at: <https://github.com/trimble-oss/modus-web-components/relea
 
 ## Unreleased
 
+### Fixed
+
+- Switch transition animation reduced to 0.1s
+
 ### Added
 
 - Added format option to the Modus Date Input component.

--- a/stencil-workspace/src/components/modus-switch/modus-switch.scss
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.scss
@@ -25,7 +25,6 @@
       position: absolute;
       right: 0;
       top: 0;
-      transition: 0.2s;
       width: 1.875rem;
     }
 
@@ -35,7 +34,7 @@
       content: '';
       height: $rem-14px;
       position: absolute;
-      transition: 0.2s;
+      transition: 0.1s;
       width: $rem-14px;
     }
 


### PR DESCRIPTION
Fixes: #1099

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v110
