### PR TITLE
Fix for border color on modus-card

### DIFF
--- a/stencil-workspace/src/components/modus-card/modus-card.scss
+++ b/stencil-workspace/src/components/modus-card/modus-card.scss
@@ -2,7 +2,8 @@
 
 article {
   background-color: $modus-card-bg;
-  border: $rem-1px solid $modus-card-border-color;
+  border: $rem-1px solid;
+  border-color: transparent;
   border-radius: $rem-2px;
   color: $modus-card-color;
   font-family: $primary-font;
@@ -14,6 +15,6 @@ article {
   }
 
   &.card-border {
-    border: $rem-1px solid $modus-card-shadow-color;
+    border-color: $modus-card-border-color;
   }
 }


### PR DESCRIPTION
## Description

Fixes: #1299

Modus Card component has border when showCardBorder property is set on false. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v113 

![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/d65b549e-8cf8-49a5-bdc8-84f93fa024b5)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (including CHANGELOG updates)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
