### PR TITLE
[NAV-110] Modus Chip - add property closeIcon to display a different icon.

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -262,13 +262,13 @@ export declare interface ModusChip extends Components.ModusChip {
 
 @ProxyCmp({
   defineCustomElementFn: undefined,
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
+  inputs: ['ariaLabel', 'chipStyle', 'closeIcon', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
 })
 @Component({
   selector: 'modus-chip',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
+  inputs: ['ariaLabel', 'chipStyle', 'closeIcon', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
 })
 export class ModusChip {
   protected el: HTMLElement;

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -253,14 +253,14 @@ export declare interface ModusCheckbox extends Components.ModusCheckbox {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
+  inputs: ['ariaLabel', 'chipStyle', 'closeIcon', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
 })
 @Component({
   selector: 'modus-chip',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value'],
+  inputs: ['ariaLabel', 'chipStyle', 'closeIcon', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value'],
 })
 export class ModusChip {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -251,6 +251,10 @@ export namespace Components {
          */
         "chipStyle": 'outline' | 'solid';
         /**
+          * (optional) The chip's close icon.
+         */
+        "closeIcon": 'close' | 'remove';
+        /**
           * (optional) Whether the chip is disabled.
          */
         "disabled": boolean;
@@ -1851,6 +1855,10 @@ declare namespace LocalJSX {
           * (optional) The chip's style.
          */
         "chipStyle"?: 'outline' | 'solid';
+        /**
+          * (optional) The chip's close icon.
+         */
+        "closeIcon"?: 'close' | 'remove';
         /**
           * (optional) Whether the chip is disabled.
          */

--- a/stencil-workspace/src/components/icons/icon-close.tsx
+++ b/stencil-workspace/src/components/icons/icon-close.tsx
@@ -3,7 +3,7 @@ import { FunctionalComponent, h } from '@stencil/core';
 
 interface IconProps {
   color?: string;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent) => void;
   size?: string;
 }
 
@@ -12,7 +12,7 @@ export const IconClose: FunctionalComponent<IconProps> = (props: IconProps) => (
     class="icon-close"
     height={props.size ?? 16}
     width={props.size ?? 16}
-    onClick={props.onClick ? () => props.onClick() : null}
+    onClick={props.onClick ? (event) => props.onClick(event) : null}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg">

--- a/stencil-workspace/src/components/modus-chip/modus-chip.e2e.ts
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.e2e.ts
@@ -102,6 +102,23 @@ describe('modus-chip', () => {
     expect(shadowIconRemove).not.toBeNull();
   });
 
+  it('renders changes to close icon', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-chip></modus-chip>');
+    const chip = await page.find('modus-chip');
+    chip.setProperty('showClose', 'true');
+    await page.waitForChanges();
+    expect(await chip.getProperty('closeIcon')).toBe('remove');
+
+    chip.setProperty('closeIcon', 'close');
+    await page.waitForChanges();
+    expect(await chip.getProperty('closeIcon')).toBe('close');
+
+    const shadowIconClose = await page.find('modus-chip >>> .icon-close');
+    expect(shadowIconClose).not.toBeNull();
+  });
+
   it('renders changes to size', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-chip/modus-chip.scss
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.scss
@@ -16,7 +16,7 @@
   vertical-align: middle;
 
   &.no-left-icon.no-right-icon {
-    padding: 0 $rem-16px;
+    padding: $rem-2px $rem-16px;
   }
 
   &.small {

--- a/stencil-workspace/src/components/modus-chip/modus-chip.tsx
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.tsx
@@ -117,7 +117,7 @@ export class ModusChip {
           this.closeIcon == 'remove'? (
             <IconRemove onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'24'}></IconRemove>
           ): (
-            <IconClose onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'24'}></IconClose>
+            <IconClose onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'18'}></IconClose>
           ) : null}
       </div>
     );

--- a/stencil-workspace/src/components/modus-chip/modus-chip.tsx
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.tsx
@@ -2,6 +2,7 @@
 import { Component, Prop, h, EventEmitter, Event, Listen } from '@stencil/core';
 import { IconRemove } from '../icons/icon-remove';
 import { IconCheck } from '../icons/icon-check';
+import { IconClose } from '../icons/icon-close';
 
 @Component({
   tag: 'modus-chip',
@@ -14,6 +15,9 @@ export class ModusChip {
 
   /** (optional) The chip's style. */
   @Prop() chipStyle: 'outline' | 'solid' = 'solid';
+
+  /** (optional) The chip's close icon. */
+  @Prop() closeIcon: 'close' | 'remove' = 'remove';
 
   /** (optional) Whether the chip is disabled. */
   @Prop() disabled = false;
@@ -109,9 +113,12 @@ export class ModusChip {
           <IconCheck size={'24'}></IconCheck>
         ) : null}
         <span>{this.value}</span>
-        {this.showClose ? (
-          <IconRemove onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'24'}></IconRemove>
-        ) : null}
+        {this.showClose ?
+          this.closeIcon == 'remove'? (
+            <IconRemove onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'24'}></IconRemove>
+          ): (
+            <IconClose onClick={this.disabled ? null : (event) => this.onCloseClick(event)} size={'24'}></IconClose>
+          ) : null}
       </div>
     );
   }

--- a/stencil-workspace/src/components/modus-chip/readme.md
+++ b/stencil-workspace/src/components/modus-chip/readme.md
@@ -11,6 +11,7 @@
 | --------------- | ---------------- | ------------------------------------------ | ---------------------- | ----------- |
 | `ariaLabel`     | `aria-label`     | (optional) The chip's aria-label.          | `string`               | `undefined` |
 | `chipStyle`     | `chip-style`     | (optional) The chip's style.               | `"outline" \| "solid"` | `'solid'`   |
+| `closeIcon`     | `close-icon`     | (optional) The chip's close icon.          | `"close" \| "remove"`  | `'remove'`  |
 | `disabled`      | `disabled`       | (optional) Whether the chip is disabled.   | `boolean`              | `false`     |
 | `hasError`      | `has-error`      | (optional) Whether the chip has an error.  | `boolean`              | `false`     |
 | `imageUrl`      | `image-url`      | (optional) The image's url.                | `string`               | `undefined` |

--- a/stencil-workspace/storybook/stories/components/modus-chip/modus-chip-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-chip/modus-chip-storybook-docs.mdx
@@ -26,6 +26,10 @@ import { Anchor } from '@storybook/addon-docs';
 
 <modus-chip show-checkmark size="small" value="Pets OK"></modus-chip>
 
+### Close Icon
+
+<modus-chip show-checkmark show-close close-icon="close" value="Bryan"></modus-chip>
+
 ```html
 <modus-chip
   image-url="https://example.com/image.jpg"
@@ -61,6 +65,8 @@ import { Anchor } from '@storybook/addon-docs';
   value="Bryan"></modus-chip>
 
 <modus-chip show-checkmark size="small" value="Pets OK"></modus-chip>
+
+<modus-chip show-checkmark show-close close-icon="close" value="Bryan"></modus-chip>
 ```
 
 ### Properties
@@ -69,6 +75,7 @@ import { Anchor } from '@storybook/addon-docs';
 | -------------- | ------------------------------ | ------- | ------------------ | ------------- | -------- |
 | aria-label     | The chip's aria-label          | string  |                    |               |          |
 | chip-style     | The chip's style               | string  | 'outline', 'solid' | 'solid'       |          |
+| close-icon     | The chip's close icon          | string  | 'close', 'remove'  | 'remove'      |          |
 | disabled       | Whether the chip is disabled   | boolean |                    | false         |          |
 | has-error      | Whether the chip has an error  | boolean |                    | false         |          |
 | image-url      | The chip's image url           | string  |                    |               |          |

--- a/stencil-workspace/storybook/stories/components/modus-chip/modus-chip.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-chip/modus-chip.stories.tsx
@@ -24,6 +24,18 @@ export default {
         type: { summary: `'solid' | 'outline'` },
       },
     },
+    closeIcon: {
+      name: 'close-icon',
+      control: {
+        options: ['remove', 'close'],
+        type: 'select',
+      },
+      description: 'The close icon of the chip',
+      table: {
+        defaultValue: { summary: `'remove'` },
+        type: { summary: `'remove' | 'close'` },
+      },
+    },
     disabled: {
       description: 'Whether the chip is disabled',
       table: {
@@ -97,6 +109,7 @@ export default {
 export const Default = ({
   ariaLabel,
   chipStyle,
+  closeIcon,
   disabled,
   hasError,
   imageUrl,
@@ -108,6 +121,7 @@ export const Default = ({
   <modus-chip
     aria-label=${ariaLabel}
     chip-style=${chipStyle}
+    close-icon=${closeIcon}
     disabled=${disabled}
     has-error=${hasError}
     image-url=${imageUrl}
@@ -120,6 +134,7 @@ export const Default = ({
 Default.args = {
   ariaLabel: '',
   chipStyle: 'solid',
+  closeIcon: 'remove',
   disabled: false,
   hasError: false,
   imageUrl: 'https://randomuser.me/api/portraits/lego/1.jpg',
@@ -132,6 +147,7 @@ Default.args = {
 export const Outline = ({
   ariaLabel,
   chipStyle,
+  closeIcon,
   disabled,
   hasError,
   imageUrl,
@@ -143,6 +159,7 @@ export const Outline = ({
   <modus-chip
     aria-label=${ariaLabel}
     chip-style=${chipStyle}
+    close-icon=${closeIcon}
     disabled=${disabled}
     has-error=${hasError}
     image-url=${imageUrl}
@@ -155,6 +172,7 @@ export const Outline = ({
 Outline.args = {
   ariaLabel: '',
   chipStyle: 'outline',
+  closeIcon: 'remove',
   disabled: false,
   hasError: false,
   imageUrl: 'https://randomuser.me/api/portraits/lego/1.jpg',


### PR DESCRIPTION
## Description

Adding a property closeIcon to Modus Chip. The property has two values: remove, close. The default is remove. The new option is to display the icon-close following the guidelines https://modus.trimble.com/components/web/chips/styles/
Using the same padding-top and padding-bottom when the icons are visible.

References #1336

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested manually and in Storybook. Added a new e2e test to check if the close icon is displayed when the closeIcon property is set to 'close'.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
