### PR TITLE
(Draft) Upgrade guide template 

### DIFF
--- a/stencil-workspace/storybook/.storybook/preview.js
+++ b/stencil-workspace/storybook/.storybook/preview.js
@@ -4,19 +4,16 @@ import yourTheme from './your-theme';
 import { themes } from '@storybook/theming';
 import addons from '@storybook/addons';
 import { DocsContainer } from '@storybook/addon-docs';
-import {
-  useDarkMode
-} from 'storybook-dark-mode';
-import '../../dist/modus-web-components/modus-web-components.css'
+import { useDarkMode } from 'storybook-dark-mode';
+import '../../dist/modus-web-components/modus-web-components.css';
 
 defineCustomElements();
 
 // get channel to listen to event emitter
 const channel = addons.getChannel();
 
-
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
     matchers: {
       color: /(background|color)$/i,
@@ -28,10 +25,10 @@ export const parameters = {
     current: 'light',
     // Override the default dark theme
     dark: { ...themes.dark, appBg: '#252a2e' },
-    stylePreview: true
+    stylePreview: true,
   },
   backgrounds: {
-    disable: true
+    disable: true,
   },
   docs: {
     theme: yourTheme,
@@ -43,12 +40,12 @@ export const parameters = {
         ['Welcome', 'Getting Started'],
         'Components',
         'User Inputs',
-        'Framework Integrations'
-      ]
-    }
+        'Framework Integrations',
+        'Miscellaneous',
+      ],
+    },
   },
   previewTabs: {
     'storybook/docs/panel': { index: -1 },
-  }
-}
-
+  },
+};

--- a/stencil-workspace/storybook/stories/miscellaneous/upgrade-guide.stories.mdx
+++ b/stencil-workspace/storybook/stories/miscellaneous/upgrade-guide.stories.mdx
@@ -1,0 +1,51 @@
+import { Meta } from '@storybook/addon-docs';
+
+<Meta
+  title="Miscellaneous/Upgrade Guide"
+  parameters={{
+    previewTabs: {
+      canvas: {
+        hidden: true,
+      },
+    },
+    options: {
+      isToolshown: false,
+    },
+    viewMode: 'docs',
+  }}
+/>
+
+# Upgrade Guide
+
+This guide will help you upgrade from one version of the library to the next. It outlines the information about any
+breaking changes or deprecations that might affect your existing codebase, and provides the necessary upgrade steps to
+resolve them.
+
+<details>
+  <summary>v0.0.1 ⟶ v0.0.2</summary>
+
+  # Breaking Changes
+
+  ## ❌ Some Feature
+  Name and interface update to the `example` input.
+
+  #### Upgrade Steps
+  To fix this feature you must update the name of the input from `example` to `another-name`.
+
+  ## ❌ Another Feature
+  Details about the feature.
+
+  #### Upgrade Steps
+  To fix this feature you must update the name of the input from `oldName` to `newName`.
+
+  # Deprecations
+
+  ## ⚠️ Old Feature
+  Description of the deprecated feature and reasons for deprecation. It is recommended to use the alternative
+  `newFeature` feature.
+
+  ## ⚠️ Old Method
+  Description of the deprecated method and reasons for deprecation. It is recommended to use the new method `newMethod`
+  for better functionality and performance.
+</details>
+


### PR DESCRIPTION
## Description

Here is my proposal for the Upgrade Guide on the Storybook site. I put it under a Miscellaneous tab in the left panel

Here are the current [PRs that contain breaking changes and deprecations](https://github.com/trimble-oss/modus-web-components/labels/breaking-change,deprecation)

References #1337 

## Type of change

- [X] Documentation update
