### PR TITLE
Fix incorrect data-table row action menu placement when scrolling

### DIFF
--- a/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
+++ b/stencil-workspace/src/components/modus-data-table/modus-data-table.scss
@@ -180,13 +180,11 @@ modus-dropdown {
   }
 
   .list-container {
-    left: 84px;
     position: relative;
-    top: -6px;
 
     .items-container {
       display: inline-block;
-      position: fixed;
+      position: sticky;
       width: 200px;
 
       .action-item {

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
@@ -27,6 +27,7 @@
     &.visible {
       display: block;
       opacity: 1;
+      overflow: visible;
       visibility: visible;
     }
 


### PR DESCRIPTION
Fix incorrect data-table row action menu placement when scrolling

## Description

Modified the data-table and dropdown components scss files to fix an issue where the row action menu was not appearing in the correct position when the page had been scrolled down. The element had been using `fixed` positioning without a `top` property so was calculating `top` based on position from the top of the page, meaning, when a scrollbar was present this value was larger than the viewport. 

We have noticed this issue in VfP where we use infinite scroll to populate the table rather than pagination.

References #1416 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In the stencil test harness I added a fixed height `div` above a data table to force a scroll bar (see gif in linked issue).

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas [Not applicable]
- [X] I have made corresponding changes to the documentation [Not applicable]
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works [Not applicable]
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules [Not applicable]
- [X] I have checked my code and corrected any misspellings
