### PR TITLE
Added support for slot in Modus Alert

### DIFF
--- a/stencil-workspace/src/components/modus-alert/modus-alert.e2e.ts
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.e2e.ts
@@ -28,12 +28,12 @@ describe('modus-alert', () => {
 
     await page.setContent('<modus-alert message="Hello"></modus-alert>');
     const component = await page.find('modus-alert');
-    let element = await page.find('modus-alert >>> div.message');
-    expect(element.innerHTML).toEqual('Hello');
+    const element = await page.find('modus-alert >>> div.message');
+    expect(element.innerHTML).toContain('Hello');
 
     component.setProperty('message', 'Hello world!');
     await page.waitForChanges();
-    expect(element.innerHTML).toEqual('Hello world!');
+    expect(element.innerHTML).toContain('Hello world!');
   });
 
   it('renders changes to the type prop', async () => {
@@ -41,7 +41,7 @@ describe('modus-alert', () => {
 
     await page.setContent('<modus-alert></modus-alert>');
     const component = await page.find('modus-alert');
-    let element = await page.find('modus-alert >>> div.alert');
+    const element = await page.find('modus-alert >>> div.alert');
     expect(element).toHaveClass('type-info');
 
     component.setProperty('type', 'error');

--- a/stencil-workspace/src/components/modus-alert/modus-alert.scss
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.scss
@@ -16,6 +16,13 @@ div.alert {
     border-color: $modus-alert-danger-border-color;
     color: $modus-alert-danger-color;
 
+    // Note - ::slotted targets only the first level elements. Although nested text nodes are receiving the styles, the nested anchor links are not functioning properly.
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted
+    // https://stackoverflow.com/questions/61626493/slotted-css-selector-for-nested-children-in-shadowdom-slot
+    ::slotted(a) {
+      color: $modus-alert-danger-link-color;
+    }
+
     .icon-check-circle,
     .icon-error,
     .icon-info,
@@ -30,6 +37,10 @@ div.alert {
     background-color: $modus-alert-primary-bg;
     border-color: $modus-alert-primary-border-color;
     color: $modus-alert-primary-color;
+
+    ::slotted(a) {
+      color: $modus-alert-primary-link-color;
+    }
 
     .icon-check-circle,
     .icon-error,
@@ -46,6 +57,10 @@ div.alert {
     border-color: $modus-alert-secondary-border-color;
     color: $modus-alert-secondary-color;
 
+    ::slotted(a) {
+      color: $modus-alert-secondary-link-color;
+    }
+
     .icon-check-circle,
     .icon-error,
     .icon-info,
@@ -60,6 +75,10 @@ div.alert {
     background-color: $modus-alert-dark-bg;
     border-color: $modus-alert-dark-border-color;
     color: $modus-alert-dark-color;
+
+    ::slotted(a) {
+      color: $modus-alert-dark-link-color;
+    }
 
     .icon-check-circle,
     .icon-error,
@@ -76,6 +95,10 @@ div.alert {
     border-color: $modus-alert-success-border-color;
     color: $modus-alert-success-color;
 
+    ::slotted(a) {
+      color: $modus-alert-success-link-color;
+    }
+
     .icon-check-circle,
     .icon-error,
     .icon-info,
@@ -90,6 +113,10 @@ div.alert {
     background-color: $modus-alert-warning-bg;
     border-color: $modus-alert-warning-border-color;
     color: $modus-alert-warning-color;
+
+    ::slotted(a) {
+      color: $modus-alert-warning-link-color;
+    }
 
     .icon-check-circle,
     .icon-error,

--- a/stencil-workspace/src/components/modus-alert/modus-alert.spec.ts
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.spec.ts
@@ -11,7 +11,9 @@ describe('modus-alert', () => {
       <modus-alert type='none'>
         <mock:shadow-root>
           <div class='alert undefined' role="alert" tabindex="0">
-            <div class='message'></div>
+            <div class='message'>
+            <slot></slot>
+            </div>
           </div>
         </mock:shadow-root>
       </modus-alert>

--- a/stencil-workspace/src/components/modus-alert/modus-alert.tsx
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.tsx
@@ -61,7 +61,11 @@ export class ModusAlert {
         {this.infoTypes.includes(this.type) ? <IconInfo size={iconSize} /> : null}
         {this.type === 'success' ? <IconCheckCircle size={iconSize} /> : null}
         {this.type === 'warning' ? <IconWarning size={iconSize} /> : null}
-        <div class="message">{this.message}</div>
+        <div class="message">
+          {this.message}
+          <slot></slot>
+        </div>
+
         {this.dismissible ? <IconClose size="18" onClick={() => this.dismissClick.emit()} /> : null}
       </div>
     );

--- a/stencil-workspace/src/components/modus-alert/modus-alert.vars.scss
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.vars.scss
@@ -14,6 +14,14 @@ $modus-alert-success-color: var(--modus-alert-success-color, #006638) !default;
 $modus-alert-danger-color: var(--modus-alert-danger-color, #da212c) !default;
 $modus-alert-warning-color: var(--modus-alert-warning-color, #252a2e) !default;
 
+// link color
+$modus-alert-primary-link-color: var(--modus-alert-primary-link-color, #003b61) !default;
+$modus-alert-secondary-link-color: var(--modus-alert-secondary-link-color, #4b4e56) !default;
+$modus-alert-dark-link-color: var(--modus-alert-dark-link-color, #070809) !default;
+$modus-alert-success-link-color: var(--modus-alert-success-link-color, #002414) !default;
+$modus-alert-danger-link-color: var(--modus-alert-danger-link-color, #a01820) !default;
+$modus-alert-warning-link-color: var(--modus-alert-warning-link-color, #b16f16) !default;
+
 // Border color
 $modus-alert-primary-border-color: var(--modus-alert-primary-border-color, #0063a3) !default;
 $modus-alert-secondary-border-color: var(--modus-alert-secondary-border-color, #6a6e79) !default;

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -90,6 +90,14 @@
   --modus-alert-danger-color: var(--modus-danger);
   --modus-alert-warning-color: var(--modus-gray-10);
 
+  // Links
+  --modus-alert-primary-link-color: #003b61;
+  --modus-alert-secondary-link-color: #4b4e56;
+  --modus-alert-dark-link-color: #070809;
+  --modus-alert-success-link-color: #002414;
+  --modus-alert-danger-link-color: #a01820;
+  --modus-alert-warning-link-color: #070809;
+
   // Border
   --modus-alert-primary-border-color: var(--modus-primary);
   --modus-alert-secondary-border-color: var(--modus-gray-6);
@@ -416,6 +424,14 @@
   --modus-alert-success-color: var(--modus-body-color);
   --modus-alert-danger-color: var(--modus-body-color);
   --modus-alert-warning-color: var(--modus-body-color);
+
+  // Links
+  --modus-alert-primary-link-color: #c9c9dc;
+  --modus-alert-secondary-link-color: #c9c9dc;
+  --modus-alert-dark-link-color: #c9c9dc;
+  --modus-alert-success-link-color: #c9c9dc;
+  --modus-alert-danger-link-color: #c9c9dc;
+  --modus-alert-warning-link-color: #c9c9dc;
 
   // Border
   --modus-alert-primary-border-color: var(--modus-primary);

--- a/stencil-workspace/storybook/public/storybook-styles.css
+++ b/stencil-workspace/storybook/public/storybook-styles.css
@@ -103,7 +103,7 @@ hr {
   opacity: 0.8;
 }
 
-body .sbdocs a {
+body .sbdocs-a {
   color: var(--theme-sbdocs-link-color) !important;
 }
 

--- a/stencil-workspace/storybook/stories/components/modus-alert/modus-alert-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-alert/modus-alert-storybook-docs.mdx
@@ -1,4 +1,4 @@
-import { Anchor } from '@storybook/addon-docs';
+import { Anchor, Story } from '@storybook/addon-docs';
 
 # Alert
 
@@ -48,6 +48,15 @@ import { Anchor } from '@storybook/addon-docs';
 
 <modus-alert message="Warning alert" type="warning"></modus-alert>
 
+<Anchor storyId="components-alert--with-link" />
+
+### Alert with Link
+
+By using the `slot`, it is possible to add a link in the message. Note: To color the inner nested anchor tags, it is recommended to use CSS variables such as `--modus-alert-<variant>-link-color`, due to the limitations of `slot` elements.
+
+
+<Story id="components-alert--with-link" />
+
 ```html
 <modus-alert message="Info alert (default)"></modus-alert>
 <modus-alert dismissible message="Dismissible alert"></modus-alert>
@@ -56,6 +65,9 @@ import { Anchor } from '@storybook/addon-docs';
 <modus-alert message="Info gray dark alert" type="info-gray-dark"></modus-alert>
 <modus-alert message="Success alert" type="success"></modus-alert>
 <modus-alert message="Warning alert" type="warning"></modus-alert>
+<modus-alert type="info">
+  This is a info alert with <a href="#" class="alert-link">an example link</a>
+</modus-alert>
 ```
 
 ### Properties

--- a/stencil-workspace/storybook/stories/components/modus-alert/modus-alert.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-alert/modus-alert.stories.tsx
@@ -81,6 +81,7 @@ Default.args = {
   type: 'info',
 };
 
+
 export const Dismissible = Template.bind({});
 Dismissible.args = {
   ariaLabel: '',
@@ -127,4 +128,24 @@ Warning.args = {
   dismissible: false,
   message: 'Warning alert',
   type: 'warning',
+};
+
+
+const TemplateWithLink = ({ ariaLabel, dismissible, message, type }) =>
+  html`
+    <modus-alert
+      ariaLabel=${ariaLabel}
+      dismissible=${dismissible}
+      message=${message}
+      type=${type}>
+      This is a info alert with <a href="#" class="alert-link">an example link</a>
+    </modus-alert>
+  `;
+
+export const WithLink = TemplateWithLink.bind({});
+WithLink.args = {
+  ariaLabel: '',
+  dismissible: false,
+  type: 'info',
+  message: null,
 };

--- a/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table-storybook-docs.mdx
@@ -2,7 +2,7 @@ import { Story } from '@storybook/addon-docs';
 
 # Data Table
 
-<modus-alert type="warning" message="This component is under construction!"></modus-alert>
+  <modus-alert type="warning" message="This component will be deprecated soon and replaced by a new Table component!"> Check our open <a href="https://github.com/trimble-oss/modus-web-components/issues?q=is%3Aopen+is%3Aissue+label%3Adata-table" target="_blank" rel="noopener">GitHub issues</a>.</modus-alert>
 
 ---
 


### PR DESCRIPTION
Fixes #1500 

It's essential to offer users the option to include custom message content, such as adding a hyperlink to the message, as shown in Modus Bootstrap and Modus React Bootstrap.

Preview: https://icy-ground-0374a1310-1491.centralus.1.azurestaticapps.net/?path=/story/components-alert--with-link

### :loudspeaker: Also added a deprecation warning to the [Modus Data Table](https://icy-ground-0374a1310-1491.centralus.1.azurestaticapps.net/?path=/docs/components-data-table--default) component using Alert's slot

![image](https://github.com/trimble-oss/modus-web-components/assets/50131391/ba37631b-c827-4865-b4a9-cb0cfdbebd26)

No issue is attached.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
