### PR TITLE
Release v0146 for React and Angular

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/package-lock.json
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-angular-components",
-  "version": "0.1.45-ng14",
+  "version": "0.1.46-ng14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-angular-components",
-      "version": "0.1.45-ng14",
+      "version": "0.1.46-ng14",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.5.3"
@@ -17,7 +17,7 @@
       "peerDependencies": {
         "@angular/common": "^14.1.1",
         "@angular/core": "^14.1.1",
-        "@trimble-oss/modus-web-components": "0.1.45"
+        "@trimble-oss/modus-web-components": "0.1.46"
       }
     },
     "node_modules/@angular/common": {
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.45.tgz",
-      "integrity": "sha512-3iLz/oB0fKm8M4MVq1ERJtI6ZZnuyB7YmB3Kgp6/RMZMhNreQSnTiIMarA+y8Uh2Dvrw56H5X9V3iuV04SJmvg==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.46.tgz",
+      "integrity": "sha512-XV5jezLLqMPhtB/Vx9u/a86ggGgGg1I+UU6k1YDmWtbGieexsKtwX92Et9qFaHOzMYwgJxTTqAyRbdyFRFI7nA==",
       "peer": true,
       "dependencies": {
         "@stencil/core": "^3.3.0"
@@ -128,9 +128,9 @@
       "peer": true
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.45.tgz",
-      "integrity": "sha512-3iLz/oB0fKm8M4MVq1ERJtI6ZZnuyB7YmB3Kgp6/RMZMhNreQSnTiIMarA+y8Uh2Dvrw56H5X9V3iuV04SJmvg==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.46.tgz",
+      "integrity": "sha512-XV5jezLLqMPhtB/Vx9u/a86ggGgGg1I+UU6k1YDmWtbGieexsKtwX92Et9qFaHOzMYwgJxTTqAyRbdyFRFI7nA==",
       "peer": true,
       "requires": {
         "@stencil/core": "^3.3.0"

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/package.json
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-angular-components",
-  "version": "0.1.45-ng14",
+  "version": "0.1.46-ng14",
   "license": "MIT",
   "description": "Trimble Modus Angular Components Library",
   "homepage": "https://modus-web-components.trimble.com/",
@@ -14,7 +14,7 @@
   "peerDependencies": {
     "@angular/common": "^14.1.1",
     "@angular/core": "^14.1.1",
-    "@trimble-oss/modus-web-components": "0.1.45"
+    "@trimble-oss/modus-web-components": "0.1.46"
   },
   "dependencies": {
     "tslib": "^2.5.3"

--- a/react-workspace/react-17/package-lock.json
+++ b/react-workspace/react-17/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@trimble-oss/modus-react-components",
-  "version": "0.1.45-17",
+  "version": "0.1.46-react17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-react-components",
-      "version": "0.1.45-17",
+      "version": "0.1.46-react17",
       "license": "MIT",
       "dependencies": {
-        "@trimble-oss/modus-web-components": "0.1.45"
+        "@trimble-oss/modus-web-components": "0.1.46"
       },
       "devDependencies": {
         "@types/jest": "23.3.9",
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.45.tgz",
-      "integrity": "sha512-3iLz/oB0fKm8M4MVq1ERJtI6ZZnuyB7YmB3Kgp6/RMZMhNreQSnTiIMarA+y8Uh2Dvrw56H5X9V3iuV04SJmvg==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.46.tgz",
+      "integrity": "sha512-XV5jezLLqMPhtB/Vx9u/a86ggGgGg1I+UU6k1YDmWtbGieexsKtwX92Et9qFaHOzMYwgJxTTqAyRbdyFRFI7nA==",
       "dependencies": {
         "@stencil/core": "^3.3.0"
       },
@@ -4758,9 +4758,9 @@
       "integrity": "sha512-I+660Oe9OMLiU+thjV1GgcI27dcvrSpF3xisHWBOU/4mzRtho3YW0cI8lSjcqyB1KirGTA6QeQ0Xif5UHqn8hw=="
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.45.tgz",
-      "integrity": "sha512-3iLz/oB0fKm8M4MVq1ERJtI6ZZnuyB7YmB3Kgp6/RMZMhNreQSnTiIMarA+y8Uh2Dvrw56H5X9V3iuV04SJmvg==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.46.tgz",
+      "integrity": "sha512-XV5jezLLqMPhtB/Vx9u/a86ggGgGg1I+UU6k1YDmWtbGieexsKtwX92Et9qFaHOzMYwgJxTTqAyRbdyFRFI7nA==",
       "requires": {
         "@stencil/core": "^3.3.0"
       }

--- a/react-workspace/react-17/package.json
+++ b/react-workspace/react-17/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-react-components",
-  "version": "0.1.45-17",
+  "version": "0.1.46-react17",
   "description": "Trimble Modus React Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@trimble-oss/modus-web-components": "0.1.45"
+    "@trimble-oss/modus-web-components": "0.1.46"
   },
   "devDependencies": {
     "@types/jest": "23.3.9",

--- a/react-workspace/react-18/package-lock.json
+++ b/react-workspace/react-18/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@trimble-oss/modus-react-components",
-  "version": "0.1.45-18",
+  "version": "0.1.46-react18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-react-components",
-      "version": "0.1.45-18",
+      "version": "0.1.46-react18",
       "license": "MIT",
       "dependencies": {
-        "@trimble-oss/modus-web-components": "0.1.45"
+        "@trimble-oss/modus-web-components": "0.1.46"
       },
       "devDependencies": {
         "@types/jest": "23.3.14",
@@ -973,9 +973,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.45.tgz",
-      "integrity": "sha512-3iLz/oB0fKm8M4MVq1ERJtI6ZZnuyB7YmB3Kgp6/RMZMhNreQSnTiIMarA+y8Uh2Dvrw56H5X9V3iuV04SJmvg==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.46.tgz",
+      "integrity": "sha512-XV5jezLLqMPhtB/Vx9u/a86ggGgGg1I+UU6k1YDmWtbGieexsKtwX92Et9qFaHOzMYwgJxTTqAyRbdyFRFI7nA==",
       "dependencies": {
         "@stencil/core": "^3.3.0"
       },
@@ -4807,9 +4807,9 @@
       "integrity": "sha512-kEtPtV6QegME8YgMjWrhS7KktItbhqOpAuK9aXypDdI/7bLU9iM/4DtnQGWY/DARBophk+XRBfNXcE62Bmi0dw=="
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.1.45",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.45.tgz",
-      "integrity": "sha512-3iLz/oB0fKm8M4MVq1ERJtI6ZZnuyB7YmB3Kgp6/RMZMhNreQSnTiIMarA+y8Uh2Dvrw56H5X9V3iuV04SJmvg==",
+      "version": "0.1.46",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.1.46.tgz",
+      "integrity": "sha512-XV5jezLLqMPhtB/Vx9u/a86ggGgGg1I+UU6k1YDmWtbGieexsKtwX92Et9qFaHOzMYwgJxTTqAyRbdyFRFI7nA==",
       "requires": {
         "@stencil/core": "^3.3.0"
       }

--- a/react-workspace/react-18/package.json
+++ b/react-workspace/react-18/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-react-components",
-  "version": "0.1.45-18",
+  "version": "0.1.46-react18",
   "description": "Trimble Modus React Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {
@@ -33,7 +33,7 @@
     ]
   },
   "dependencies": {
-    "@trimble-oss/modus-web-components": "0.1.45"
+    "@trimble-oss/modus-web-components": "0.1.46"
   },
   "devDependencies": {
     "@types/jest": "23.3.14",


### PR DESCRIPTION
- Version bumps for MWC from `"0.1.45"` to `"0.1.46"`
- React Component Library now has suffix react17 or react18 (instead of just 17 or 18)