### PR TITLE
Add Compact Progress Bar variant (4px height)

### DIFF
--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -710,7 +710,7 @@ export namespace Components {
         /**
           * (optional) The progress bar's size.
          */
-        "size": 'default' | 'compact';
+        "size": 'default' | 'small' | 'compact';
         /**
           * (optional) The text displayed on the progress bar.
          */
@@ -1115,7 +1115,7 @@ export namespace Components {
          */
         "checkedItems": string[];
         /**
-          * (optional) Disable usage of `tab` key to focus elements inside a tree view. Use `Arrow Up/Down` for focussing an tree item and `Shift + Arrow Right` for focussing a checkbox inside the item.
+          * (optional) Disable usage of `tab` key to focus elements inside a tree view. Use `Arrow Up/Down` for focussing a tree item and `Shift + Arrow Right` for focussing a checkbox inside the item.
          */
         "disableTabbing": boolean;
         /**
@@ -2399,7 +2399,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The progress bar's size.
          */
-        "size"?: 'default' | 'compact';
+        "size"?: 'default' | 'small' | 'compact';
         /**
           * (optional) The text displayed on the progress bar.
          */
@@ -2849,7 +2849,7 @@ declare namespace LocalJSX {
          */
         "checkedItems"?: string[];
         /**
-          * (optional) Disable usage of `tab` key to focus elements inside a tree view. Use `Arrow Up/Down` for focussing an tree item and `Shift + Arrow Right` for focussing a checkbox inside the item.
+          * (optional) Disable usage of `tab` key to focus elements inside a tree view. Use `Arrow Up/Down` for focussing a tree item and `Shift + Arrow Right` for focussing a checkbox inside the item.
          */
         "disableTabbing"?: boolean;
         /**

--- a/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.scss
+++ b/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.scss
@@ -27,7 +27,11 @@
     }
   }
 
-  &.compact {
+  &.small {
     height: $rem-8px;
+  }
+
+  &.compact {
+    height: $rem-4px;
   }
 }

--- a/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.spec.ts
+++ b/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.spec.ts
@@ -44,6 +44,9 @@ describe('modus-progress-bar', () => {
     let className = modusProgress.classBySize.get(modusProgress.size);
     expect(className).toEqual('default');
 
+    className = modusProgress.classBySize.get('small');
+    expect(className).toEqual('small');
+
     className = modusProgress.classBySize.get('compact');
     expect(className).toEqual('compact');
   });

--- a/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.tsx
+++ b/stencil-workspace/src/components/modus-progress-bar/modus-progress-bar.tsx
@@ -6,7 +6,6 @@ import { Component, Prop, h, Host } from '@stencil/core';
   styleUrl: 'modus-progress-bar.scss',
   shadow: true,
 })
-
 export class ModusProgressBar {
   /** (optional) The progress bar's aria-label. */
   @Prop() ariaLabel: string | null;
@@ -24,7 +23,7 @@ export class ModusProgressBar {
   @Prop() minValue = 0;
 
   /** (optional) The progress bar's size. */
-  @Prop() size: 'default' | 'compact' = 'default';
+  @Prop() size: 'default' | 'small' | 'compact' = 'default';
 
   /** (optional) The text displayed on the progress bar. */
   @Prop() text: string;
@@ -37,14 +36,19 @@ export class ModusProgressBar {
 
   classBySize: Map<string, string> = new Map([
     ['default', 'default'],
+    ['small', 'small'],
     ['compact', 'compact'],
   ]);
 
-  getProgressStyle(percentage: number): { backgroundColor: string, color: string, width: string } {
+  getProgressStyle(percentage: number): {
+    backgroundColor: string;
+    color: string;
+    width: string;
+  } {
     const progressStyle = {
       backgroundColor: this.color,
       color: this.textColor,
-      width: `${percentage}%`
+      width: `${percentage}%`,
     };
 
     return progressStyle;
@@ -52,15 +56,18 @@ export class ModusProgressBar {
 
   getProgressBarStyle(): { backgroundColor: string } {
     const progressBarStyle = {
-      backgroundColor: this.backgroundColor
+      backgroundColor: this.backgroundColor,
     };
 
     return progressBarStyle;
   }
 
   render(): unknown {
-    const percentage = (this.value - this.minValue) / (this.maxValue - this.minValue) * 100;
-    const progressBarBackgroundColorClass = this.backgroundColor ? '' : 'default-background-color';
+    const percentage =
+      ((this.value - this.minValue) / (this.maxValue - this.minValue)) * 100;
+    const progressBarBackgroundColorClass = this.backgroundColor
+      ? ''
+      : 'default-background-color';
     const progressColorClass = this.color ? '' : 'default-color';
     const progressTextColor = this.textColor ? '' : 'default-text-color';
     const progressBarClass = `
@@ -77,9 +84,7 @@ export class ModusProgressBar {
         aria-valuemin={this.minValue}
         aria-valuenow={this.value}
         role="progressbar">
-        <div
-          class={progressBarClass}
-          style={this.getProgressBarStyle()}>
+        <div class={progressBarClass} style={this.getProgressBarStyle()}>
           <div class={progressClass} style={this.getProgressStyle(percentage)}>
             {this.size === 'default' && this.text}
           </div>

--- a/stencil-workspace/src/components/modus-progress-bar/readme.md
+++ b/stencil-workspace/src/components/modus-progress-bar/readme.md
@@ -7,17 +7,17 @@
 
 ## Properties
 
-| Property          | Attribute          | Description                                        | Type                     | Default     |
-| ----------------- | ------------------ | -------------------------------------------------- | ------------------------ | ----------- |
-| `ariaLabel`       | `aria-label`       | (optional) The progress bar's aria-label.          | `string`                 | `undefined` |
-| `backgroundColor` | `background-color` | (optional) The progress bar's background color.    | `string`                 | `undefined` |
-| `color`           | `color`            | (optional) The progress bar's foreground color.    | `string`                 | `undefined` |
-| `maxValue`        | `max-value`        | (optional) The progress bar's maximum value.       | `number`                 | `100`       |
-| `minValue`        | `min-value`        | (optional) The progress bar's minimum value.       | `number`                 | `0`         |
-| `size`            | `size`             | (optional) The progress bar's size.                | `"compact" \| "default"` | `'default'` |
-| `text`            | `text`             | (optional) The text displayed on the progress bar. | `string`                 | `undefined` |
-| `textColor`       | `text-color`       | (optional) The progress bar's text color.          | `string`                 | `undefined` |
-| `value`           | `value`            | (optional) The progress bar's value.               | `number`                 | `0`         |
+| Property          | Attribute          | Description                                        | Type                                | Default     |
+| ----------------- | ------------------ | -------------------------------------------------- | ----------------------------------- | ----------- |
+| `ariaLabel`       | `aria-label`       | (optional) The progress bar's aria-label.          | `string`                            | `undefined` |
+| `backgroundColor` | `background-color` | (optional) The progress bar's background color.    | `string`                            | `undefined` |
+| `color`           | `color`            | (optional) The progress bar's foreground color.    | `string`                            | `undefined` |
+| `maxValue`        | `max-value`        | (optional) The progress bar's maximum value.       | `number`                            | `100`       |
+| `minValue`        | `min-value`        | (optional) The progress bar's minimum value.       | `number`                            | `0`         |
+| `size`            | `size`             | (optional) The progress bar's size.                | `"compact" \| "default" \| "small"` | `'default'` |
+| `text`            | `text`             | (optional) The text displayed on the progress bar. | `string`                            | `undefined` |
+| `textColor`       | `text-color`       | (optional) The progress bar's text color.          | `string`                            | `undefined` |
+| `value`           | `value`            | (optional) The progress bar's value.               | `number`                            | `0`         |
 
 
 ----------------------------------------------

--- a/stencil-workspace/storybook/stories/components/modus-progress-bar/modus-progress-bar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-progress-bar/modus-progress-bar-storybook-docs.mdx
@@ -16,6 +16,18 @@
 
 <Anchor storyId="components-progress-bar--default" />
 
+### Small
+
+<div>
+  <modus-progress-bar
+    value="3"
+    max-value="4"
+    min-value="0"
+    size="small"></modus-progress-bar>
+</div>
+
+<Anchor storyId="components-progress-bar--small" />
+
 ### Compact
 
 <div>
@@ -38,22 +50,27 @@
   value="3"
   max-value="4"
   min-value="0"
+  size="small"></modus-progress-bar>
+<modus-progress-bar
+  value="3"
+  max-value="4"
+  min-value="0"
   size="compact"></modus-progress-bar>
 ```
 
 ### Properties
 
-| Name               | Description                   | Type                   | Options | Default Value                | Required |
-| ------------------ | ----------------------------- | ---------------------- | ------- | ---------------------------- | -------- |
-| `aria-label`       | The progress bar's aria-label | `string`               |         |                              |          |
-| `background-color` | The bar's background color    | `string`               |         | `#FFFFFF` (Trimble White)    |          |
-| `color`            | The bar's color               | `string`               |         | `#005F9E` (Trimble Blue Mid) |          |
-| `max-value`        | The maximum value             | `number`               |         | 100                          |          |
-| `min-value `       | The minimum value             | `number`               |         | 0                            |          |
-| `size`             | The size of the bar           | `'default'`, `'small'` |         | `default`                    |          |
-| `text`             | The text displayed on the bar | `string`               |         |                              |          |
-| `text-color`       | The text color                | `string`               |         | `#FFFFFF` (Trimble White)    |          |
-| `value`            | The progress value            | `number`               |         | 0                            |          |
+| Name               | Description                   | Type                                | Default Value                | Required |
+| ------------------ | ----------------------------- | ----------------------------------- | ---------------------------- | -------- |
+| `aria-label`       | The progress bar's aria-label | `string`                            |                              |          |
+| `background-color` | The bar's background color    | `string`                            | `#FFFFFF` (Trimble White)    |          |
+| `color`            | The bar's color               | `string`                            | `#005F9E` (Trimble Blue Mid) |          |
+| `max-value`        | The maximum value             | `number`                            | `100`                        |          |
+| `min-value `       | The minimum value             | `number`                            | `0`                          |          |
+| `size`             | The size of the bar           | `'default'`, `'small'`, `'compact'` | `default`                    |          |
+| `text`             | The text displayed on the bar | `string`                            |                              |          |
+| `text-color`       | The text color                | `string`                            | `#FFFFFF` (Trimble White)    |          |
+| `value`            | The progress value            | `number`                            | `0`                          |          |
 
 ### Accessibility
 

--- a/stencil-workspace/storybook/stories/components/modus-progress-bar/modus-progress-bar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-progress-bar/modus-progress-bar.stories.tsx
@@ -42,10 +42,14 @@ export default {
       },
     },
     size: {
+      control: {
+        options: ['default', 'small', 'compact'],
+        type: 'select',
+      },
       description: "The progress bar's size",
       table: {
         defaultValue: { summary: 'default' },
-        type: { summary: 'string' },
+        type: { summary: `'default' | 'small' | 'compact'` },
       },
     },
     text: {
@@ -113,6 +117,19 @@ Default.args = {
   minValue: 0,
   size: 'default',
   text: 'Some progress!',
+  textColor: '',
+  value: 50,
+};
+
+export const Small = Template.bind({});
+Small.args = {
+  ariaLabel: 'progress bar',
+  backgroundColor: '',
+  color: '',
+  maxValue: 100,
+  minValue: 0,
+  size: 'small',
+  text: '',
   textColor: '',
   value: 50,
 };


### PR DESCRIPTION
Note: The small variant on the site right now was referred to compact in some places.
There is now both a small (8px) and compact variant (4px). 

PREVIEW: https://icy-ground-0374a1310-1296.centralus.1.azurestaticapps.net/?path=/docs/components-progress-bar--default