### PR TITLE
Add a deprecation warning to the Modus Table

### DIFF
--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -15,7 +15,6 @@ import { ModusNavbarApp as ModusNavbarApp1 } from "./components/modus-navbar/app
 import { ModusNavbarProfileMenuLink as ModusNavbarProfileMenuLink1 } from "./components/modus-navbar/profile-menu/modus-navbar-profile-menu";
 import { RadioButton } from "./components/modus-radio-group/modus-radio-button";
 import { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/modus-side-navigation.models";
-import { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/modus-side-navigation.types";
 import { ModusTableCellLink, ModusTableDisplayOptions, ModusTableRowAction, ModusTableRowActionClickEvent, ModusTableSelectionOptions, ModusTableSortEvent, ModusTableSortOptions, TCell, TColumn, TRow } from "./components/modus-table/modus-table.models";
 import { Tab } from "./components/modus-tabs/modus-tabs";
 import { TimeInputEventData } from "./components/modus-time-picker/modus-time-picker.types";

--- a/stencil-workspace/src/components/modus-switch/modus-switch.scss
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.scss
@@ -18,9 +18,9 @@
     .slider {
       background-color: $modus-switch-bg;
       border-radius: $rem-16px;
-      inset: 0;
       cursor: pointer;
       height: $rem-14px;
+      inset: 0;
       position: absolute;
       right: 0;
       top: 0;

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
@@ -2,7 +2,7 @@ import { Story } from '@storybook/addon-docs';
 
 # Table
 
-<modus-alert type="warning" message="This component is under construction!"></modus-alert>
+<modus-alert type="warning" message="This component will be deprecated very soon! Please use Modus Data Table for displaying data in rows and columns."></modus-alert>
 
 ---
 
@@ -34,11 +34,7 @@ They are referenced using the `<modus-table>` custom HTML element.
   <modus-table />
 </div>
 <script>
-  document.querySelector('modus-table').columns = [
-    'Name',
-    'Age',
-    'Contacted',
-  ];
+  document.querySelector('modus-table').columns = ['Name', 'Age', 'Contacted'];
   document.querySelector('modus-table').data = [
     ['John', 25, false],
     ['Jane', 26, false],
@@ -234,21 +230,21 @@ interface ModusTableSortOptions {
 
 ### Properties
 
-| Property               | Attribute | Description                                | Type                           | Default                                                                                                         |
-| ---------------------- | --------- | ------------------------------------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `columns` _(required)_ | --        |                                            | `TColumn[], string[]`          | `undefined`                                                                                                     |
-| `data` _(required)_    | --        |                                            | `TCell[][], TRow[]`            | `undefined`                                                                                                     |
-| `displayOptions`       | --        | Options for table display.            | `ModusTableDisplayOptions` | `{ animateRowActionsDropdown: false, borderless: true, cellBorderless: true, rowStripe: false, size: 'large' }` |
-| `rowActions`           | --        | Actions that can be performed on each row. | `ModusTableRowAction[]`    | `[]`                                                                                                            |
-| `selectionOptions`     | --        | Options for table item selection.     | `ModusTableSelectionOptions`   | `{ canSelect: false, checkboxSelection: false, }`                                                               |
-| `sortOptions`          | --        | Options for table column sort.        | `ModusTableSortOptions`        | `{ canSort: false, serverSide: false, }`                                                                        |
+| Property               | Attribute | Description                                | Type                         | Default                                                                                                         |
+| ---------------------- | --------- | ------------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `columns` _(required)_ | --        |                                            | `TColumn[], string[]`        | `undefined`                                                                                                     |
+| `data` _(required)_    | --        |                                            | `TCell[][], TRow[]`          | `undefined`                                                                                                     |
+| `displayOptions`       | --        | Options for table display.                 | `ModusTableDisplayOptions`   | `{ animateRowActionsDropdown: false, borderless: true, cellBorderless: true, rowStripe: false, size: 'large' }` |
+| `rowActions`           | --        | Actions that can be performed on each row. | `ModusTableRowAction[]`      | `[]`                                                                                                            |
+| `selectionOptions`     | --        | Options for table item selection.          | `ModusTableSelectionOptions` | `{ canSelect: false, checkboxSelection: false, }`                                                               |
+| `sortOptions`          | --        | Options for table column sort.             | `ModusTableSortOptions`      | `{ canSort: false, serverSide: false, }`                                                                        |
 
 ### Events
 
 | Event            | Description                                       | Type                                                |
 | ---------------- | ------------------------------------------------- | --------------------------------------------------- |
-| `cellLinkClick`  | An event that fires on cell link click.           | `CustomEvent<ModusTableCellLink>`               |
+| `cellLinkClick`  | An event that fires on cell link click.           | `CustomEvent<ModusTableCellLink>`                   |
 | `rowActionClick` | An event that fires when a row action is clicked. | `CustomEvent<{ actionId: string; rowId: string; }>` |
 | `rowDoubleClick` | An event that fires on row double click.          | `CustomEvent<string>`                               |
 | `selection`      | An event that fires on selection change.          | `CustomEvent<string[]>`                             |
-| `sort`           | An event that fires on column sort.               | `CustomEvent<ModusTableSortEvent>`              |
+| `sort`           | An event that fires on column sort.               | `CustomEvent<ModusTableSortEvent>`                  |


### PR DESCRIPTION
When we release the new [modus-data-table](https://deploy-preview-1231--modus-webcomponents.netlify.app/?path=/story/components-data-table--default), we must warn users not to use [modus-table](https://deploy-preview-1231--modus-webcomponents.netlify.app/?path=/story/components-table--default)(renamed because it used to be `modus-data-table`) component and it will be deprecated soon.

Note: the branch will not merge to `main` branch directly until data table is available.

Fixes #693 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
