### PR TITLE
add properties to align right on text and number inputs

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -725,14 +725,14 @@ export declare interface ModusNavbarProfileMenu extends Components.ModusNavbarPr
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'validText', 'value']
+  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'textAlign', 'validText', 'value']
 })
 @Component({
   selector: 'modus-number-input',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'validText', 'value'],
+  inputs: ['ariaLabel', 'disabled', 'errorText', 'helperText', 'label', 'maxValue', 'minValue', 'placeholder', 'readOnly', 'required', 'size', 'step', 'textAlign', 'validText', 'value'],
 })
 export class ModusNumberInput {
   protected el: HTMLElement;
@@ -1030,7 +1030,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
 @Component({
@@ -1038,7 +1038,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -676,6 +676,10 @@ export namespace Components {
          */
         "step": number;
         /**
+          * (optional) Set text alignment for the number input.
+         */
+        "textAlign": 'left' | 'right';
+        /**
           * (optional) The input's valid state text.
          */
         "validText": string;
@@ -979,6 +983,10 @@ export namespace Components {
           * (optional) The input's size.
          */
         "size": 'medium' | 'large';
+        /**
+          * (optional) Set text alignment for the input.
+         */
+        "textAlign": 'left' | 'right';
         /**
           * (optional) The input's type.
          */
@@ -2351,6 +2359,10 @@ declare namespace LocalJSX {
          */
         "step"?: number;
         /**
+          * (optional) Set text alignment for the number input.
+         */
+        "textAlign"?: 'left' | 'right';
+        /**
           * (optional) The input's valid state text.
          */
         "validText"?: string;
@@ -2695,6 +2707,10 @@ declare namespace LocalJSX {
           * (optional) The input's size.
          */
         "size"?: 'medium' | 'large';
+        /**
+          * (optional) Set text alignment for the input.
+         */
+        "textAlign"?: 'left' | 'right';
         /**
           * (optional) The input's type.
          */

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.e2e.ts
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.e2e.ts
@@ -96,6 +96,21 @@ describe('modus-number-input', () => {
     expect(label.textContent).toEqual('Hello Label');
   });
 
+  it('renders changes to textAlign', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-number-input></modus-number-input>');
+    await page.waitForChanges();
+
+    const modusNumberInput = await page.find('modus-number-input');
+    expect(await page.find('modus-number-input >>> input')).toHaveClass('text-align-left');
+
+    modusNumberInput.setProperty('textAlign', 'right');
+    await page.waitForChanges();
+
+    expect(await page.find('modus-number-input >>> input')).toHaveClass('text-align-right');
+  });
+
   it('renders changes to placeholder', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
@@ -44,6 +44,10 @@
       padding: 0 $rem-8px;
       width: 100%;
 
+      &.text-align-right {
+        text-align: right;
+      }
+
       &::placeholder {
         color: $modus-input-hint-text-color;
       }

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.spec.tsx
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.spec.tsx
@@ -12,7 +12,7 @@ describe('modus-number-input', () => {
         <mock:shadow-root>
           <div class="modus-number-input">
             <div class="input-container medium">
-              <input tabindex="0" type="number">
+              <input class="text-align-left" tabindex="0" type="number">
             </div>
           </div>
         </mock:shadow-root>

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
@@ -43,6 +43,9 @@ export class ModusNumberInput {
   /** (optional) The input's step. */
   @Prop() step: number;
 
+  /** (optional) Set text alignment for the number input. */
+  @Prop() textAlign: 'left' | 'right' = 'left';
+
   /** (optional) The input's valid state text. */
   @Prop() validText: string;
 
@@ -78,6 +81,7 @@ export class ModusNumberInput {
     const inputContainerClassName = `input-container ${
       this.errorText ? 'error' : this.validText ? 'valid' : ''
     } ${this.classBySize.get(this.size)}`;
+    const textAlign = `text-align-${this.textAlign}`;
 
     return (
       <div
@@ -99,6 +103,7 @@ export class ModusNumberInput {
         ) : null}
         <div class={inputContainerClassName}>
           <input
+            class={`${textAlign}`}
             disabled={this.disabled}
             max={this.maxValue}
             min={this.minValue}

--- a/stencil-workspace/src/components/modus-number-input/readme.md
+++ b/stencil-workspace/src/components/modus-number-input/readme.md
@@ -21,6 +21,7 @@
 | `required`    | `required`    | (optional) Whether the input is required.                     | `boolean`             | `undefined` |
 | `size`        | `size`        | (optional) The input's size.                                  | `"large" \| "medium"` | `'medium'`  |
 | `step`        | `step`        | (optional) The input's step.                                  | `number`              | `undefined` |
+| `textAlign`   | `text-align`  | (optional) Set text alignment for the number input.           | `"left" \| "right"`   | `'left'`    |
 | `validText`   | `valid-text`  | (optional) The input's valid state text.                      | `string`              | `undefined` |
 | `value`       | `value`       | (optional) The input's value.                                 | `string`              | `undefined` |
 

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
@@ -207,6 +207,21 @@ describe('modus-text-input', () => {
     expect(await input.getProperty('autofocus')).toBeTruthy();
   });
 
+  it('renders changes to textAlign', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-text-input></modus-text-input>');
+    await page.waitForChanges();
+
+    const modusTextInput = await page.find('modus-text-input');
+    expect(await page.find('modus-text-input >>> input')).toHaveClass('text-align-left');
+
+    modusTextInput.setProperty('textAlign', 'right');
+    await page.waitForChanges();
+
+    expect(await page.find('modus-text-input >>> input')).toHaveClass('text-align-right');
+  });
+
   it('should clear on handleClear', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -67,6 +67,10 @@
         padding-right: 0;
       }
 
+      &.text-align-right {
+        text-align: right;
+      }
+
       &::placeholder {
         color: $modus-input-hint-text-color;
       }

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
@@ -12,7 +12,7 @@ describe('modus-text-input', () => {
         <mock:shadow-root>
             <div class="modus-text-input">
                 <div class="input-container medium">
-                    <input type="text" tabindex="0">
+                    <input class="text-align-left" type="text" tabindex="0">
                     <span class="icons"></span>
                 </div>
             </div>
@@ -31,7 +31,7 @@ describe('modus-text-input', () => {
         <mock:shadow-root>
             <div class="modus-text-input">
                 <div class="input-container medium">
-                <input tabindex="0" type="password">
+                <input class="text-align-left" tabindex="0" type="password">
                 </div>
             </div>
         </mock:shadow-root>

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -59,6 +59,9 @@ export class ModusTextInput {
   /** (optional) The input's size. */
   @Prop() size: 'medium' | 'large' = 'medium';
 
+  /** (optional) Set text alignment for the input. */
+  @Prop() textAlign: 'left' | 'right' = 'left';
+
   /** (optional) The input's type. */
   @Prop() type: 'text' | 'password' = 'text';
 
@@ -116,6 +119,10 @@ export class ModusTextInput {
     const isPassword = this.type === 'password';
     const showPasswordToggle = !!(this.includePasswordTextToggle && isPassword && this.value?.length);
     const showClearIcon = (isPassword && !this.includePasswordTextToggle) || !isPassword;
+    const textAlign = `text-align-${this.textAlign}`;
+    const inputClassName = `${this.includeSearchIcon ? 'has-left-icon' : ''} ${
+      this.clearable ? 'has-right-icon' : ''
+    } ${textAlign}`;
 
     return (
       <div
@@ -139,7 +146,7 @@ export class ModusTextInput {
           {this.includeSearchIcon ? <IconSearch size="16" /> : null}
           <input
             aria-placeholder={this.placeholder}
-            class={`${this.includeSearchIcon ? 'has-left-icon' : ''} ${this.clearable ? 'has-right-icon' : ''}`}
+            class={inputClassName}
             disabled={this.disabled}
             inputmode={this.inputmode}
             maxlength={this.maxLength}

--- a/stencil-workspace/src/components/modus-text-input/readme.md
+++ b/stencil-workspace/src/components/modus-text-input/readme.md
@@ -25,6 +25,7 @@
 | `readOnly`                  | `read-only`                    | (optional) Whether the input's content is read-only           | `boolean`                                                                   | `undefined` |
 | `required`                  | `required`                     | (optional) Whether the input is required.                     | `boolean`                                                                   | `undefined` |
 | `size`                      | `size`                         | (optional) The input's size.                                  | `"large" \| "medium"`                                                       | `'medium'`  |
+| `textAlign`                 | `text-align`                   | (optional) Set text alignment for the input.                  | `"left" \| "right"`                                                         | `'left'`    |
 | `type`                      | `type`                         | (optional) The input's type.                                  | `"password" \| "text"`                                                      | `'text'`    |
 | `validText`                 | `valid-text`                   | (optional) The input's valid state text.                      | `string`                                                                    | `undefined` |
 | `value`                     | `value`                        | (optional) The input's value.                                 | `string`                                                                    | `undefined` |

--- a/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input-storybook-docs.mdx
@@ -156,6 +156,14 @@ This component is compatible with Angular reactive forms. This can be achieved t
         <td></td>
       </tr>
       <tr>
+        <td>text-align</td>
+        <td>Set text alignment for the number input</td>
+        <td>string</td>
+        <td>'left', 'right'</td>
+        <td>'left'</td>
+        <td></td>
+      </tr>
+      <tr>
         <td>valid-text</td>
         <td>The input's valid state text</td>
         <td>string</td>

--- a/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input.stories.tsx
@@ -91,6 +91,24 @@ export default {
         type: { summary: 'number' },
       },
     },
+    textAlign: {
+      name: 'text-align',
+      control: {
+        options: [
+          'left',
+          'right'
+        ],
+        type: 'select',
+      },
+      description: 'text alignment for the number input.',
+      table: {
+        defaultValue: { summary: "'left'" },
+        type: {
+          summary:
+            "'left' | 'right'",
+        },
+      },
+    },
     validText: {
       name: 'valid-text',
       description: "The number input's valid text",
@@ -132,6 +150,7 @@ const Template = ({
   required,
   size,
   step,
+  textAlign,
   validText,
   value,
 }) => html`
@@ -148,6 +167,7 @@ const Template = ({
     required=${required}
     size=${size}
     step=${step}
+    text-align=${textAlign}
     valid-text=${validText}
     value=${value}></modus-number-input>
 `;
@@ -166,6 +186,7 @@ Default.args = {
   required: false,
   size: 'medium',
   step: 1,
+  textAlign: 'left',
   validText: '',
   value: 100,
 };

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -70,27 +70,28 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 ### Properties
 
-| Property                     | Attribute                      | Description                                                   | Type                                                                        | Default     |
-| ---------------------------- | ------------------------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------- |
-| `ariaLabel`                  | `aria-label`                   | (optional) The input's aria-label.                            | `string`                                                                    | `undefined` |
-| `autoFocusInput`             | `auto-focus-input`             | (optional) Sets autofocus on the input.                       | `boolean`                                                                   | `undefined` |
-| `clearable`                  | `clearable`                    | (optional) Whether the input has a clear button.              | `boolean`                                                                   | `false`     |
-| `disabled`                   | `disabled`                     | (optional) Whether the input is disabled.                     | `boolean`                                                                   | `undefined` |
-| `errorText`                  | `error-text`                   | (optional) The input's error state text.                      | `string`                                                                    | `undefined` |
-| `helperText`                 | `helper-text`                  | (optional) The input's helper text displayed below the input. | `string`                                                                    | `undefined` |
-| `includePasswordTextTog gle` | `include-password-text-toggle` | (optional) Whether the password text toggle icon is included. | `boolean`                                                                   | `true`      |
-| `includeSearchIcon`          | `include-search-icon`          | (optional) Whether the search icon is included.               | `boolean`                                                                   | `undefined` |
-| `inputmode`                  | `inputmode`                    | (optional) The input's inputmode.                             | `"decimal" \| "email" \| "numeric" \| "search" \| "tel" \| "text" \| "url"` | `undefined` |
-| `label`                      | `label`                        | (optional) The input's label.                                 | `string`                                                                    | `undefined` |
-| `maxLength`                  | `max-length`                   | (optional) The input's maximum length.                        | `number`                                                                    | `undefined` |
-| `minLength`                  | `min-length`                   | (optional) The input's minimum length.                        | `number`                                                                    | `undefined` |
-| `placeholder`                | `placeholder`                  | (optional) The input's placeholder text.                      | `string`                                                                    | `undefined` |
-| `readOnly`                   | `read-only`                    | (optional) Whether the input's content is read-only           | `boolean`                                                                   | `undefined` |
-| `required`                   | `required`                     | (optional) Whether the input is required.                     | `boolean`                                                                   | `undefined` |
-| `size`                       | `size`                         | (optional) The input's size.                                  | `"large" \| "medium"`                                                       | `'medium'`  |
-| `type`                       | `type`                         | (optional) The input's type.                                  | `"password" \| "text"`                                                      | `'text'`    |
-| `validText`                  | `valid-text`                   | (optional) The input's valid state text.                      | `string`                                                                    | `undefined` |
-| `value`                      | `value`                        | (optional) The input's value.                                 | `string`                                                                    | `undefined` |
+| Property                    | Attribute                      | Description                                                   | Type                                                                        | Default     |
+| --------------------------- | ------------------------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------- |
+| `ariaLabel`                 | `aria-label`                   | (optional) The input's aria-label.                            | `string`                                                                    | `undefined` |
+| `autoFocusInput`            | `auto-focus-input`             | (optional) Sets autofocus on the input.                       | `boolean`                                                                   | `undefined` |
+| `clearable`                 | `clearable`                    | (optional) Whether the input has a clear button.              | `boolean`                                                                   | `false`     |
+| `disabled`                  | `disabled`                     | (optional) Whether the input is disabled.                     | `boolean`                                                                   | `undefined` |
+| `errorText`                 | `error-text`                   | (optional) The input's error state text.                      | `string`                                                                    | `undefined` |
+| `helperText`                | `helper-text`                  | (optional) The input's helper text displayed below the input. | `string`                                                                    | `undefined` |
+| `includePasswordTextToggle` | `include-password-text-toggle` | (optional) Whether the password text toggle icon is included. | `boolean`                                                                   | `true`      |
+| `includeSearchIcon`         | `include-search-icon`          | (optional) Whether the search icon is included.               | `boolean`                                                                   | `undefined` |
+| `inputmode`                 | `inputmode`                    | (optional) The input's inputmode.                             | `"decimal", "email",  "numeric", "search", "tel", "text", "url"` | `undefined` |
+| `label`                     | `label`                        | (optional) The input's label.                                 | `string`                                                                    | `undefined` |
+| `maxLength`                 | `max-length`                   | (optional) The input's maximum length.                        | `number`                                                                    | `undefined` |
+| `minLength`                 | `min-length`                   | (optional) The input's minimum length.                        | `number`                                                                    | `undefined` |
+| `placeholder`               | `placeholder`                  | (optional) The input's placeholder text.                      | `string`                                                                    | `undefined` |
+| `readOnly`                  | `read-only`                    | (optional) Whether the input's content is read-only           | `boolean`                                                                   | `undefined` |
+| `required`                  | `required`                     | (optional) Whether the input is required.                     | `boolean`                                                                   | `undefined` |
+| `size`                      | `size`                         | (optional) The input's size.                                  | `"large", "medium"`                                                       | `'medium'`  |
+| `textAlign`                 | `text-align`                   | (optional) Set text alignment for the input.                  | `"left", "right"`                                                         | `'left'`    |
+| `type`                      | `type`                         | (optional) The input's type.                                  | `"password", "text"`                                                      | `'text'`    |
+| `validText`                 | `valid-text`                   | (optional) The input's valid state text.                      | `string`                                                                    | `undefined` |
+| `value`                     | `value`                        | (optional) The input's value.                                 |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
@@ -136,6 +136,24 @@ export default {
         type: { summary: "'medium' | 'large'" },
       },
     },
+    textAlign: {
+      name: 'text-align',
+      control: {
+        options: [
+          'left',
+          'right'
+        ],
+        type: 'select',
+      },
+      description: 'text alignment for the input.',
+      table: {
+        defaultValue: { summary: "'left'" },
+        type: {
+          summary:
+            "'left' | 'right'",
+        },
+      },
+    },
     type: {
       control: {
         options: ['text', 'password'],
@@ -192,6 +210,7 @@ const Template = ({
   readOnly,
   required,
   size,
+  textAlign,
   type,
   validText,
   value,
@@ -213,6 +232,7 @@ const Template = ({
     read-only=${readOnly}
     required=${required}
     size=${size}
+    text-align=${textAlign}
     type=${type}
     valid-text=${validText}
     value=${value}></modus-text-input>
@@ -236,6 +256,7 @@ Default.args = {
   readOnly: false,
   required: false,
   size: 'medium',
+  textAlign: 'left',
   type: 'text',
   validText: '',
   value: 'Hello, text input!',


### PR DESCRIPTION
## Description
Add ability to configure the modus-text-input and modus-number-input text alignment to be left or right.

To address this problem I added properties to align right on modus-text-input and modus-number-input, and default this property to be left aligned.  This also allows for the inclusion of center alignment at some point in the future if needed.  The docs and control for modus-text-input and modus-number-input have been updated, as well as the tests.

References #1301 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Manually tested as well as adding jest tests to check for the addition of the new classes and styling.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
