### PR TITLE
Fix deployment skip parameter

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -36,6 +36,7 @@ jobs:
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
+          skip_deploy_on_missing_secrets: true
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_GROUND_0374A1310 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
@@ -44,8 +45,7 @@ jobs:
           app_location: "/stencil-workspace/storybook/dist/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "/stencil-workspace/storybook/dist/" # Built app content directory - optional
-        env:
-          skip_deploy_on_missing_secrets: true
+          
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -45,7 +45,6 @@ jobs:
           app_location: "/stencil-workspace/storybook/dist/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "/stencil-workspace/storybook/dist/" # Built app content directory - optional
-          
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
## Description

There's limited information on `skip_deploy_on_missing_secrets` in the Microsoft docs. Dapr has an example [here](https://docs.dapr.io/contributing/docs-contrib/maintainer-guide/) that shows the parameter actually goes in the `with` section