### PR TITLE
Modus checkbox focus state corrections - focused exclusively on the checkbox and ignoring the label

### DIFF
--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.scss
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.scss
@@ -29,6 +29,12 @@
     transition: background-color 0.15s ease-in-out;
     width: $rem-16px;
 
+    &:focus,
+    &:focus-visible {
+      box-shadow: 0 0 0 0.2rem $modus-checkbox-focus-box-shadow-color;
+      outline: 0;
+    }
+
     &.blue-background {
       background-color: $modus-checkbox-selected-border-color !important;
       border: $rem-2px solid $modus-checkbox-selected-border-color !important;

--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.spec.tsx
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.spec.tsx
@@ -10,8 +10,8 @@ describe('modus-checkbox', () => {
     expect(page.root).toEqualHtml(`
       <modus-checkbox>
         <mock:shadow-root>
-          <div class="modus-checkbox" tabindex="0">
-            <div class="checkbox">
+          <div class="modus-checkbox">
+            <div class="checkbox" tabindex="0">
               <div class="checkmark">
                 <svg class="icon-check" fill="none" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
                   <path clip-rule="evenodd" d="M9.08471 15.4676L5.29164 11.736L4 12.9978L9.08471 18L20 7.26174L18.7175 6L9.08471 15.4676Z" fill="#FFFFFF" fill-rule="evenodd"></path>

--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.tsx
@@ -87,9 +87,9 @@ export class ModusCheckbox {
         onClick={() => {
           this.handleCheckboxClick();
         }}
-        tabindex={tabIndexValue}
         ref={(el) => (this.checkboxContainer = el)}>
         <div
+          tabindex={tabIndexValue}
           class={`${this.checked || this.indeterminate ? 'checkbox blue-background checked' : 'checkbox'} ${
             this.disabled ? 'disabled' : ''
           }`}>

--- a/stencil-workspace/src/components/modus-checkbox/modus-checkbox.vars.scss
+++ b/stencil-workspace/src/components/modus-checkbox/modus-checkbox.vars.scss
@@ -11,3 +11,6 @@ $modus-checkbox-selected-border-color: var(--modus-checkbox-selected-border-colo
 
 // Indeterminate state
 $modus-checkbox-indeterminate-border-color: var(--modus-checkbox-indeterminate-border-color, #217cbb) !default;
+
+// Focus state
+$modus-checkbox-focus-box-shadow-color: var(--modus-checkbox-focus-box-shadow-color, rgba(#217cbb, 0.34)) !default;

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -175,6 +175,7 @@
   --modus-check-input-label-color: var(--modus-input-label-color);
   --modus-check-input-hover-border-color: var(--modus-highlight-blue-color);
   --modus-check-input-active-border-color: var(--modus-highlight-blue-color);
+  --modus-check-input-focus-box-shadow-color: #217fbb57;
 
   // Card
   --modus-card-bg: var(--modus-white);
@@ -480,6 +481,7 @@
   --modus-check-input-label-color: var(--modus-input-label-color);
   --modus-check-input-hover-border-color: var(--modus-highlight-blue-color);
   --modus-check-input-active-border-color: var(--modus-highlight-blue-color);
+  --modus-check-input-focus-box-shadow-color: #019aeb66;
 
   // Card
   --modus-card-bg: var(--modus-gray-9);
@@ -705,6 +707,7 @@
   --modus-checkbox-hover-border-color: var(--modus-check-input-active-border-color);
   --modus-checkbox-selected-border-color: var(--modus-check-input-active-border-color);
   --modus-checkbox-indeterminate-border-color: var(--modus-check-input-active-border-color);
+  --modus-checkbox-focus-box-shadow-color: var(--modus-check-input-focus-box-shadow-color);
 }
 
 @mixin modus-list-item {


### PR DESCRIPTION
## Description

Modus checkbox focus state corrections 
- Focused exclusively on the checkbox and ignoring the label.
- Focus state colors (for light and dark) are updated, taken from the Modus Trimble style guide.

References [#1393](https://github.com/trimble-oss/modus-web-components/issues/1393)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
