### PR TITLE
Remove duplicate `ModusNavbarProfileMenuLink` export

### DIFF
--- a/stencil-workspace/src/interfaces.d.ts
+++ b/stencil-workspace/src/interfaces.d.ts
@@ -1,7 +1,6 @@
 export { Components, JSX } from './components';
 export { Crumb } from './components/modus-breadcrumb/modus-breadcrumb';
 export { ModusNavbarApp } from './components/modus-navbar/apps-menu/modus-navbar-apps-menu';
-export { ModusNavbarProfileMenuLink } from './components/modus-navbar/profile-menu/modus-navbar-profile-menu';
 export * from './components/modus-data-table/modus-data-table.models';
 export { ModusAutocompleteOption } from './components/modus-autocomplete/modus-autocomplete';
 export { ModusSideNavigationItemInfo } from './components/modus-side-navigation/modus-side-navigation.models';
@@ -11,6 +10,6 @@ export {
   ModusNavbarTooltip,
   ModusNavbarProfileMenuLink,
   ModusProfileMenuOptions,
-  ModusNavbarLogo, 
-  ModusNavbarLogoOptions
+  ModusNavbarLogo,
+  ModusNavbarLogoOptions,
 } from './components/modus-navbar/modus-navbar.models';


### PR DESCRIPTION
### Root cause: 
Duplicate interface export is causing the below build error in Angular components,

Error: [node_modules/@trimble-oss/modus-web-components/dist/types/interfaces.d.ts:4:10](mailto:node_modules/@trimble-oss/modus-web-components/dist/types/interfaces.d.ts:4:10) - error TS2300: Duplicate identifier 'ModusNavbarProfileMenuLink'.

4 export { ModusNavbarProfileMenuLink } from './components/modus-navbar/profile-menu/modus-navbar-profile-menu';

### Fix: 
Remove the duplicate export.

References #1427 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
