### PR TITLE
Fix for npm publish steps GH Action

### DIFF
--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -8,6 +8,7 @@ on:
         options:
           - '14'
           - '15'
+          - '16'
         description: The version of Angular you want to build
 
 permissions:
@@ -39,6 +40,12 @@ jobs:
 
       - name: Build Angular ${{ github.event.inputs.angularVersion }}
         run: npm run build
+
+      - name: Change directory
+        run: cd projects/trimble-oss/modus-angular-components
+
+      - name: npm install
+        run: npm i
 
       - name: Change directory
         run: cd dist/trimble-oss/modus-angular-components

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "author": "Trimble Inc",
   "scripts": {
     "prettier": "npx prettier --write \"**/*.*\"",
-    "update-mwc-dependants": "cd angular-workspace/ng14/projects/trimble-oss/modus-angular-components && ncu -u --dep peer @trimble-oss* && npm i && cd ../../../../ng15/projects/trimble-oss/modus-angular-components && ncu -u --dep peer @trimble-oss* && npm i && cd ../../../../../react-workspace/react-17 && ncu -u @trimble-oss* && npm i && cd ../react-18 && ncu -u @trimble-oss* && npm i"
+    "update-mwc-dependants": "cd angular-workspace/ng14/projects/trimble-oss/modus-angular-components && ncu -u --dep peer @trimble-oss* && npm i && cd ../../../../ng15/projects/trimble-oss/modus-angular-components && ncu -u --dep peer @trimble-oss* && npm i && cd ../../../../ng16/projects/trimble-oss/modus-angular-components && ncu -u --dep peer @trimble-oss* && npm i && cd ../../../../../react-workspace/react-17 && ncu -u @trimble-oss* && npm i && cd ../react-18 && ncu -u @trimble-oss* && npm i"
   },
   "engines": {
-    "node": ">=14.20.0"
+    "node": ">=16.14.0"
   }
 }


### PR DESCRIPTION
This PR

- GitHub Action was failing (see logs: https://github.com/trimble-oss/modus-web-components/actions/workflows/publish-angular.yml) because we need to change directory and run npm install
- Modifies the script in the root `package.json` to update version numbers of MWC in all 5 packages.