### PR TITLE
Make `category` and `showCategory` optional for Modus Navbar's apps menu

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.tsx
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.tsx
@@ -6,8 +6,8 @@ export interface ModusNavbarApp {
   logoUrl: string;
   name: string;
   url: string;
-  category: string;
-  showCategory: boolean;
+  category?: string;
+  showCategory?: boolean;
 }
 
 @Component({

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -43,9 +43,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
       ],
       logoUrl: '',
       name: '',
-      url: '',
-      category: '',
-      showCategory: false,
+      url: ''
     },
   ];
   element.productLogoOptions = {
@@ -90,9 +88,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
       ],
       logoUrl: '',
       name: '',
-      url: '',
-      category: '',
-      showCategory: false,
+      url: ''
     },
   ];
   element.productLogoOptions = {
@@ -140,9 +136,7 @@ Use the `variant` prop to choose a blue background navbar.
       ],
       logoUrl: '',
       name: '',
-      url: '',
-      category: '',
-      showCategory: false,
+      url: ''
     },
   ];
   element.productLogoOptions = {
@@ -166,8 +160,8 @@ interface ModusNavbarApp {
   logoUrl: string;
   name: string;
   url: string;
-  category: string;
-  showCategory: boolean;
+  category?: string;
+  showCategory?: boolean;
 }
 
 interface ModusNavbarProfileMenuLink {


### PR DESCRIPTION
## Description

Make `category` and `showCategory` properties optional as they are not really required.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Storybook example code blocks

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
