### PR TITLE
Update Prettier Config ("printWidth": 125)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "bracketSameLine": true,
+  "printWidth": 125,
   "singleQuote": true
 }

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-storybook": "^0.6.12",
         "jest": "^27.0.3",
         "jest-cli": "^27.5.1",
-        "prettier": "^2.8.7",
+        "prettier": "2.8.8",
         "puppeteer": "^19.11.1",
         "puppeteer-core": "^19.7.2",
         "stylelint": "15.5.0",
@@ -5572,9 +5572,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -33,7 +33,7 @@
     "lint": "npm run lint-js && npm run lint-css",
     "lint-js": "eslint src/** --no-error-on-unmatched-pattern",
     "lint-css": "stylelint src/**/*.scss --fix",
-    "prettier": "prettier --write storybook/stories/**/*.*",
+    "prettier": "prettier --write storybook/stories/**/*.* src/**/*.*",
     "full": "npm ci && npm run lint && npm run build && npm run test && npm run ci-storybook",
     "ci-storybook": "cd storybook && npm ci && npm run build-storybook",
     "start-storybook": "npm run build && cd storybook && npm run storybook"
@@ -54,7 +54,7 @@
     "eslint-plugin-storybook": "^0.6.12",
     "jest": "^27.0.3",
     "jest-cli": "^27.5.1",
-    "prettier": "^2.8.7",
+    "prettier": "2.8.8",
     "puppeteer": "^19.11.1",
     "puppeteer-core": "^19.7.2",
     "stylelint": "15.5.0",


### PR DESCRIPTION
Fixes:
- The default prettier config sets: "printWidth": 80, by default which is too narrow. Suggest we change it to 125.
- Currently the npm run prettier command in storybook dir only runs on storybook/stories/ - we should also run it on the src/ dir 
- We can update Prettier dev dep from v2.8.7 to v2.8.8 too
