### PR TITLE
Fix NavBar Main menu full screen height

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
@@ -7,6 +7,7 @@
   border-top: none;
   clip-path: inset(0 -10px -10px -10px);
   cursor: default;
+  height: calc(100vh - 58px);
   left: 0;
   max-width: 616px;
   min-width: 248px;

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -19,13 +19,8 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <Story id="components-navbar--default" />
 
 ```html
-<modus-navbar
-  id="working"
-  show-apps-menu
-  show-help
-  show-main-menu
-  show-notifications>
-  <div slot="main" style="height:300px;">Render your own main menu.</div>
+<modus-navbar id="working" show-apps-menu show-help show-main-menu show-notifications>
+  <div slot="main">Render your own main menu.</div>
   <div slot="notifications">Render your own notifications.</div>
 </modus-navbar>
 
@@ -66,13 +61,8 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <Story id="components-navbar--failed-avatar" />
 
 ```html
-<modus-navbar
-  id="broken"
-  show-apps-menu
-  show-help
-  show-main-menu
-  show-notifications>
-  <div slot="main" style="height:300px;">Render your own main menu.</div>
+<modus-navbar id="broken" show-apps-menu show-help show-main-menu show-notifications>
+  <div slot="main">Render your own main menu.</div>
   <div slot="notifications">Render your own notifications.</div>
 </modus-navbar>
 
@@ -115,14 +105,8 @@ Use the `variant` prop to choose a blue background navbar.
 <Story id="components-navbar--blue-navbar" />
 
 ```html
-<modus-navbar
-  id="blue-theme"
-  show-apps-menu
-  show-help
-  show-main-menu
-  show-notifications
-  variant="blue">
-  <div slot="main" style="height:300px;">Render your own main menu.</div>
+<modus-navbar id="blue-theme" show-apps-menu show-help show-main-menu show-notifications variant="blue">
+  <div slot="main">Render your own main menu.</div>
   <div slot="notifications">Render your own notifications.</div>
 </modus-navbar>
 

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -20,13 +20,8 @@ export default {
 };
 
 const Template = () => html`
-  <modus-navbar
-    id="working"
-    show-apps-menu
-    show-help
-    show-main-menu
-    show-notifications>
-    <div slot="main" style="height:300px;">Render your own main menu.</div>
+  <modus-navbar id="working" show-apps-menu show-help show-main-menu show-notifications>
+    <div slot="main">Render your own main menu.</div>
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>
   ${setNavbar(true, '#working')}
@@ -34,13 +29,8 @@ const Template = () => html`
 export const Default = Template.bind({});
 
 const FailedToLoadAvatarTemplate = () => html`
-  <modus-navbar
-    id="broken"
-    show-apps-menu
-    show-help
-    show-main-menu
-    show-notifications>
-    <div slot="main" style="height:300px;">Render your own main menu.</div>
+  <modus-navbar id="broken" show-apps-menu show-help show-main-menu show-notifications>
+    <div slot="main">Render your own main menu.</div>
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>
   ${setNavbar(false, '#broken')}
@@ -48,21 +38,11 @@ const FailedToLoadAvatarTemplate = () => html`
 export const FailedAvatar = FailedToLoadAvatarTemplate.bind({});
 
 const BlueTemplate = () => html`
-  <modus-navbar
-    id="blue-theme"
-    show-apps-menu
-    show-help
-    show-main-menu
-    show-notifications
-    variant="blue">
-    <div slot="main" style="height:300px;">Render your own main menu.</div>
+  <modus-navbar id="blue-theme" show-apps-menu show-help show-main-menu show-notifications variant="blue">
+    <div slot="main">Render your own main menu.</div>
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>
-  ${setNavbar(
-    false,
-    '#blue-theme',
-    'https://modus-bootstrap.trimble.com/img/trimble-logo-rev.svg'
-  )}
+  ${setNavbar(false, '#blue-theme', 'https://modus-bootstrap.trimble.com/img/trimble-logo-rev.svg')}
 `;
 export const BlueNavbar = BlueTemplate.bind({});
 


### PR DESCRIPTION
## Description

Reverted the change that removed full screen height on NavBar in a [commit](https://github.com/trimble-oss/modus-web-components/commit/edad227c15f9116344a8da272add8677b1f833c1#diff-3fbcd5eb11fa2bbc82440513ab25928befa8beea91da49aea1cd36e7228fa0de)  

@ryan-henness-trimble  I have set the height to `calc(100vh - 58px);`  to avoid scroll bar, earlier it was `calc(100vh - 54px);` because of which a scroll bar was appearing even after removing unwanted spaces from the web page. 
I assume that 54px represents the fixed height on NavBar container.

### created the PR to revert my changes, please feel free to close it if not required.

References #1345 


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
