### PR TITLE
Modus checkbox focus state corrections - focused exclusively on the checkbox and ignoring the label

### DIFF
--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.spec.tsx
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.spec.tsx
@@ -10,8 +10,8 @@ describe('modus-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <modus-checkbox>
         <mock:shadow-root>
-          <div class="modus-checkbox" tabindex="0">
-            <div class="checkbox">
+          <div class="modus-checkbox">
+            <div class="checkbox" tabindex="0">
               <div class="checkmark">
                 <svg class="icon-check" fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
                   <path clip-rule="evenodd" d="M9.08471 15.4676L5.29164 11.736L4 12.9978L9.08471 18L20 7.26174L18.7175 6L9.08471 15.4676Z" fill="#FFFFFF" fill-rule="evenodd"></path>

--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
@@ -69,9 +69,14 @@ export class ModusCheckbox {
         class={className}
         onClick={() => {
           this.handleCheckboxClick();
-        }}
-        tabIndex={tabIndexValue}>
-        <div class={`${this.checked || this.indeterminate ? 'checkbox blue-background checked' : 'checkbox'} ${this.disabled ? 'disabled' : ''}`}>
+        }}>
+        <div
+          tabIndex={tabIndexValue}
+          class={`${
+            this.checked || this.indeterminate
+              ? 'checkbox blue-background checked'
+              : 'checkbox'
+          } ${this.disabled ? 'disabled' : ''}`}>
           {this.indeterminate ? (
             <div class={'checkmark checked'}>
               <IconIndeterminate color="#FFFFFF" size="24" />
@@ -90,7 +95,9 @@ export class ModusCheckbox {
           disabled={this.disabled}
           ref={(el) => (this.checkboxInput = el as HTMLInputElement)}
           type="checkbox"></input>
-        {this.label ? <label class={this.disabled ? 'disabled' : null}>{this.label}</label> : null}
+        {this.label ? (
+          <label class={this.disabled ? 'disabled' : null}>{this.label}</label>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
## Description

Modus checkbox focus state corrections - focused exclusively on the checkbox and ignoring the label

References #[1393](https://github.com/trimble-oss/modus-web-components/issues/1393)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
