### PR TITLE
Remove mention about needing Material icons on getting-started

### DIFF
--- a/stencil-workspace/storybook/stories/introduction/getting-started.stories.mdx
+++ b/stencil-workspace/storybook/stories/introduction/getting-started.stories.mdx
@@ -27,15 +27,12 @@ The Modus Web Components package is hosted publicly through the [npm package reg
 npm install @trimble-oss/modus-web-components --save
 ```
 
-2. Make sure Open Sans, and Google Material Icons are available browser resources in your application:
+2. Make sure the Open Sans font is available in your application:
 
 ```html
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
   href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=fallback"
-  rel="stylesheet" />
-<link
-  href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block"
   rel="stylesheet" />
 ```
 


### PR DESCRIPTION
## Description

There is no need to load Material Icons now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
