### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,7 @@
 
 ## Folders
 
-*                    @ryan-henness-trimble
-/react-workspace/    @msankaran0712
-/stencil-workspace/  @ryan-henness-trimble
+*                    @mwc-review
 
 ## File Types
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 ## Folders
 
-*                    @mwc-review
+*                    @trimble-oss/mwc-review
 
 ## File Types
 


### PR DESCRIPTION
Use a team instead of usernames so we can easily add or remove additional reviewers without needing to make a PR to update the CODEOWNERS file.

Note: everyone in the CODEOWNERS file must have Write-access. It doesn't work if they don't.