### PR TITLE
(Deprecated Data Table) Fix header min-height

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,13 +165,11 @@ You can add the following code to the test file to pause the test at a specific 
 5. If the library is going to require a version bump for release, bump the version in `package.json` and run `npm i` after. If a release is not needed at this point, don't worry about this step.
 6. If there is any change to the library's API, update the Storybook documentation under `./storybook/stories`.
    - To run the Storybook site, `cd` into the directory and run `npm run storybook`. The library build will need to be up to date. The changes to the site will be deployed upon the PR merge to `main`.
-7. Update the `CHANGELOG.md` with notes on your changes.
-   - For more information about how to update the changelog, refer to the detailed section in the readme.
-8. Once all of your changes have been made, squash your commits down to a singular commit with a relevant message.
+7. Once all of your changes have been made, squash your commits down to a singular commit with a relevant message.
    - If you prefer to do this with a GUI, GitHub Desktop has a [great squashing feature](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/squashing-commits).
-9. Submit your PR with your branch as the `head`, and the `@trimble-oss/modus-web-components` `main` branch as the `base`.
+8. Submit your PR with your branch as the `head`, and the `@trimble-oss/modus-web-components` `main` branch as the `base`.
    - Don't forget to link your relevant issue in the PR description.
-10. Rebase and Merge the PR upon approval.
+9. Rebase and Merge the PR upon approval.
 
 ## Changelog
 

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
@@ -20,7 +20,7 @@ table {
     .column-header {
       display: flex;
       flex-direction: row;
-      height: $rem-20px;
+      min-height: $rem-20px;
       justify-content: center;
       padding: 0 $rem-8px;
 


### PR DESCRIPTION
## Description

Set the deprecated table's header min height instead of height.

Also removed the section about updating the CHANGELOG in the CONTRIBUTING doc

Fixes #1263 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

## How Has This Been Tested?

Manually through the index.html

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
