### PR TITLE
Modus Table(with tanstack) - Column resize - Column header background color not rendering after column resize fixes

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.spec.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.spec.tsx
@@ -10,7 +10,7 @@ describe('modus-table', () => {
     expect(root).toEqualHtml(`
       <modus-table>
         <mock:shadow-root>
-          <table class="false" style="width: 100%">
+          <table class="false" style="width: 0px; table-layout: fixed;">
             <thead>
               <tr>
               </tr>

--- a/stencil-workspace/src/components/modus-table/parts/header/modus-table-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/header/modus-table-header.tsx
@@ -16,9 +16,12 @@ interface ModusTableHeaderProps {
 /**
  * Modus Table Header
  */
-export const ModusTableHeader: FunctionalComponent<
-  ModusTableHeaderProps
-> = ({ table, header, isNestedParentHeader, showSortIconOnHover }) => {
+export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
+  table,
+  header,
+  isNestedParentHeader,
+  showSortIconOnHover,
+}) => {
   return (
     <th
       key={header.id}
@@ -27,7 +30,11 @@ export const ModusTableHeader: FunctionalComponent<
         ${isNestedParentHeader ? 'text-align-center' : ''}
         ${header.column.getIsResizing() ? 'active-resize' : ''}
       `}
-      style={{ width: `${header.getSize()}px` }}
+      // The column sizing indicator (blue border right line) is left with a white shadow after being resized.
+      // It appears to have been incorrectly rendered.
+      // So deducting a minute amount from the width of the header column in order to render the component
+      // and the view is thus unaffected by this fix.
+      style={{ width: `${header.column.getIsResizing() ? header.getSize() : header.getSize() - 0.001}px` }}
       aria-label={header.column.columnDef.header}
       role="columnheader"
       scope="col">
@@ -35,10 +42,7 @@ export const ModusTableHeader: FunctionalComponent<
         <div class={header.column.getCanSort() && 'can-sort'}>
           <span>{header.column.columnDef.header}</span>
           {header.column.getCanSort() && (
-            <ModusTableHeaderSort
-              column={header.column}
-              showSortIconOnHover={showSortIconOnHover}
-            />
+            <ModusTableHeaderSort column={header.column} showSortIconOnHover={showSortIconOnHover} />
           )}
         </div>
       )}


### PR DESCRIPTION
## Description

Column header background color not rendering after column resize fixes

References [#1467](https://github.com/trimble-oss/modus-web-components/issues/1467)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
