### PR TITLE
Fix Navbar Main Menu height

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.models.ts
+++ b/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.models.ts
@@ -1,0 +1,13 @@
+export interface ContainerLayout {
+  height: string;
+  top: string;
+}
+
+export const INITIAL_CONTAINER_LAYOUT: ContainerLayout = {
+  height: '0px',
+  top: '0px',
+};
+
+export const DOM_OBSERVER_CONFIG: MutationObserverInit = {
+  childList: true,
+};

--- a/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
@@ -5,12 +5,12 @@
 
   border-radius: 0 0 $rem_2px $rem_2px;
   border-top: none;
+  box-sizing: border-box;
   clip-path: inset(0 -10px -10px -10px);
   cursor: default;
   left: 0;
   max-width: 616px;
   min-width: 248px;
   padding: 0;
-  top: 52px;
   width: max-content;
 }

--- a/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.tsx
+++ b/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line
-import { Component, h } from '@stencil/core';
+import { Component, h, State } from '@stencil/core';
+import { ContainerLayout, DOM_OBSERVER_CONFIG, INITIAL_CONTAINER_LAYOUT } from './modus-navbar-main-menu.models';
 
 @Component({
   tag: 'modus-navbar-main-menu',
@@ -7,9 +8,59 @@ import { Component, h } from '@stencil/core';
   shadow: true,
 })
 export class ModusNavbarMainMenu {
+  @State() containerLayout: ContainerLayout = INITIAL_CONTAINER_LAYOUT;
+
+  private observer: MutationObserver | null = null;
+
+  componentDidLoad(): void {
+    this.updateContainerLayout();
+    this.addSubscriptions();
+  }
+
+  disconnectedCallback(): void {
+    this.removeSubscriptions();
+  }
+
+  addSubscriptions(): void {
+    window.addEventListener('resize', this.updateContainerLayout);
+    this.connectDOMObserver();
+  }
+
+  removeSubscriptions(): void {
+    window.removeEventListener('resize', this.updateContainerLayout);
+    this.disconnectDOMObserver();
+  }
+
+  connectDOMObserver(): void {
+    this.observer = new MutationObserver(this.updateContainerLayout);
+    this.observer.observe(document.body, DOM_OBSERVER_CONFIG);
+  }
+
+  disconnectDOMObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  updateContainerLayout = (): void => {
+    const navbarRect = document.querySelector('modus-navbar')?.getBoundingClientRect();
+
+    if (!navbarRect) {
+      return;
+    }
+
+    this.containerLayout = {
+      height: `${window.innerHeight - navbarRect.bottom}px`,
+      top: `${navbarRect.bottom}px`,
+    };
+  };
+
   render(): unknown {
     return (
-      <div class={'main-menu'} onClick={(event) => event.preventDefault()}>
+      <div
+        class="main-menu"
+        style={{ height: this.containerLayout.height, top: this.containerLayout.top }}
+        onClick={(event) => event.preventDefault()}>
         <slot />
       </div>
     );

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -45,7 +45,7 @@ nav {
     }
   }
 
-  .main-menu {
+  .main-menu-button {
     padding: 0 $rem-8px;
   }
 
@@ -75,6 +75,7 @@ nav {
       filter: $modus-navbar-brand-logo-filter;
       max-height: 32px;
       padding: 0 $rem-8px;
+      user-select: none;
     }
   }
 

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
@@ -270,20 +270,21 @@ export class ModusNavbar {
     const direction = this.reverse ? 'reverse' : '';
     const shadow = this.showShadow ? 'shadow' : '';
     const variant = `${this.variant === 'default' ? '' : 'nav-' + this.variant}`;
+
     return (
       <nav class={`${direction} ${shadow} ${variant}`}>
         <div class={`left ${direction}`}>
           {this.showMainMenu && (
-            <div class="navbar-button main-menu">
+            <div class="navbar-button main-menu-button">
               <span class="navbar-button-icon" onKeyDown={(event) => this.mainMenuKeydownHandler(event)} tabIndex={0}>
                 <IconMenu size="24" pressed={this.mainMenuVisible} onClick={(event) => this.mainMenuClickHandler(event)} />
               </span>
-              {this.mainMenuVisible && (
-                <modus-navbar-main-menu>
-                  <slot name={this.SLOT_MAIN}></slot>
-                </modus-navbar-main-menu>
-              )}
             </div>
+          )}
+          {this.mainMenuVisible && (
+            <modus-navbar-main-menu>
+              <slot name={this.SLOT_MAIN}></slot>
+            </modus-navbar-main-menu>
           )}
           <img
             class="product-logo"

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.vars.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.vars.scss
@@ -58,3 +58,4 @@ $modus-navbar-blue-profile-icon-active-border-color: var(
   --modus-navbar-blue-profile-icon-active-border-color,
   #019aeb
 ) !default;
+


### PR DESCRIPTION
## Description

The goal of this work was to modify the Main Menu to occupy the remaining portion of the screen. By implementing this change, the Main Menu is now positioned directly below the Navbar and occupies the rest of the viewport. This enhancement allows for the placement of items like notifications, messages, and other elements on top of the Navbar while maintaining the remaining screen height for the Main Menu

The main approach involved was to ensure that the Main Menu dynamically adjusts its container's layout. This layout is set when the component initially loads and also when any observed changes occur in the DOM

To address alignment issues within the Shadow DOM, I moved the Main Menu component outside of the navbar-button div. This adjustment resolved the problems caused by the misalignment of the Shadow DOM

References #1345

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested this in the Stencil playground and in our Work Center application

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
