### PR TITLE
Added a few optional fields to the GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,8 +11,6 @@ body:
       options:
         - label: I have [searched](https://github.com/trimble-oss/modus-web-components/issues?q=is%3Aissue) for duplicate or closed issues
           required: true
-        - label: I have validated any HTML to avoid common problems
-          required: true
         - label: I have read the [contributing guidelines](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md)
           required: true
   - type: textarea
@@ -27,8 +25,6 @@ body:
     attributes:
       label: Reduced test cases
       description: Include links [reduced test case](https://css-tricks.com/reduced-test-cases/) links or suggested fixes using a online code editor.
-    validations:
-      required: false
   - type: dropdown
     id: os
     attributes:
@@ -40,8 +36,6 @@ body:
         - Android
         - iOS
         - Linux
-    validations:
-      required: false
   - type: dropdown
     id: browser
     attributes:
@@ -56,20 +50,19 @@ body:
   - type: dropdown
     id: package
     attributes:
-      label: Which npm package?
+      label: What is the issue regarding ?
       multiple: true
       options:
         - '@trimble-oss/modus-web-components'
         - '@trimble-oss/modus-angular-components'
+        - Modus Web Components Website (Storybook)
     validations:
-      required: false
+      required: true
   - type: input
     id: version
     attributes:
-      label: What version of npm package are you using?
+      label: What version of npm package are you using ?
       placeholder: 'e.g., v0.0.1'
-    validations:
-      required: false
   - type: dropdown
     id: priority
     attributes:
@@ -84,12 +77,26 @@ body:
   - type: input
     id: product
     attributes:
-      label: What product/project are you using Modus Components for?
+      label: What product/project are you using Modus Components for ?
     validations:
       required: true
   - type: input
     id: team
     attributes:
-      label: What is your team/division name?
+      label: What is your team/division name ?
     validations:
       required: true
+  - type: input
+    id: team
+    attributes:
+      label: Are you willing to contribute ?
+      multiple: false
+      options:
+        - 'Yes'
+        - 'No'
+        - 'Maybe'
+  - type: input
+    id: team
+    attributes:
+      label: Are you using Modus Web Components in production ?
+      placeholder: 'If yes, please feel free to share with us the app URL (optional).'

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       options:
         - label: I have [searched](https://github.com/trimble-oss/modus-web-components/issues?q=is%3Aissue) for duplicate or closed feature requests
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md)
+        - label: I have read the [Modus style guidelines](https://modus.trimble.com/components/web/introduction/)
           required: true
   - type: textarea
     id: proposal
@@ -23,16 +23,15 @@ body:
     attributes:
       label: Motivation and context
       description: Tell us why this change is needed or helpful, and what problems it may help solve.
-    validations:
-      required: false
   - type: dropdown
     id: package
     attributes:
-      label: Which npm package?
+      label: What is the issue regarding ?
       multiple: true
       options:
         - '@trimble-oss/modus-web-components'
         - '@trimble-oss/modus-angular-components'
+        - Modus Web Components Website (Storybook)
     validations:
       required: true
   - type: dropdown
@@ -49,18 +48,26 @@ body:
   - type: input
     id: product
     attributes:
-      label: What is the product name the feature is requested for?
+      label: What product/project are you using Modus Components for ?
     validations:
       required: true
   - type: input
     id: team
     attributes:
-      label: What is the team name the product belongs to?
+      label: What is your team/division name ?
     validations:
       required: true
   - type: input
-    id: division
+    id: team
     attributes:
-      label: What is the division name the team belongs to?
-    validations:
-      required: true
+      label: Are you willing to contribute ?
+      multiple: false
+      options:
+        - 'Yes'
+        - 'No'
+        - 'Maybe'
+  - type: input
+    id: team
+    attributes:
+      label: Are you using Modus Web Components in production ?
+      placeholder: 'If yes, please feel free to share with us the app URL (optional).'


### PR DESCRIPTION
Added a couple of optional fields to help with Modus adoption tracking.

template:
![image](https://github.com/trimble-oss/modus-web-components/assets/50131391/bf601236-99b8-4ea0-bc76-93a30816f3cb)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

GitHub Issue templates

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
