### PR TITLE
Update Modus Tooltip Storybook page to add `disabled` control

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-tooltip/modus-tooltip.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-tooltip/modus-tooltip.stories.tsx
@@ -12,6 +12,12 @@ export default {
         type: { summary: 'string' },
       },
     },
+    disabled: {
+      description: "Hide the tooltip",
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
     position: {
       control: {
         options: ['bottom', 'left', 'right', 'top'],
@@ -45,17 +51,20 @@ export default {
 export const Default = ({
   ariaLabel,
   position,
-  text
+  text,
+  disabled
 }) => html`
   <modus-tooltip
     aria-label=${ariaLabel}
     position=${position}
-    text=${text}>
+    text=${text}
+    disabled=${disabled}>
     <modus-button>Button</modus-button>
   </modus-tooltip>
 `;
 Default.args = {
   ariaLabel: '',
   position: 'bottom',
-  text: 'Tooltip text...'
+  text: 'Tooltip text...',
+  disabled: false
 };


### PR DESCRIPTION
## Description

Add the missing `disabled` in controls tab in Storybook page for Modus Tooltip

Preview: 

Note: Might fix https://github.com/trimble-oss/modus-web-components/issues/1303

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
