### PR TITLE
add tooltip to canvas section in storybook

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-tooltip/modus-tooltip.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-tooltip/modus-tooltip.stories.tsx
@@ -4,19 +4,58 @@ import { html } from 'lit-html';
 
 export default {
   title: 'Components/Tooltip',
+  argTypes: {
+    ariaLabel: {
+      name: 'aria-label',
+      description: "The tooltip's aria-label",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    position: {
+      control: {
+        options: ['bottom', 'left', 'right', 'top'],
+        type: 'select',
+      },
+      description: "The tooltip's position relative to the item it's wrapping",
+      table: {
+        defaultValue: { summary: `'top'` },
+        type: { summary: `'bottom' | 'left' | 'right' | 'top'` },
+      },
+    },
+    text: {
+      description: "The tooltip's text",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+  },
   parameters: {
+    controls: { expanded: true },
     docs: {
       page: docs,
     },
     options: {
       isToolshown: true,
     },
-    controls: {
-      disabled: true,
-    },
-    viewMode: 'docs',
+    layout: 'centered'
   },
 };
 
-const Template = () => html` <modus-tooltip></modus-tooltip> `;
-export const Default = Template.bind({});
+export const Default = ({
+  ariaLabel,
+  position,
+  text
+}) => html`
+  <modus-tooltip
+    aria-label=${ariaLabel}
+    position=${position}
+    text=${text}>
+    <modus-button>Button</modus-button>
+  </modus-tooltip>
+`;
+Default.args = {
+  ariaLabel: '',
+  position: 'bottom',
+  text: 'Tooltip text...'
+};


### PR DESCRIPTION
## Description

Adding the tooltip properties to the modus-tooltip stories in Storybook. Adding a button inside the tooltip to be able to see the tooltip in Storybook.

References #1276

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested locally.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
