### PR TITLE
Skip Azure Static Web App deployment on missing secrets

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -44,6 +44,8 @@ jobs:
           app_location: "/stencil-workspace/storybook/dist/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "/stencil-workspace/storybook/dist/" # Built app content directory - optional
+        env:
+          skip_deploy_on_missing_secrets: true
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
## Description

We should consider skipping the Azure Static Web App step when there are missing secrets. PRs from a forked branch are not working since they don't have access to the secrets, which is blocking merging

We can depend on the Netlify deployment for checking the preview