### PR TITLE
Remove Material Icons from Storybook preview window

### DIFF
--- a/stencil-workspace/storybook/.storybook/preview-head.html
+++ b/stencil-workspace/storybook/.storybook/preview-head.html
@@ -1,4 +1,2 @@
 <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=fallback" rel="stylesheet">
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block" rel="stylesheet">
 <link href="/storybook-styles.css" rel="stylesheet">
-


### PR DESCRIPTION
Material Icons are not used or needed
