### PR TITLE
Prevent Azure SWA Deploy Preview being deployed when not needed

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -4,19 +4,23 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.vscode/**'
+      - 'angular-workspace/**'
+      - 'react-workspace/**'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - main
 
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
 
 jobs:
   build_and_deploy_job:
     permissions:
-      contents: read  # for actions/checkout to fetch code
-      pull-requests: write  # for Azure/static-web-apps-deploy to comment on PRs
+      contents: read # for actions/checkout to fetch code
+      pull-requests: write # for Azure/static-web-apps-deploy to comment on PRs
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
@@ -39,12 +43,12 @@ jobs:
           skip_deploy_on_missing_secrets: true
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_GROUND_0374A1310 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
-          action: "upload"
+          action: 'upload'
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          skip_app_build: "true"
-          app_location: "/stencil-workspace/storybook/dist/" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "/stencil-workspace/storybook/dist/" # Built app content directory - optional
+          skip_app_build: 'true'
+          app_location: '/stencil-workspace/storybook/dist/' # App source code path
+          api_location: '' # Api source code path - optional
+          output_location: '/stencil-workspace/storybook/dist/' # Built app content directory - optional
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
@@ -56,4 +60,4 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_GROUND_0374A1310 }}
-          action: "close"
+          action: 'close'


### PR DESCRIPTION
## Description

Prevent Azure SWA Deploy Preview being deployed when changes are made to files where it wouldn't affect the Storybook site.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions extension was installed and offers real-time validation of GitHub Actions and reported no issues.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
