### PR TITLE
Upgrade to Stencil 3.0

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/angular-component-lib/utils.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/angular-component-lib/utils.ts
@@ -4,46 +4,40 @@ import { fromEvent } from 'rxjs';
 
 export const proxyInputs = (Cmp: any, inputs: string[]) => {
   const Prototype = Cmp.prototype;
-  inputs.forEach(item => {
+  inputs.forEach((item) => {
     Object.defineProperty(Prototype, item, {
       get() {
         return this.el[item];
       },
       set(val: any) {
         this.z.runOutsideAngular(() => (this.el[item] = val));
-      }
+      },
     });
   });
 };
 
 export const proxyMethods = (Cmp: any, methods: string[]) => {
   const Prototype = Cmp.prototype;
-  methods.forEach(methodName => {
+  methods.forEach((methodName) => {
     Prototype[methodName] = function () {
       const args = arguments;
-      return this.z.runOutsideAngular(() =>
-        this.el[methodName].apply(this.el, args)
-      );
+      return this.z.runOutsideAngular(() => this.el[methodName].apply(this.el, args));
     };
   });
 };
 
 export const proxyOutputs = (instance: any, el: any, events: string[]) => {
-  events.forEach(eventName => instance[eventName] = fromEvent(el, eventName));
-}
+  events.forEach((eventName) => (instance[eventName] = fromEvent(el, eventName)));
+};
 
 export const defineCustomElement = (tagName: string, customElement: any) => {
-  if (
-    customElement !== undefined &&
-    typeof customElements !== 'undefined' &&
-    !customElements.get(tagName)
-  ) {
+  if (customElement !== undefined && typeof customElements !== 'undefined' && !customElements.get(tagName)) {
     customElements.define(tagName, customElement);
   }
-}
+};
 
 // tslint:disable-next-line: only-arrow-functions
-export function ProxyCmp(opts: { defineCustomElementFn?: () => void, inputs?: any; methods?: any }) {
+export function ProxyCmp(opts: { defineCustomElementFn?: () => void; inputs?: any; methods?: any }) {
   const decorator = function (cls: any) {
     const { defineCustomElementFn, inputs, methods } = opts;
 

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1,24 +1,21 @@
 /* tslint:disable */
 /* auto-generated angular directive proxies */
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, NgZone } from '@angular/core';
+
 import { ProxyCmp, proxyOutputs } from './angular-component-lib/utils';
 
 import { Components } from '@trimble-oss/modus-web-components';
 
 
-
-
-export declare interface ModusAccordion extends Components.ModusAccordion {}
-
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel']
 })
 @Component({
   selector: 'modus-accordion',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel'],
 })
 export class ModusAccordion {
   protected el: HTMLElement;
@@ -29,27 +26,18 @@ export class ModusAccordion {
 }
 
 
-export declare interface ModusAccordionItem extends Components.ModusAccordionItem {
-  /**
-   * An event that fires on every accordion close. 
-   */
-  closed: EventEmitter<CustomEvent<any>>;
-  /**
-   * An event that fires on every accordion open. 
-   */
-  opened: EventEmitter<CustomEvent<any>>;
+export declare interface ModusAccordion extends Components.ModusAccordion {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['disabled', 'expanded', 'headerText', 'size']
 })
 @Component({
   selector: 'modus-accordion-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled', 'expanded', 'headerText', 'size']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['disabled', 'expanded', 'headerText', 'size'],
 })
 export class ModusAccordionItem {
   protected el: HTMLElement;
@@ -61,23 +49,27 @@ export class ModusAccordionItem {
 }
 
 
-export declare interface ModusAlert extends Components.ModusAlert {
+export declare interface ModusAccordionItem extends Components.ModusAccordionItem {
   /**
-   * An event that fires when the alert is dismissed 
+   * An event that fires on every accordion close.
    */
-  dismissClick: EventEmitter<CustomEvent<any>>;
-
+  closed: EventEmitter<CustomEvent<any>>;
+  /**
+   * An event that fires on every accordion open.
+   */
+  opened: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'dismissible', 'message', 'type']
 })
 @Component({
   selector: 'modus-alert',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'dismissible', 'message', 'type']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'dismissible', 'message', 'type'],
 })
 export class ModusAlert {
   protected el: HTMLElement;
@@ -89,27 +81,23 @@ export class ModusAlert {
 }
 
 
-export declare interface ModusAutocomplete extends Components.ModusAutocomplete {
+export declare interface ModusAlert extends Components.ModusAlert {
   /**
-   * An event that fires when a dropdown option is selected. Emits the option id. 
+   * An event that fires when the alert is dismissed
    */
-  optionSelected: EventEmitter<CustomEvent<string>>;
-  /**
-   * An event that fires when the input value changes. Emits the value string. 
-   */
-  valueChange: EventEmitter<CustomEvent<string>>;
-
+  dismissClick: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'clearable', 'disabled', 'dropdownMaxHeight', 'dropdownZIndex', 'errorText', 'includeSearchIcon', 'label', 'noResultsFoundSubtext', 'noResultsFoundText', 'options', 'placeholder', 'readOnly', 'required', 'showNoResultsFoundMessage', 'size', 'value']
 })
 @Component({
   selector: 'modus-autocomplete',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'clearable', 'disabled', 'dropdownMaxHeight', 'dropdownZIndex', 'errorText', 'includeSearchIcon', 'label', 'noResultsFoundSubtext', 'noResultsFoundText', 'options', 'placeholder', 'readOnly', 'required', 'showNoResultsFoundMessage', 'size', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'clearable', 'disabled', 'dropdownMaxHeight', 'dropdownZIndex', 'errorText', 'includeSearchIcon', 'label', 'noResultsFoundSubtext', 'noResultsFoundText', 'options', 'placeholder', 'readOnly', 'required', 'showNoResultsFoundMessage', 'size', 'value'],
 })
 export class ModusAutocomplete {
   protected el: HTMLElement;
@@ -121,17 +109,27 @@ export class ModusAutocomplete {
 }
 
 
-export declare interface ModusBadge extends Components.ModusBadge {}
+export declare interface ModusAutocomplete extends Components.ModusAutocomplete {
+  /**
+   * An event that fires when a dropdown option is selected. Emits the option id.
+   */
+  optionSelected: EventEmitter<CustomEvent<string>>;
+  /**
+   * An event that fires when the input value changes. Emits the value string.
+   */
+  valueChange: EventEmitter<CustomEvent<string>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'color', 'size', 'type']
 })
 @Component({
   selector: 'modus-badge',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'color', 'size', 'type']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'color', 'size', 'type'],
 })
 export class ModusBadge {
   protected el: HTMLElement;
@@ -141,24 +139,19 @@ export class ModusBadge {
   }
 }
 
-import type { Crumb as IModusBreadcrumbCrumb } from '@trimble-oss/modus-web-components';
-export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
-  /**
-   * (optional) An event that fires on breadcrumb click. 
-   */
-  crumbClick: EventEmitter<CustomEvent<IModusBreadcrumbCrumb>>;
 
-}
+export declare interface ModusBadge extends Components.ModusBadge {}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'crumbs']
 })
 @Component({
   selector: 'modus-breadcrumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'crumbs']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'crumbs'],
 })
 export class ModusBreadcrumb {
   protected el: HTMLElement;
@@ -170,23 +163,25 @@ export class ModusBreadcrumb {
 }
 
 
-export declare interface ModusButton extends Components.ModusButton {
-  /**
-   * (optional) An event that fires on button click. 
-   */
-  buttonClick: EventEmitter<CustomEvent<any>>;
+import type { Crumb as IModusBreadcrumbCrumb } from '@trimble-oss/modus-web-components';
 
+export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
+  /**
+   * (optional) An event that fires on breadcrumb click.
+   */
+  crumbClick: EventEmitter<CustomEvent<IModusBreadcrumbCrumb>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'size']
 })
 @Component({
   selector: 'modus-button',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'size']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'size'],
 })
 export class ModusButton {
   protected el: HTMLElement;
@@ -198,17 +193,23 @@ export class ModusButton {
 }
 
 
-export declare interface ModusCard extends Components.ModusCard {}
+export declare interface ModusButton extends Components.ModusButton {
+  /**
+   * (optional) An event that fires on button click.
+   */
+  buttonClick: EventEmitter<CustomEvent<any>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'backgroundColor', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width']
 })
 @Component({
   selector: 'modus-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'backgroundColor', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'backgroundColor', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width'],
 })
 export class ModusCard {
   protected el: HTMLElement;
@@ -219,16 +220,10 @@ export class ModusCard {
 }
 
 
-export declare interface ModusCheckbox extends Components.ModusCheckbox {
-  /**
-   * An event that fires on checkbox click. 
-   */
-  checkboxClick: EventEmitter<CustomEvent<boolean>>;
+export declare interface ModusCard extends Components.ModusCard {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'checked', 'disabled', 'indeterminate', 'label', 'tabIndexValue'],
   methods: ['focusCheckbox']
 })
@@ -236,7 +231,8 @@ export declare interface ModusCheckbox extends Components.ModusCheckbox {
   selector: 'modus-checkbox',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'checked', 'disabled', 'indeterminate', 'label', 'tabIndexValue']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'checked', 'disabled', 'indeterminate', 'label', 'tabIndexValue'],
 })
 export class ModusCheckbox {
   protected el: HTMLElement;
@@ -248,27 +244,23 @@ export class ModusCheckbox {
 }
 
 
-export declare interface ModusChip extends Components.ModusChip {
+export declare interface ModusCheckbox extends Components.ModusCheckbox {
   /**
-   * An event that fires on chip click. 
+   * An event that fires on checkbox click.
    */
-  chipClick: EventEmitter<CustomEvent<any>>;
-  /**
-   * An event that fires on close icon click. 
-   */
-  closeClick: EventEmitter<CustomEvent<any>>;
-
+  checkboxClick: EventEmitter<CustomEvent<boolean>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
 })
 @Component({
   selector: 'modus-chip',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value'],
 })
 export class ModusChip {
   protected el: HTMLElement;
@@ -279,42 +271,28 @@ export class ModusChip {
   }
 }
 
-import type { ModusDataTableCellLink as IModusDataTableModusDataTableCellLink } from '@trimble-oss/modus-web-components';
-import type { ModusDataTableSortEvent as IModusDataTableModusDataTableSortEvent } from '@trimble-oss/modus-web-components';
-import type { ModusDataTableRowActionClickEvent as IModusDataTableModusDataTableRowActionClickEvent } from '@trimble-oss/modus-web-components';
-export declare interface ModusDataTable extends Components.ModusDataTable {
-  /**
-   * An event that fires on cell link click. 
-   */
-  cellLinkClick: EventEmitter<CustomEvent<IModusDataTableModusDataTableCellLink>>;
-  /**
-   * An event that fires on row double click. 
-   */
-  rowDoubleClick: EventEmitter<CustomEvent<string>>;
-  /**
-   * An event that fires on selection change. 
-   */
-  selection: EventEmitter<CustomEvent<string[]>>;
-  /**
-   * An event that fires on column sort. 
-   */
-  sort: EventEmitter<CustomEvent<IModusDataTableModusDataTableSortEvent>>;
-  /**
-   * An event that fires when a row action is clicked. 
-   */
-  rowActionClick: EventEmitter<CustomEvent<IModusDataTableModusDataTableRowActionClickEvent>>;
 
+export declare interface ModusChip extends Components.ModusChip {
+  /**
+   * An event that fires on chip click.
+   */
+  chipClick: EventEmitter<CustomEvent<any>>;
+  /**
+   * An event that fires on close icon click.
+   */
+  closeClick: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['columns', 'data', 'displayOptions', 'rowActions', 'selectionOptions', 'sortOptions']
 })
 @Component({
   selector: 'modus-data-table',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['columns', 'data', 'displayOptions', 'rowActions', 'selectionOptions', 'sortOptions']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['columns', 'data', 'displayOptions', 'rowActions', 'selectionOptions', 'sortOptions'],
 })
 export class ModusDataTable {
   protected el: HTMLElement;
@@ -325,25 +303,36 @@ export class ModusDataTable {
   }
 }
 
-import type { ModusDateInputEventDetails as IModusDateInputModusDateInputEventDetails } from '@trimble-oss/modus-web-components';
-export declare interface ModusDateInput extends Components.ModusDateInput {
-  /**
-   * An event that fires on calendar icon click. 
-   */
-  calendarIconClicked: EventEmitter<CustomEvent<IModusDateInputModusDateInputEventDetails>>;
-  /**
-   * An event that fires on input value out of focus. 
-   */
-  dateInputBlur: EventEmitter<CustomEvent<IModusDateInputModusDateInputEventDetails>>;
-  /**
-   * An event that fires on input value change. 
-   */
-  valueChange: EventEmitter<CustomEvent<IModusDateInputModusDateInputEventDetails>>;
 
+import type { ModusDataTableCellLink as IModusDataTableModusDataTableCellLink } from '@trimble-oss/modus-web-components';
+import type { ModusDataTableSortEvent as IModusDataTableModusDataTableSortEvent } from '@trimble-oss/modus-web-components';
+import type { ModusDataTableRowActionClickEvent as IModusDataTableModusDataTableRowActionClickEvent } from '@trimble-oss/modus-web-components';
+
+export declare interface ModusDataTable extends Components.ModusDataTable {
+  /**
+   * An event that fires on cell link click.
+   */
+  cellLinkClick: EventEmitter<CustomEvent<IModusDataTableModusDataTableCellLink>>;
+  /**
+   * An event that fires on row double click.
+   */
+  rowDoubleClick: EventEmitter<CustomEvent<string>>;
+  /**
+   * An event that fires on selection change.
+   */
+  selection: EventEmitter<CustomEvent<string[]>>;
+  /**
+   * An event that fires on column sort.
+   */
+  sort: EventEmitter<CustomEvent<IModusDataTableModusDataTableSortEvent>>;
+  /**
+   * An event that fires when a row action is clicked.
+   */
+  rowActionClick: EventEmitter<CustomEvent<IModusDataTableModusDataTableRowActionClickEvent>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['allowedCharsRegex', 'ariaLabel', 'autoFocusInput', 'disableValidation', 'disabled', 'errorText', 'fillerDate', 'format', 'helperText', 'label', 'placeholder', 'readOnly', 'required', 'showCalendarIcon', 'size', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
@@ -351,7 +340,8 @@ export declare interface ModusDateInput extends Components.ModusDateInput {
   selector: 'modus-date-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['allowedCharsRegex', 'ariaLabel', 'autoFocusInput', 'disableValidation', 'disabled', 'errorText', 'fillerDate', 'format', 'helperText', 'label', 'placeholder', 'readOnly', 'required', 'showCalendarIcon', 'size', 'type', 'validText', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['allowedCharsRegex', 'ariaLabel', 'autoFocusInput', 'disableValidation', 'disabled', 'errorText', 'fillerDate', 'format', 'helperText', 'label', 'placeholder', 'readOnly', 'required', 'showCalendarIcon', 'size', 'type', 'validText', 'value'],
 })
 export class ModusDateInput {
   protected el: HTMLElement;
@@ -363,17 +353,33 @@ export class ModusDateInput {
 }
 
 
-export declare interface ModusDatePicker extends Components.ModusDatePicker {}
+import type { ModusDateInputEventDetails as IModusDateInputModusDateInputEventDetails } from '@trimble-oss/modus-web-components';
+
+export declare interface ModusDateInput extends Components.ModusDateInput {
+  /**
+   * An event that fires on calendar icon click.
+   */
+  calendarIconClicked: EventEmitter<CustomEvent<IModusDateInputModusDateInputEventDetails>>;
+  /**
+   * An event that fires on input value out of focus.
+   */
+  dateInputBlur: EventEmitter<CustomEvent<IModusDateInputModusDateInputEventDetails>>;
+  /**
+   * An event that fires on input value change.
+   */
+  valueChange: EventEmitter<CustomEvent<IModusDateInputModusDateInputEventDetails>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['label']
 })
 @Component({
   selector: 'modus-date-picker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['label']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['label'],
 })
 export class ModusDatePicker {
   protected el: HTMLElement;
@@ -384,23 +390,18 @@ export class ModusDatePicker {
 }
 
 
-export declare interface ModusDropdown extends Components.ModusDropdown {
-  /**
-   * An event that fires on dropdown close. 
-   */
-  dropdownClose: EventEmitter<CustomEvent<any>>;
+export declare interface ModusDatePicker extends Components.ModusDatePicker {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'toggleElementId']
 })
 @Component({
   selector: 'modus-dropdown',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'toggleElementId']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'toggleElementId'],
 })
 export class ModusDropdown {
   protected el: HTMLElement;
@@ -412,16 +413,15 @@ export class ModusDropdown {
 }
 
 
-export declare interface ModusFileDropzone extends Components.ModusFileDropzone {
+export declare interface ModusDropdown extends Components.ModusDropdown {
   /**
-   * An event that fires when files have been added or removed, regardless of whether they're valid. 
+   * An event that fires on dropdown close.
    */
-  files: EventEmitter<CustomEvent<[File[], string | null]>>;
-
+  dropdownClose: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'description', 'dropzoneHeight', 'dropzoneWidth', 'includeStateIcon', 'label', 'maxFileCount', 'maxFileNameLength', 'maxTotalFileSizeBytes', 'multiple'],
   methods: ['addFile', 'getError', 'getFiles', 'removeFile']
 })
@@ -429,7 +429,8 @@ export declare interface ModusFileDropzone extends Components.ModusFileDropzone 
   selector: 'modus-file-dropzone',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'description', 'dropzoneHeight', 'dropzoneWidth', 'includeStateIcon', 'label', 'maxFileCount', 'maxFileNameLength', 'maxTotalFileSizeBytes', 'multiple']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'description', 'dropzoneHeight', 'dropzoneWidth', 'includeStateIcon', 'label', 'maxFileCount', 'maxFileNameLength', 'maxTotalFileSizeBytes', 'multiple'],
 })
 export class ModusFileDropzone {
   protected el: HTMLElement;
@@ -441,15 +442,22 @@ export class ModusFileDropzone {
 }
 
 
-export declare interface ModusList extends Components.ModusList {}
+export declare interface ModusFileDropzone extends Components.ModusFileDropzone {
+  /**
+   * An event that fires when files have been added or removed, regardless of whether they're valid.
+   */
+  files: EventEmitter<CustomEvent<[File[], string | null]>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined
 })
 @Component({
   selector: 'modus-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: '<ng-content></ng-content>'
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [],
 })
 export class ModusList {
   protected el: HTMLElement;
@@ -460,23 +468,18 @@ export class ModusList {
 }
 
 
-export declare interface ModusListItem extends Components.ModusListItem {
-  /**
-   * An event that fires on list item click 
-   */
-  itemClick: EventEmitter<CustomEvent<any>>;
+export declare interface ModusList extends Components.ModusList {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['disabled', 'selected', 'size', 'type']
 })
 @Component({
   selector: 'modus-list-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled', 'selected', 'size', 'type']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['disabled', 'selected', 'size', 'type'],
 })
 export class ModusListItem {
   protected el: HTMLElement;
@@ -488,17 +491,23 @@ export class ModusListItem {
 }
 
 
-export declare interface ModusMessage extends Components.ModusMessage {}
+export declare interface ModusListItem extends Components.ModusListItem {
+  /**
+   * An event that fires on list item click
+   */
+  itemClick: EventEmitter<CustomEvent<any>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'icon', 'type']
 })
 @Component({
   selector: 'modus-message',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'icon', 'type']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'icon', 'type'],
 })
 export class ModusMessage {
   protected el: HTMLElement;
@@ -509,28 +518,10 @@ export class ModusMessage {
 }
 
 
-export declare interface ModusModal extends Components.ModusModal {
-  /**
-   * An event that fires on modal close. 
-   */
-  closed: EventEmitter<CustomEvent<any>>;
-  /**
-   * An event that fires on modal open. 
-   */
-  opened: EventEmitter<CustomEvent<any>>;
-  /**
-   * An event that fires on primary button click. 
-   */
-  primaryButtonClick: EventEmitter<CustomEvent<any>>;
-  /**
-   * An event that fires on secondary button click. 
-   */
-  secondaryButtonClick: EventEmitter<CustomEvent<any>>;
+export declare interface ModusMessage extends Components.ModusMessage {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'headerText', 'primaryButtonAriaLabel', 'primaryButtonText', 'secondaryButtonAriaLabel', 'secondaryButtonText', 'zIndex'],
   methods: ['close', 'open']
 })
@@ -538,7 +529,8 @@ export declare interface ModusModal extends Components.ModusModal {
   selector: 'modus-modal',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'headerText', 'primaryButtonAriaLabel', 'primaryButtonText', 'secondaryButtonAriaLabel', 'secondaryButtonText', 'zIndex']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'headerText', 'primaryButtonAriaLabel', 'primaryButtonText', 'secondaryButtonAriaLabel', 'secondaryButtonText', 'zIndex'],
 })
 export class ModusModal {
   protected el: HTMLElement;
@@ -549,49 +541,28 @@ export class ModusModal {
   }
 }
 
-import type { ModusNavbarApp as IModusNavbarModusNavbarApp } from '@trimble-oss/modus-web-components';
-export declare interface ModusNavbar extends Components.ModusNavbar {
-  /**
-   * An event that fires when the apps menu opens. 
-   */
-  appsMenuOpen: EventEmitter<CustomEvent<void>>;
-  /**
-   * An event that fires when an apps menu app opens. 
-   */
-  appsMenuAppOpen: EventEmitter<CustomEvent<IModusNavbarModusNavbarApp>>;
-  /**
-   * An event that fires when the help link opens. 
-   */
-  helpOpen: EventEmitter<CustomEvent<void>>;
-  /**
-   * An event that fires on main menu click. 
-   */
-  mainMenuClick: EventEmitter<CustomEvent<KeyboardEvent | MouseEvent>>;
-  /**
-   * An event that fires when the notifications menu opens. 
-   */
-  notificationsMenuOpen: EventEmitter<CustomEvent<void>>;
-  /**
-   * An event that fires on product logo click. 
-   */
-  productLogoClick: EventEmitter<CustomEvent<MouseEvent>>;
-  /**
-   * An event that fires on profile menu link click. 
-   */
-  profileMenuLinkClick: EventEmitter<CustomEvent<string>>;
-  /**
-   * An event that fires when the profile menu opens. 
-   */
-  profileMenuOpen: EventEmitter<CustomEvent<void>>;
-  /**
-   * An event that fires on profile menu sign out click. 
-   */
-  profileMenuSignOutClick: EventEmitter<CustomEvent<MouseEvent>>;
 
+export declare interface ModusModal extends Components.ModusModal {
+  /**
+   * An event that fires on modal close.
+   */
+  closed: EventEmitter<CustomEvent<any>>;
+  /**
+   * An event that fires on modal open.
+   */
+  opened: EventEmitter<CustomEvent<any>>;
+  /**
+   * An event that fires on primary button click.
+   */
+  primaryButtonClick: EventEmitter<CustomEvent<any>>;
+  /**
+   * An event that fires on secondary button click.
+   */
+  secondaryButtonClick: EventEmitter<CustomEvent<any>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['apps', 'helpUrl', 'productLogoOptions', 'profileMenuOptions', 'reverse', 'searchLabel', 'showAppsMenu', 'showHelp', 'showMainMenu', 'showNotifications', 'showPendoPlaceholder', 'showSearch', 'showShadow', 'variant'],
   methods: ['hideMainMenu']
 })
@@ -599,7 +570,8 @@ export declare interface ModusNavbar extends Components.ModusNavbar {
   selector: 'modus-navbar',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['apps', 'helpUrl', 'productLogoOptions', 'profileMenuOptions', 'reverse', 'searchLabel', 'showAppsMenu', 'showHelp', 'showMainMenu', 'showNotifications', 'showPendoPlaceholder', 'showSearch', 'showShadow', 'variant']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['apps', 'helpUrl', 'productLogoOptions', 'profileMenuOptions', 'reverse', 'searchLabel', 'showAppsMenu', 'showHelp', 'showMainMenu', 'showNotifications', 'showPendoPlaceholder', 'showSearch', 'showShadow', 'variant'],
 })
 export class ModusNavbar {
   protected el: HTMLElement;
@@ -610,24 +582,58 @@ export class ModusNavbar {
   }
 }
 
-import type { ModusNavbarApp as IModusNavbarAppsMenuModusNavbarApp } from '@trimble-oss/modus-web-components';
-export declare interface ModusNavbarAppsMenu extends Components.ModusNavbarAppsMenu {
-  /**
-   *  
-   */
-  appOpen: EventEmitter<CustomEvent<IModusNavbarAppsMenuModusNavbarApp>>;
 
+import type { ModusNavbarApp as IModusNavbarModusNavbarApp } from '@trimble-oss/modus-web-components';
+
+export declare interface ModusNavbar extends Components.ModusNavbar {
+  /**
+   * An event that fires when the apps menu opens.
+   */
+  appsMenuOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires when an apps menu app opens.
+   */
+  appsMenuAppOpen: EventEmitter<CustomEvent<IModusNavbarModusNavbarApp>>;
+  /**
+   * An event that fires when the help link opens.
+   */
+  helpOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires on main menu click.
+   */
+  mainMenuClick: EventEmitter<CustomEvent<KeyboardEvent | MouseEvent>>;
+  /**
+   * An event that fires when the notifications menu opens.
+   */
+  notificationsMenuOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires on product logo click.
+   */
+  productLogoClick: EventEmitter<CustomEvent<MouseEvent>>;
+  /**
+   * An event that fires on profile menu link click.
+   */
+  profileMenuLinkClick: EventEmitter<CustomEvent<string>>;
+  /**
+   * An event that fires when the profile menu opens.
+   */
+  profileMenuOpen: EventEmitter<CustomEvent<void>>;
+  /**
+   * An event that fires on profile menu sign out click.
+   */
+  profileMenuSignOutClick: EventEmitter<CustomEvent<MouseEvent>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['apps', 'reverse']
 })
 @Component({
   selector: 'modus-navbar-apps-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['apps', 'reverse']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['apps', 'reverse'],
 })
 export class ModusNavbarAppsMenu {
   protected el: HTMLElement;
@@ -639,15 +645,22 @@ export class ModusNavbarAppsMenu {
 }
 
 
-export declare interface ModusNavbarMainMenu extends Components.ModusNavbarMainMenu {}
+import type { ModusNavbarApp as IModusNavbarAppsMenuModusNavbarApp } from '@trimble-oss/modus-web-components';
+
+export declare interface ModusNavbarAppsMenu extends Components.ModusNavbarAppsMenu {
+
+  appOpen: EventEmitter<CustomEvent<IModusNavbarAppsMenuModusNavbarApp>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined
 })
 @Component({
   selector: 'modus-navbar-main-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  template: '<ng-content></ng-content>'
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: [],
 })
 export class ModusNavbarMainMenu {
   protected el: HTMLElement;
@@ -658,17 +671,18 @@ export class ModusNavbarMainMenu {
 }
 
 
-export declare interface ModusNavbarNotificationsMenu extends Components.ModusNavbarNotificationsMenu {}
+export declare interface ModusNavbarMainMenu extends Components.ModusNavbarMainMenu {}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['reverse']
 })
 @Component({
   selector: 'modus-navbar-notifications-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['reverse']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['reverse'],
 })
 export class ModusNavbarNotificationsMenu {
   protected el: HTMLElement;
@@ -679,27 +693,18 @@ export class ModusNavbarNotificationsMenu {
 }
 
 
-export declare interface ModusNavbarProfileMenu extends Components.ModusNavbarProfileMenu {
-  /**
-   *  
-   */
-  linkClick: EventEmitter<CustomEvent<string>>;
-  /**
-   *  
-   */
-  signOutClick: EventEmitter<CustomEvent<MouseEvent>>;
+export declare interface ModusNavbarNotificationsMenu extends Components.ModusNavbarNotificationsMenu {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['avatarUrl', 'email', 'initials', 'links', 'reverse', 'username', 'variant']
 })
 @Component({
   selector: 'modus-navbar-profile-menu',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['avatarUrl', 'email', 'initials', 'links', 'reverse', 'username', 'variant']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['avatarUrl', 'email', 'initials', 'links', 'reverse', 'username', 'variant'],
 })
 export class ModusNavbarProfileMenu {
   protected el: HTMLElement;
@@ -711,23 +716,23 @@ export class ModusNavbarProfileMenu {
 }
 
 
-export declare interface ModusNumberInput extends Components.ModusNumberInput {
-  /**
-   * An event that fires on input value change. 
-   */
-  valueChange: EventEmitter<CustomEvent<string>>;
+export declare interface ModusNavbarProfileMenu extends Components.ModusNavbarProfileMenu {
 
+  linkClick: EventEmitter<CustomEvent<string>>;
+
+  signOutClick: EventEmitter<CustomEvent<MouseEvent>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'validText', 'value']
 })
 @Component({
   selector: 'modus-number-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'validText', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'validText', 'value'],
 })
 export class ModusNumberInput {
   protected el: HTMLElement;
@@ -739,23 +744,23 @@ export class ModusNumberInput {
 }
 
 
-export declare interface ModusPagination extends Components.ModusPagination {
+export declare interface ModusNumberInput extends Components.ModusNumberInput {
   /**
-   * An event that fires on page change. 
+   * An event that fires on input value change.
    */
-  pageChange: EventEmitter<CustomEvent<number>>;
-
+  valueChange: EventEmitter<CustomEvent<string>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['activePage', 'ariaLabel', 'maxPage', 'minPage', 'size']
 })
 @Component({
   selector: 'modus-pagination',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['activePage', 'ariaLabel', 'maxPage', 'minPage', 'size']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['activePage', 'ariaLabel', 'maxPage', 'minPage', 'size'],
 })
 export class ModusPagination {
   protected el: HTMLElement;
@@ -767,17 +772,23 @@ export class ModusPagination {
 }
 
 
-export declare interface ModusProgressBar extends Components.ModusProgressBar {}
+export declare interface ModusPagination extends Components.ModusPagination {
+  /**
+   * An event that fires on page change.
+   */
+  pageChange: EventEmitter<CustomEvent<number>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'backgroundColor', 'color', 'maxValue', 'minValue', 'size', 'text', 'textColor', 'value']
 })
 @Component({
   selector: 'modus-progress-bar',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'backgroundColor', 'color', 'maxValue', 'minValue', 'size', 'text', 'textColor', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'backgroundColor', 'color', 'maxValue', 'minValue', 'size', 'text', 'textColor', 'value'],
 })
 export class ModusProgressBar {
   protected el: HTMLElement;
@@ -788,23 +799,18 @@ export class ModusProgressBar {
 }
 
 
-export declare interface ModusRadioGroup extends Components.ModusRadioGroup {
-  /**
-   * Fires on radio button click. 
-   */
-  buttonClick: EventEmitter<CustomEvent<string>>;
+export declare interface ModusProgressBar extends Components.ModusProgressBar {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'checkedId', 'name', 'radioButtons']
 })
 @Component({
   selector: 'modus-radio-group',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'checkedId', 'name', 'radioButtons']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'checkedId', 'name', 'radioButtons'],
 })
 export class ModusRadioGroup {
   protected el: HTMLElement;
@@ -816,23 +822,23 @@ export class ModusRadioGroup {
 }
 
 
-export declare interface ModusSelect extends Components.ModusSelect {
+export declare interface ModusRadioGroup extends Components.ModusRadioGroup {
   /**
-   * An event that fires on input value change. 
+   * Fires on radio button click.
    */
-  valueChange: EventEmitter<CustomEvent<unknown>>;
-
+  buttonClick: EventEmitter<CustomEvent<string>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'menuSize', 'options', 'optionsDisplayProp', 'required', 'size', 'validText', 'value']
 })
 @Component({
   selector: 'modus-select',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'menuSize', 'options', 'optionsDisplayProp', 'required', 'size', 'validText', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'menuSize', 'options', 'optionsDisplayProp', 'required', 'size', 'validText', 'value'],
 })
 export class ModusSelect {
   protected el: HTMLElement;
@@ -844,23 +850,23 @@ export class ModusSelect {
 }
 
 
-export declare interface ModusSideNavigation extends Components.ModusSideNavigation {
+export declare interface ModusSelect extends Components.ModusSelect {
   /**
-   * An event that fires on side navigation panel collapse & expand. 
+   * An event that fires on input value change.
    */
-  sideNavExpand: EventEmitter<CustomEvent<boolean>>;
-
+  valueChange: EventEmitter<CustomEvent<unknown>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['data', 'expanded', 'maxWidth', 'mode', 'targetContent']
 })
 @Component({
   selector: 'modus-side-navigation',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['data', 'expanded', 'maxWidth', 'mode', 'targetContent']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['data', 'expanded', 'maxWidth', 'mode', 'targetContent'],
 })
 export class ModusSideNavigation {
   protected el: HTMLElement;
@@ -872,20 +878,15 @@ export class ModusSideNavigation {
 }
 
 
-export declare interface ModusSideNavigationItem extends Components.ModusSideNavigationItem {
+export declare interface ModusSideNavigation extends Components.ModusSideNavigation {
   /**
-   * An event that fires when mouse click or `Enter` key press on an item. 
+   * An event that fires on side navigation panel collapse & expand.
    */
-  sideNavItemClicked: EventEmitter<CustomEvent<{ id: string; selected: boolean }>>;
-  /**
-   * An event that fires when an item is in focus. 
-   */
-  sideNavItemFocus: EventEmitter<CustomEvent<{ id: string }>>;
-
+  sideNavExpand: EventEmitter<CustomEvent<boolean>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['disableSelection', 'disabled', 'label', 'menuIcon', 'selected', 'showExpandIcon'],
   methods: ['focusItem']
 })
@@ -893,7 +894,8 @@ export declare interface ModusSideNavigationItem extends Components.ModusSideNav
   selector: 'modus-side-navigation-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disableSelection', 'disabled', 'label', 'menuIcon', 'selected', 'showExpandIcon']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['disableSelection', 'disabled', 'label', 'menuIcon', 'selected', 'showExpandIcon'],
 })
 export class ModusSideNavigationItem {
   protected el: HTMLElement;
@@ -905,27 +907,27 @@ export class ModusSideNavigationItem {
 }
 
 
-export declare interface ModusSlider extends Components.ModusSlider {
+export declare interface ModusSideNavigationItem extends Components.ModusSideNavigationItem {
   /**
-   * An event that fires on slider value change. 
+   * An event that fires when mouse click or `Enter` key press on an item.
    */
-  valueChange: EventEmitter<CustomEvent<string>>;
+  sideNavItemClicked: EventEmitter<CustomEvent<{ id: string; selected: boolean }>>;
   /**
-   * An event that fires on slider value input. 
+   * An event that fires when an item is in focus.
    */
-  valueInput: EventEmitter<CustomEvent<string>>;
-
+  sideNavItemFocus: EventEmitter<CustomEvent<{ id: string }>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'disabled', 'label', 'maxValue', 'minValue', 'value']
 })
 @Component({
   selector: 'modus-slider',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'disabled', 'label', 'maxValue', 'minValue', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'disabled', 'label', 'maxValue', 'minValue', 'value'],
 })
 export class ModusSlider {
   protected el: HTMLElement;
@@ -937,17 +939,27 @@ export class ModusSlider {
 }
 
 
-export declare interface ModusSpinner extends Components.ModusSpinner {}
+export declare interface ModusSlider extends Components.ModusSlider {
+  /**
+   * An event that fires on slider value change.
+   */
+  valueChange: EventEmitter<CustomEvent<string>>;
+  /**
+   * An event that fires on slider value input.
+   */
+  valueInput: EventEmitter<CustomEvent<string>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['color', 'size']
 })
 @Component({
   selector: 'modus-spinner',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['color', 'size']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['color', 'size'],
 })
 export class ModusSpinner {
   protected el: HTMLElement;
@@ -958,23 +970,18 @@ export class ModusSpinner {
 }
 
 
-export declare interface ModusSwitch extends Components.ModusSwitch {
-  /**
-   * An event that fires on switch click. 
-   */
-  switchClick: EventEmitter<CustomEvent<boolean>>;
+export declare interface ModusSpinner extends Components.ModusSpinner {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'checked', 'disabled', 'label']
 })
 @Component({
   selector: 'modus-switch',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'checked', 'disabled', 'label']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'checked', 'disabled', 'label'],
 })
 export class ModusSwitch {
   protected el: HTMLElement;
@@ -986,23 +993,23 @@ export class ModusSwitch {
 }
 
 
-export declare interface ModusTabs extends Components.ModusTabs {
+export declare interface ModusSwitch extends Components.ModusSwitch {
   /**
-   * An event that fires on tab change. 
+   * An event that fires on switch click.
    */
-  tabChange: EventEmitter<CustomEvent<string>>;
-
+  switchClick: EventEmitter<CustomEvent<boolean>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'fullWidth', 'size', 'tabs']
 })
 @Component({
   selector: 'modus-tabs',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'fullWidth', 'size', 'tabs']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'fullWidth', 'size', 'tabs'],
 })
 export class ModusTabs {
   protected el: HTMLElement;
@@ -1014,16 +1021,15 @@ export class ModusTabs {
 }
 
 
-export declare interface ModusTextInput extends Components.ModusTextInput {
+export declare interface ModusTabs extends Components.ModusTabs {
   /**
-   * An event that fires on input value change. 
+   * An event that fires on tab change.
    */
-  valueChange: EventEmitter<CustomEvent<string>>;
-
+  tabChange: EventEmitter<CustomEvent<string>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
@@ -1031,7 +1037,8 @@ export declare interface ModusTextInput extends Components.ModusTextInput {
   selector: 'modus-text-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value'],
 })
 export class ModusTextInput {
   protected el: HTMLElement;
@@ -1042,21 +1049,16 @@ export class ModusTextInput {
   }
 }
 
-import type { ModusTimePickerEventDetails as IModusTimePickerModusTimePickerEventDetails } from '@trimble-oss/modus-web-components';
-export declare interface ModusTimePicker extends Components.ModusTimePicker {
-  /**
-   * An event that fires on input value out of focus. 
-   */
-  timeInputBlur: EventEmitter<CustomEvent<IModusTimePickerModusTimePickerEventDetails>>;
-  /**
-   * An event that fires on input value change. 
-   */
-  valueChange: EventEmitter<CustomEvent<IModusTimePickerModusTimePickerEventDetails>>;
 
+export declare interface ModusTextInput extends Components.ModusTextInput {
+  /**
+   * An event that fires on input value change.
+   */
+  valueChange: EventEmitter<CustomEvent<string>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['allowedCharsRegex', 'ampm', 'ariaLabel', 'autoFocusInput', 'autoFormat', 'disableValidation', 'disabled', 'errorText', 'helperText', 'label', 'max', 'min', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value'],
   methods: ['focusInput']
 })
@@ -1064,7 +1066,8 @@ export declare interface ModusTimePicker extends Components.ModusTimePicker {
   selector: 'modus-time-picker',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['allowedCharsRegex', 'ampm', 'ariaLabel', 'autoFocusInput', 'autoFormat', 'disableValidation', 'disabled', 'errorText', 'helperText', 'label', 'max', 'min', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['allowedCharsRegex', 'ampm', 'ariaLabel', 'autoFocusInput', 'autoFormat', 'disableValidation', 'disabled', 'errorText', 'helperText', 'label', 'max', 'min', 'placeholder', 'readOnly', 'required', 'size', 'validText', 'value'],
 })
 export class ModusTimePicker {
   protected el: HTMLElement;
@@ -1076,23 +1079,29 @@ export class ModusTimePicker {
 }
 
 
-export declare interface ModusToast extends Components.ModusToast {
-  /**
-   * An event that fires when the toast is dismissed 
-   */
-  dismissClick: EventEmitter<CustomEvent<any>>;
+import type { ModusTimePickerEventDetails as IModusTimePickerModusTimePickerEventDetails } from '@trimble-oss/modus-web-components';
 
+export declare interface ModusTimePicker extends Components.ModusTimePicker {
+  /**
+   * An event that fires on input value out of focus.
+   */
+  timeInputBlur: EventEmitter<CustomEvent<IModusTimePickerModusTimePickerEventDetails>>;
+  /**
+   * An event that fires on input value change.
+   */
+  valueChange: EventEmitter<CustomEvent<IModusTimePickerModusTimePickerEventDetails>>;
 }
 
+
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'dismissible', 'showIcon', 'type']
 })
 @Component({
   selector: 'modus-toast',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'dismissible', 'showIcon', 'type']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'dismissible', 'showIcon', 'type'],
 })
 export class ModusToast {
   protected el: HTMLElement;
@@ -1104,17 +1113,23 @@ export class ModusToast {
 }
 
 
-export declare interface ModusTooltip extends Components.ModusTooltip {}
+export declare interface ModusToast extends Components.ModusToast {
+  /**
+   * An event that fires when the toast is dismissed
+   */
+  dismissClick: EventEmitter<CustomEvent<any>>;
+}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['ariaLabel', 'position', 'text']
 })
 @Component({
   selector: 'modus-tooltip',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['ariaLabel', 'position', 'text']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['ariaLabel', 'position', 'text'],
 })
 export class ModusTooltip {
   protected el: HTMLElement;
@@ -1125,17 +1140,18 @@ export class ModusTooltip {
 }
 
 
-export declare interface ModusTreeView extends Components.ModusTreeView {}
+export declare interface ModusTooltip extends Components.ModusTooltip {}
+
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['checkboxSelection', 'checkedItems', 'disableTabbing', 'expandedItems', 'multiCheckboxSelection', 'multiSelection', 'selectedItems', 'size']
 })
 @Component({
   selector: 'modus-tree-view',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['checkboxSelection', 'checkedItems', 'disableTabbing', 'expandedItems', 'multiCheckboxSelection', 'multiSelection', 'selectedItems', 'size']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['checkboxSelection', 'checkedItems', 'disableTabbing', 'expandedItems', 'multiCheckboxSelection', 'multiSelection', 'selectedItems', 'size'],
 })
 export class ModusTreeView {
   protected el: HTMLElement;
@@ -1146,24 +1162,10 @@ export class ModusTreeView {
 }
 
 
-export declare interface ModusTreeViewItem extends Components.ModusTreeViewItem {
-  /**
-   * An event that fires on tree item checkbox click 
-   */
-  checkboxClick: EventEmitter<CustomEvent<boolean>>;
-  /**
-   * An event that fires on tree item click 
-   */
-  itemClick: EventEmitter<CustomEvent<boolean>>;
-  /**
-   * An event that fires on tree item expand/collapse 
-   */
-  itemExpandToggle: EventEmitter<CustomEvent<boolean>>;
+export declare interface ModusTreeView extends Components.ModusTreeView {}
 
-}
 
 @ProxyCmp({
-  defineCustomElementFn: undefined,
   inputs: ['disabled', 'draggableItem', 'droppableItem', 'editable', 'label', 'nodeId', 'tabIndexValue'],
   methods: ['focusItem', 'focusCheckbox']
 })
@@ -1171,7 +1173,8 @@ export declare interface ModusTreeViewItem extends Components.ModusTreeViewItem 
   selector: 'modus-tree-view-item',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
-  inputs: ['disabled', 'draggableItem', 'droppableItem', 'editable', 'label', 'nodeId', 'tabIndexValue']
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['disabled', 'draggableItem', 'droppableItem', 'editable', 'label', 'nodeId', 'tabIndexValue'],
 })
 export class ModusTreeViewItem {
   protected el: HTMLElement;
@@ -1181,3 +1184,21 @@ export class ModusTreeViewItem {
     proxyOutputs(this, this.el, ['checkboxClick', 'itemClick', 'itemExpandToggle']);
   }
 }
+
+
+export declare interface ModusTreeViewItem extends Components.ModusTreeViewItem {
+  /**
+   * An event that fires on tree item checkbox click
+   */
+  checkboxClick: EventEmitter<CustomEvent<boolean>>;
+  /**
+   * An event that fires on tree item click
+   */
+  itemClick: EventEmitter<CustomEvent<boolean>>;
+  /**
+   * An event that fires on tree item expand/collapse
+   */
+  itemExpandToggle: EventEmitter<CustomEvent<boolean>>;
+}
+
+

--- a/react-workspace/src/components/stencil-generated/react-component-lib/createComponent.tsx
+++ b/react-workspace/src/components/stencil-generated/react-component-lib/createComponent.tsx
@@ -1,13 +1,6 @@
 import React, { createElement } from 'react';
 
-import {
-  attachProps,
-  camelToDashCase,
-  createForwardRef,
-  dashToPascalCase,
-  isCoveredByReact,
-  mergeRefs,
-} from './utils';
+import { attachProps, camelToDashCase, createForwardRef, dashToPascalCase, isCoveredByReact, mergeRefs } from './utils';
 
 export interface HTMLStencilElement extends HTMLElement {
   componentOnReady(): Promise<this>;
@@ -28,9 +21,9 @@ export const createReactComponent = <
   ReactComponentContext?: React.Context<ContextStateType>,
   manipulatePropsFunction?: (
     originalProps: StencilReactInternalProps<ElementType>,
-    propsToPass: any,
+    propsToPass: any
   ) => ExpandedPropsTypes,
-  defineCustomElement?: () => void,
+  defineCustomElement?: () => void
 ) => {
   if (defineCustomElement !== undefined) {
     defineCustomElement();
@@ -77,7 +70,7 @@ export const createReactComponent = <
           }
         }
         return acc;
-      }, {});
+      }, {} as ExpandedPropsTypes);
 
       if (manipulatePropsFunction) {
         propsToPass = manipulatePropsFunction(this.props, propsToPass);

--- a/react-workspace/src/components/stencil-generated/react-component-lib/createOverlayComponent.tsx
+++ b/react-workspace/src/components/stencil-generated/react-component-lib/createOverlayComponent.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { OverlayEventDetail } from './interfaces';
-import {
-  StencilReactForwardedRef,
-  attachProps,
-  dashToPascalCase,
-  defineCustomElement,
-  setRef,
-} from './utils';
+import { StencilReactForwardedRef, attachProps, dashToPascalCase, defineCustomElement, setRef } from './utils';
 
 interface OverlayElement extends HTMLElement {
   present: () => Promise<void>;
@@ -24,10 +18,7 @@ export interface ReactOverlayProps {
   onWillPresent?: (event: CustomEvent<OverlayEventDetail>) => void;
 }
 
-export const createOverlayComponent = <
-  OverlayComponent extends object,
-  OverlayType extends OverlayElement
->(
+export const createOverlayComponent = <OverlayComponent extends object, OverlayType extends OverlayElement>(
   tagName: string,
   controller: { create: (options: any) => Promise<OverlayType> },
   customElement?: any
@@ -79,7 +70,7 @@ export const createOverlayComponent = <
       if (this.props.onDidDismiss) {
         this.props.onDidDismiss(event);
       }
-      setRef(this.props.forwardedRef, null)
+      setRef(this.props.forwardedRef, null);
     }
 
     shouldComponentUpdate(nextProps: Props) {
@@ -113,25 +104,14 @@ export const createOverlayComponent = <
     }
 
     async present(prevProps?: Props) {
-      const {
-        children,
-        isOpen,
-        onDidDismiss,
-        onDidPresent,
-        onWillDismiss,
-        onWillPresent,
-        ...cProps
-      } = this.props;
+      const { children, isOpen, onDidDismiss, onDidPresent, onWillDismiss, onWillPresent, ...cProps } = this.props;
       const elementProps = {
         ...cProps,
         ref: this.props.forwardedRef,
         [didDismissEventName]: this.handleDismiss,
-        [didPresentEventName]: (e: CustomEvent) =>
-          this.props.onDidPresent && this.props.onDidPresent(e),
-        [willDismissEventName]: (e: CustomEvent) =>
-          this.props.onWillDismiss && this.props.onWillDismiss(e),
-        [willPresentEventName]: (e: CustomEvent) =>
-          this.props.onWillPresent && this.props.onWillPresent(e),
+        [didPresentEventName]: (e: CustomEvent) => this.props.onDidPresent && this.props.onDidPresent(e),
+        [willDismissEventName]: (e: CustomEvent) => this.props.onWillDismiss && this.props.onWillDismiss(e),
+        [willPresentEventName]: (e: CustomEvent) => this.props.onWillPresent && this.props.onWillPresent(e),
       };
 
       this.overlay = await controller.create({

--- a/react-workspace/src/components/stencil-generated/react-component-lib/utils/case.ts
+++ b/react-workspace/src/components/stencil-generated/react-component-lib/utils/case.ts
@@ -4,5 +4,4 @@ export const dashToPascalCase = (str: string) =>
     .split('-')
     .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join('');
-export const camelToDashCase = (str: string) =>
-  str.replace(/([A-Z])/g, (m: string) => `-${m[0].toLowerCase()}`);
+export const camelToDashCase = (str: string) => str.replace(/([A-Z])/g, (m: string) => `-${m[0].toLowerCase()}`);

--- a/react-workspace/src/components/stencil-generated/react-component-lib/utils/index.tsx
+++ b/react-workspace/src/components/stencil-generated/react-component-lib/utils/index.tsx
@@ -11,10 +11,10 @@ export type StencilReactForwardedRef<T> = ((instance: T | null) => void) | React
 
 export const setRef = (ref: StencilReactForwardedRef<any> | React.Ref<any> | undefined, value: any) => {
   if (typeof ref === 'function') {
-    ref(value)
+    ref(value);
   } else if (ref != null) {
     // Cast as a MutableRef so we can assign current
-    (ref as React.MutableRefObject<any>).current = value
+    (ref as React.MutableRefObject<any>).current = value;
   }
 };
 
@@ -22,19 +22,16 @@ export const mergeRefs = (
   ...refs: (StencilReactForwardedRef<any> | React.Ref<any> | undefined)[]
 ): React.RefCallback<any> => {
   return (value: any) => {
-    refs.forEach(ref => {
-      setRef(ref, value)
-    })
-  }
+    refs.forEach((ref) => {
+      setRef(ref, value);
+    });
+  };
 };
 
-export const createForwardRef = <PropType, ElementType>(
-  ReactComponent: any,
-  displayName: string,
-) => {
+export const createForwardRef = <PropType, ElementType>(ReactComponent: any, displayName: string) => {
   const forwardRef = (
     props: StencilReactExternalProps<PropType, ElementType>,
-    ref: StencilReactForwardedRef<ElementType>,
+    ref: StencilReactForwardedRef<ElementType>
   ) => {
     return <ReactComponent {...props} forwardedRef={ref} />;
   };
@@ -44,14 +41,10 @@ export const createForwardRef = <PropType, ElementType>(
 };
 
 export const defineCustomElement = (tagName: string, customElement: any) => {
-  if (
-    customElement !== undefined &&
-    typeof customElements !== 'undefined' &&
-    !customElements.get(tagName)
-  ) {
+  if (customElement !== undefined && typeof customElements !== 'undefined' && !customElements.get(tagName)) {
     customElements.define(tagName, customElement);
   }
-}
+};
 
 export * from './attachProps';
 export * from './case';

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.42",
       "license": "MIT",
       "dependencies": {
-        "@stencil/core": "^2.22.3"
+        "@stencil/core": "^3.3.0"
       },
       "devDependencies": {
-        "@stencil/angular-output-target": "^0.4.0",
+        "@stencil/angular-output-target": "^0.5.0",
         "@stencil/postcss": "^2.1.0",
-        "@stencil/react-output-target": "^0.3.1",
+        "@stencil/react-output-target": "^0.4.0",
         "@stencil/sass": "^2.0.3",
         "@types/jest": "^27.5.1",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
@@ -1298,23 +1298,23 @@
       }
     },
     "node_modules/@stencil/angular-output-target": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.4.0.tgz",
-      "integrity": "sha512-zauaj0za46IWoPgv2IanDp3tiljwDRDNk4jB7WII6KeL66dkk7ffeqYZ0CgySTU5W2FjnKR6JEKbAnwUxjGIsA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.5.0.tgz",
+      "integrity": "sha512-U2I6dZdL8hvnogafG9IwtYRaAns5fQMacjee/3WNMRMYagrpz7R6cDdX4O0U8q6jks1ej91GchgZsQOVE9UcKg==",
       "dev": true,
       "peerDependencies": {
-        "@stencil/core": "^2.9.0"
+        "@stencil/core": "^2.9.0 || ^3.0.0-beta.0"
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
-      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-3.3.0.tgz",
+      "integrity": "sha512-+3hqJ8RmUvxz8FgvMP9lxYJdjb4EnZrkdo6ln5fUqGju62ORS5/Ch9m6OAIjlEn6CbDb5Uf1OdeMjO87DJwIAA==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=12.10.0",
+        "node": ">=14.10.0",
         "npm": ">=6.0.0"
       }
     },
@@ -1359,12 +1359,12 @@
       }
     },
     "node_modules/@stencil/react-output-target": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.3.1.tgz",
-      "integrity": "sha512-6d9pPhyajFfdxkqU/pPP2SzI7wn+EklySQc4KXlI/xcdvC2H9BzLmhmR40fR1q2TQoJbJui/nvSWhbYqkE3OBQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-0.4.0.tgz",
+      "integrity": "sha512-X7XW6aHSU7ZypkFj4wX/XL7ROj2GXcdTL+Emo1mKNg5laBcuTVtt8zPR4ERG/grq8ec8wav+FxBuSlQ3cH0qcg==",
       "dev": true,
       "peerDependencies": {
-        "@stencil/core": "^2.9.0"
+        "@stencil/core": "^2.9.0 || ^3.0.0-beta.0"
       }
     },
     "node_modules/@stencil/sass": {

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -39,12 +39,12 @@
     "start-storybook": "npm run build && cd storybook && npm run storybook"
   },
   "dependencies": {
-    "@stencil/core": "^2.22.3"
+    "@stencil/core": "^3.3.0"
   },
   "devDependencies": {
-    "@stencil/angular-output-target": "^0.4.0",
+    "@stencil/angular-output-target": "^0.5.0",
     "@stencil/postcss": "^2.1.0",
-    "@stencil/react-output-target": "^0.3.1",
+    "@stencil/react-output-target": "^0.4.0",
     "@stencil/sass": "^2.0.3",
     "@types/jest": "^27.5.1",
     "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -18,6 +18,19 @@ import { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/
 import { Tab } from "./components/modus-tabs/modus-tabs";
 import { ModusTimePickerEventDetails } from "./components/modus-time-picker/modus-time-picker.models";
 import { TreeViewItemOptions } from "./components/modus-content-tree/modus-content-tree.types";
+export { ModusAutocompleteOption } from "./components/modus-autocomplete/modus-autocomplete";
+export { Crumb } from "./components/modus-breadcrumb/modus-breadcrumb";
+export { ModusDataTableCellLink, ModusDataTableDisplayOptions, ModusDataTableRowAction, ModusDataTableRowActionClickEvent, ModusDataTableSortEvent, ModusTableSelectionOptions, ModusTableSortOptions, TCell, TColumn, TRow } from "./components/modus-data-table/modus-data-table.models";
+export { ModusDateInputEventDetails, ModusDateInputType } from "./components/modus-date-input/utils/modus-date-input.models";
+export { ModusNavbarApp } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
+export { ModusNavbarProfileMenuLink } from "./components/modus-navbar/profile-menu/modus-navbar-profile-menu";
+export { ModusNavbarApp as ModusNavbarApp1 } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
+export { ModusNavbarProfileMenuLink as ModusNavbarProfileMenuLink1 } from "./components/modus-navbar/profile-menu/modus-navbar-profile-menu";
+export { RadioButton } from "./components/modus-radio-group/modus-radio-button";
+export { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/modus-side-navigation.models";
+export { Tab } from "./components/modus-tabs/modus-tabs";
+export { ModusTimePickerEventDetails } from "./components/modus-time-picker/modus-time-picker.models";
+export { TreeViewItemOptions } from "./components/modus-content-tree/modus-content-tree.types";
 export namespace Components {
     interface ModusAccordion {
         /**
@@ -396,10 +409,10 @@ export namespace Components {
           * (optional) Determines custom dropdown placement offset.
          */
         "customPlacement": {
-    top?: number,
-    right?: number,
-    bottom?: number,
-    left?: number
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
   };
         /**
           * (optional) Disables the dropdown.
@@ -604,7 +617,7 @@ export namespace Components {
         "variant": 'default' | 'blue';
     }
     interface ModusNavbarAppsMenu {
-        "apps": ModusNavbarApp[];
+        "apps": ModusNavbarApp1[];
         "reverse": boolean;
     }
     interface ModusNavbarMainMenu {
@@ -616,7 +629,7 @@ export namespace Components {
         "avatarUrl": string;
         "email": string;
         "initials": string;
-        "links": ModusNavbarProfileMenuLink[];
+        "links": ModusNavbarProfileMenuLink1[];
         "reverse": boolean;
         "username": string;
         "variant": 'default' | 'blue';
@@ -945,13 +958,7 @@ export namespace Components {
         /**
           * (optional) The input's inputmode.
          */
-        "inputmode": | 'decimal'
-    | 'email'
-    | 'numeric'
-    | 'search'
-    | 'tel'
-    | 'text'
-    | 'url';
+        "inputmode": 'decimal' | 'email' | 'numeric' | 'search' | 'tel' | 'text' | 'url';
         /**
           * (optional) The input's label.
          */
@@ -1087,13 +1094,7 @@ export namespace Components {
         /**
           * (optional) The toasts' type.
          */
-        "type": | 'danger'
-    | 'dark'
-    | 'default'
-    | 'primary'
-    | 'secondary'
-    | 'success'
-    | 'warning';
+        "type": 'danger' | 'dark' | 'default' | 'primary' | 'secondary' | 'success' | 'warning';
     }
     interface ModusTooltip {
         /**
@@ -2033,10 +2034,10 @@ declare namespace LocalJSX {
           * (optional) Determines custom dropdown placement offset.
          */
         "customPlacement"?: {
-    top?: number,
-    right?: number,
-    bottom?: number,
-    left?: number
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
   };
         /**
           * (optional) Disables the dropdown.
@@ -2286,8 +2287,8 @@ declare namespace LocalJSX {
         "variant"?: 'default' | 'blue';
     }
     interface ModusNavbarAppsMenu {
-        "apps"?: ModusNavbarApp[];
-        "onAppOpen"?: (event: ModusNavbarAppsMenuCustomEvent<ModusNavbarApp>) => void;
+        "apps"?: ModusNavbarApp1[];
+        "onAppOpen"?: (event: ModusNavbarAppsMenuCustomEvent<ModusNavbarApp1>) => void;
         "reverse"?: boolean;
     }
     interface ModusNavbarMainMenu {
@@ -2299,7 +2300,7 @@ declare namespace LocalJSX {
         "avatarUrl"?: string;
         "email"?: string;
         "initials"?: string;
-        "links"?: ModusNavbarProfileMenuLink[];
+        "links"?: ModusNavbarProfileMenuLink1[];
         "onLinkClick"?: (event: ModusNavbarProfileMenuCustomEvent<string>) => void;
         "onSignOutClick"?: (event: ModusNavbarProfileMenuCustomEvent<MouseEvent>) => void;
         "reverse"?: boolean;
@@ -2671,13 +2672,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The input's inputmode.
          */
-        "inputmode"?: | 'decimal'
-    | 'email'
-    | 'numeric'
-    | 'search'
-    | 'tel'
-    | 'text'
-    | 'url';
+        "inputmode"?: 'decimal' | 'email' | 'numeric' | 'search' | 'tel' | 'text' | 'url';
         /**
           * (optional) The input's label.
          */
@@ -2825,13 +2820,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The toasts' type.
          */
-        "type"?: | 'danger'
-    | 'dark'
-    | 'default'
-    | 'primary'
-    | 'secondary'
-    | 'success'
-    | 'warning';
+        "type"?: 'danger' | 'dark' | 'default' | 'primary' | 'secondary' | 'success' | 'warning';
     }
     interface ModusTooltip {
         /**

--- a/stencil-workspace/src/components/icons/icon.spec.tsx
+++ b/stencil-workspace/src/components/icons/icon.spec.tsx
@@ -32,6 +32,7 @@ describe('icon-triangle-down', () => {
   });
 });
 
+// eslint-disable-next-line @typescript-eslint/ban-types
 function renderFunctionalComponentToSpecPage<T extends {}>(componentConstructor: FunctionalComponent<T>): Promise<SpecPage> {
   return newSpecPage({
     components: [],

--- a/stencil-workspace/src/components/icons/icon.spec.tsx
+++ b/stencil-workspace/src/components/icons/icon.spec.tsx
@@ -1,11 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { h, Component, FunctionalComponent } from '@stencil/core';
-import { newSpecPage, SpecPage } from '@stencil/core/testing';
+import { h, FunctionalComponent } from '@stencil/core';
 import { IconTriangleDown } from './icon-triangle-down';
+import { SpecPage } from '@stencil/core/internal';
+import { newSpecPage } from '@stencil/core/testing';
 
 describe('icon-triangle-down', () => {
   it('should render', async () => {
-    const page = await renderFunctionalComponentToSpecPage(() => <IconTriangleDown />);
+    const page = await renderFunctionalComponentToSpecPage(<IconTriangleDown />);
 
     expect(page.root).toEqualHtml(`
       <svg class="icon-triangle-down" height="16" width="16" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -15,7 +16,7 @@ describe('icon-triangle-down', () => {
   });
 
   it('should render correct size', async () => {
-    const page = await renderFunctionalComponentToSpecPage(() => <IconTriangleDown size="12" />);
+    const page = await renderFunctionalComponentToSpecPage(<IconTriangleDown size="12" />);
 
     expect(page.root).toEqualHtml(`
       <svg class="icon-triangle-down" height="12" width="12" viewBox="0 0 10 6" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -25,21 +26,15 @@ describe('icon-triangle-down', () => {
   });
 
   it('should not have onClick by default', async () => {
-    const page = await renderFunctionalComponentToSpecPage(() => <IconTriangleDown />);
+    const page = await renderFunctionalComponentToSpecPage(<IconTriangleDown />);
 
     expect(page.root).not.toContain('onClick');
   });
 });
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-function renderFunctionalComponentToSpecPage<T extends {}>(
-  componentConstructor: () => FunctionalComponent<T>
-): Promise<SpecPage> {
-  @Component({ tag: 'test-component' })
-  class TestComponent {}
-
+function renderFunctionalComponentToSpecPage<T extends {}>(componentConstructor: FunctionalComponent<T>): Promise<SpecPage> {
   return newSpecPage({
-    components: [TestComponent],
-    template: componentConstructor,
+    components: [],
+    template: () => componentConstructor,
   });
 }

--- a/stencil-workspace/src/components/modus-data-table/readme.md
+++ b/stencil-workspace/src/components/modus-data-table/readme.md
@@ -7,14 +7,14 @@
 
 ## Properties
 
-| Property               | Attribute | Description                                | Type                           | Default                                                                                                                               |
-| ---------------------- | --------- | ------------------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `columns` _(required)_ | --        |                                            | `TColumn[] \| string[]`        | `undefined`                                                                                                                           |
-| `data` _(required)_    | --        |                                            | `TCell[][] \| TRow[]`          | `undefined`                                                                                                                           |
-| `displayOptions`       | --        | Options for data table display.            | `ModusDataTableDisplayOptions` | `{     animateRowActionsDropdown: false,     borderless: true,     cellBorderless: true,     rowStripe: false,     size: 'large'   }` |
-| `rowActions`           | --        | Actions that can be performed on each row. | `ModusDataTableRowAction[]`    | `[]`                                                                                                                                  |
-| `selectionOptions`     | --        | Options for data table item selection.     | `ModusTableSelectionOptions`   | `{     canSelect: false,     checkboxSelection: false,   }`                                                                           |
-| `sortOptions`          | --        | Options for data table column sort.        | `ModusTableSortOptions`        | `{     canSort: false,     serverSide: false,   }`                                                                                    |
+| Property               | Attribute | Description                                | Type                           | Default                                                                                                                                |
+| ---------------------- | --------- | ------------------------------------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `columns` _(required)_ | --        |                                            | `TColumn[] \| string[]`        | `undefined`                                                                                                                            |
+| `data` _(required)_    | --        |                                            | `TCell[][] \| TRow[]`          | `undefined`                                                                                                                            |
+| `displayOptions`       | --        | Options for data table display.            | `ModusDataTableDisplayOptions` | `{     animateRowActionsDropdown: false,     borderless: true,     cellBorderless: true,     rowStripe: false,     size: 'large',   }` |
+| `rowActions`           | --        | Actions that can be performed on each row. | `ModusDataTableRowAction[]`    | `[]`                                                                                                                                   |
+| `selectionOptions`     | --        | Options for data table item selection.     | `ModusTableSelectionOptions`   | `{     canSelect: false,     checkboxSelection: false,   }`                                                                            |
+| `sortOptions`          | --        | Options for data table column sort.        | `ModusTableSortOptions`        | `{     canSort: false,     serverSide: false,   }`                                                                                     |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.e2e.ts
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.e2e.ts
@@ -1,19 +1,19 @@
 import { newE2EPage } from '@stencil/core/testing';
 
-const monthNames = [
-  'January',
-  'February',
-  'March',
-  'April',
-  'May',
-  'June',
-  'July',
-  'August',
-  'September',
-  'October',
-  'November',
-  'December',
-];
+// const monthNames = [
+//   'January',
+//   'February',
+//   'March',
+//   'April',
+//   'May',
+//   'June',
+//   'July',
+//   'August',
+//   'September',
+//   'October',
+//   'November',
+//   'December',
+// ];
 
 describe('modus-date-picker', () => {
   it('renders', async () => {

--- a/stencil-workspace/src/components/modus-radio-group/modus-radio-group.e2e.ts
+++ b/stencil-workspace/src/components/modus-radio-group/modus-radio-group.e2e.ts
@@ -1,5 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
-import { RadioButton } from './modus-radio-group';
+import { RadioButton } from './modus-radio-button';
 
 describe('modus-radio-group', () => {
   it('renders', async () => {

--- a/stencil-workspace/stencil.config.ts
+++ b/stencil-workspace/stencil.config.ts
@@ -8,6 +8,7 @@ import angularValueAccessorBindings from './angular-value-accessor-bindings';
 
 export const config: Config = {
   namespace: 'modus-web-components',
+  sourceMap: false,
   outputTargets: [
     {
       type: 'dist',
@@ -15,6 +16,7 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements',
+      generateTypeDeclarations: false,
     },
     {
       type: 'docs-vscode',
@@ -30,8 +32,10 @@ export const config: Config = {
     },
     angularOutputTarget({
       componentCorePackage: '@trimble-oss/modus-web-components',
-      directivesProxyFile: '../angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts',
-      directivesArrayFile: '../angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts',
+      directivesProxyFile:
+        '../angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts',
+      directivesArrayFile:
+        '../angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts',
       valueAccessorConfigs: angularValueAccessorBindings,
     }),
     react({


### PR DESCRIPTION
## Description
- Walked through Stencil's upgrade guide: https://stenciljs.com/docs/v2/introduction/upgrading-to-stencil-three#add-customelementsexportbehavior-to-control-export-behavior
- Fixed an issue with a `modus-radio-group.e2e.ts` import path
- Fixed an issue with an unused variable in `modus-date-picker.e2e.ts`
- Fixed `icon.spec.ts`. There was an unneeded `Component` import that was causing rollup errors

**I noted my thought process throughout the upgrade, please open and check the detailed notes below**:
<details>
<summary>Upgrade Guide Notes</summary>

# New Configuration Defaults

### SourceMaps

Manually set the `sourceMap` config to `false` 

Source maps should not be included in our production builds as they are representations of the original code. Including them would increase bundle size and impact performance

### `dist-custom-elements` Type Declarations

Manually set `generateTypeDeclarations` config to `false` to mimic v2 behavior

I’m not sure we need these type declarations as the custom types for props and events are now exported from `components.d.ts`

# Legacy Browser Support Fields Deprecated

Does not apply, none of the configuration options are used

# Deprecated `assetsDir` Removed from `@Component` decorator

Does not apply, `assetsDir` is not used

# **Drop Node 12 Support**

Does not apply, we require Node 14 or higher

# **Strongly Typed Inputs**

Does not apply, our inputs are implicitly using these new types

# **Narrowed Typing for `autocapitalize` Attribute**

Does not apply

# **Custom Types for Props and Events are now Exported from `components.d.ts`**

Originally I thought to remove the `interfaces.d.ts` file where we are manually exporting necessary types, and update the `package.json` to reference the `components.d.ts` for the types instead of `interfaces.d.ts` - but there was an issue with name collisions.

If a component was to import a type from another component (for example, the navbar importing the `ModusNavbarApp` from the navbar-apps-menu component), `components.d.ts` was creating two exports: `ModusNavbarApp` and `ModusNavbarApp1`

I’m not sure if there is a way around this. My thought is to stick with our manual exports in `interfaces.d.ts` so that we have more control over the types we’re exposing through the package

We can use `components.d.ts` as a reference to check our `interfaces.d.ts`

# **Composition Event Handlers Renamed**

Does not apply, none of these event handlers are used

# Output Targets

### `dist-custom-elements` Output Target

`customElementsExportBehavior` does not apply, we’ll keep the default behavior

`autoDefineCustomElements` does not apply, we’re not using it

`inlineDynamicImports` does not apply, we’re not using it

### **`dist-custom-elements-bundle` Output Target**

Does not apply, we’re not using it

# **Framework Integration Output Targets**

Does not apply, we’re not setting `includeImportCustomElements` on any of the framework outputs

# **Legacy Angular Output Target**

Does not apply, we’re using the @stencil/angular-output-target already

# **Stencil APIs**

Does not apply, flag parsing and destroy callbacks are not used

# **End-to-End Testing**

Does not apply, we use Puppeteer v19+

# **Additional Packages**

`@stencil/angular-output-target` - Updated to 0.5.0

`@stencil/sass` - Does not apply, already up to date

`@stencil/store` - Does not apply, we’re not using it

`@stencil/react-output-target` - Updated to 0.4.0

`@stencil/vue-output-target` - Does not apply, we’re not using it
</details>

References #1358 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Ran tests and manually installed package in our current codebase

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
