### PR TITLE
Added functionality to make first column sticky

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -20,7 +20,8 @@
 }
 
 table {
-  border-collapse: collapse;
+  border-collapse: separate; // Sticky table cells lose their border when used with `border-collapse:collapse`.
+  border-spacing: 0; // Set `border-collapse: separate` and `border-spacing: 0` to resolve the problem metion in above line.
   font-family: $primary-font;
   font-size: $rem-14px;
   width: 100%;
@@ -28,14 +29,15 @@ table {
   thead {
     position: sticky;
     top: 0;
+    z-index: 2;
 
     tr {
-      background-color: $modus-table-header-bg;
-      box-shadow: inset 0 -0.5px 0 $modus-table-border-color;
       color: $modus-table-header-color;
 
       th {
+        background-color: $modus-table-header-bg;
         border-right: $rem-1px $modus-table-border-color solid;
+        box-shadow: inset 0 -0.5px 0 $modus-table-border-color;
         font-weight: $font-weight-semi-bold;
         overflow: hidden;
         padding: $rem-8px $rem-8px $rem-8px $rem-16px;
@@ -147,10 +149,10 @@ table {
     }
 
     tr {
-      background-color: $modus-table-body-bg;
       color: $modus-table-body-color;
 
       td {
+        background-color: $modus-table-body-bg;
         border-top: $rem-1px $modus-table-border-color solid;
 
         .table-cell {
@@ -189,7 +191,9 @@ table {
 
       &.enable-hover {
         &:hover {
-          background-color: $modus-table-hover-bg;
+          td {
+            background-color: $modus-table-hover-bg;
+          }
         }
       }
     }
@@ -201,6 +205,7 @@ table {
         bottom: 0;
         box-shadow: 1px -1px $modus-table-border-color;
         position: sticky;
+        z-index: 1;
 
         td {
           background-color: $modus-table-header-bg;
@@ -232,6 +237,13 @@ table {
 
       &.text-align-center {
         text-align: center;
+      }
+
+      &.sticky-left {
+        left: 0;
+        position: sticky;
+        z-index: 1;
+        border-right: $rem-2px $modus-table-border-color solid;
       }
     }
   }

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -28,7 +28,7 @@ import {
   getCoreRowModel,
   getExpandedRowModel,
   getPaginationRowModel,
-  getSortedRowModel
+  getSortedRowModel,
 } from '@tanstack/table-core';
 import { DefaultPageSizes } from './constants/constants';
 import { ModusTableSortingState } from './models';
@@ -104,6 +104,9 @@ export class ModusTable {
   /** (Optional) To display a panel options, which allows access to table operations like hiding columns. */
   @Prop() panelOptions: ModusTablePanelOptions | null = null;
   @Watch('panelOptions') onChangePanelOptions() {
+    if (this.table) {
+      this.table.options.enableHiding = !!this.panelOptions?.columnsVisibility;
+    }
     this.onChangeOfRowsExpandable();
   }
 
@@ -165,7 +168,7 @@ export class ModusTable {
   @State() itemDragState: ColumnDragState;
   @State() dragAndDropObj: TableHeaderDragDrop = new TableHeaderDragDrop();
 
-  private frozenColumns: string[] = [];
+  private frozenColumns: string[] = []; // Columns will remain on the left and be unable to resize, reorganize, or modify their visibility.
   /** Column reorder variables start */
   private tableHeaderRowRef: HTMLTableRowElement;
   private columnResizeEnabled = false;
@@ -448,6 +451,7 @@ export class ModusTable {
                             row={row}
                             cellIndex={cellIndex}
                             rowsExpandable={this.rowsExpandable}
+                            frozenColumns={this.frozenColumns}
                             onLinkClick={(link: ModusTableCellLink) => this.cellLinkClick.emit(link)}
                           />
                         );
@@ -461,6 +465,7 @@ export class ModusTable {
                   footerGroups={[footerGroups[0]]}
                   tableData={this.data}
                   borderlessOptions={this.displayOptions}
+                  frozenColumns={this.frozenColumns}
                 />
               ) : (
                 ''

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
@@ -14,6 +14,7 @@ interface ModusTableCellProps {
   row: Row<unknown>;
   cellIndex: number;
   rowsExpandable: boolean;
+  frozenColumns: string[];
   onLinkClick: (link: ModusTableCellLink) => void;
 }
 
@@ -22,12 +23,14 @@ export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({
   row,
   cellIndex,
   rowsExpandable,
+  frozenColumns,
   onLinkClick,
 }) => {
   return (
     <td
       key={cell.id}
       class={`
+          ${frozenColumns.includes(cell.column.id) ? 'sticky-left' : ''}
           ${cell.column.getIsResizing() ? 'active-resize' : ''}
       `}
       style={{ width: `${cell.column.getSize()}px` }}>

--- a/stencil-workspace/src/components/modus-table/parts/header/modus-table-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/header/modus-table-header.tsx
@@ -44,9 +44,17 @@ export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
       tabindex={`${!columnResizeEnabled && columnReorder ? '0' : ''}`}
       key={header.id}
       colSpan={header.colSpan}
+      /**
+       * isNestedParentHeader: If parent in nested headers, `text-align: center` will be applied.
+       * frozenColumns.includes(header.id): Checks if the header is to be frozen or not.
+       * columnReorder && !frozenColumns.includes(header.id) && !columnResizeEnabled: Allows column reorder when column in not frozen and column resize is not active/underway.
+       * columnResizeEnabled: If column resize is active, resize curser is displayed.
+       * header.column.getIsResizing(): When a column resize is active/underway.
+       */
       class={`
         ${isNestedParentHeader ? 'text-align-center' : ''}
-        ${!columnResizeEnabled && columnReorder ? (frozenColumns.includes(header.id) ? '' : 'can-reorder') : ''}
+        ${frozenColumns.includes(header.id) ? 'sticky-left' : ''}
+        ${columnReorder && !frozenColumns.includes(header.id) && !columnResizeEnabled ? 'can-reorder' : ''}
         ${columnResizeEnabled ? 'show-resize-cursor' : ''}
         ${header.column.getIsResizing() ? 'active-resize' : ''}
       `}

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-summary-row.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-summary-row.tsx
@@ -11,6 +11,7 @@ interface ModusTableSummaryRowProps {
   footerGroups: HeaderGroup<unknown>[];
   tableData: unknown[];
   borderlessOptions: ModusTableDisplayOptions;
+  frozenColumns: string[];
 }
 
 function calculateSum(tableData: unknown[], header: Header<unknown, unknown>): number | string {
@@ -23,6 +24,7 @@ export const ModusTableSummaryRow: FunctionalComponent<ModusTableSummaryRowProps
   footerGroups,
   tableData,
   borderlessOptions,
+  frozenColumns,
 }) => {
   const borderLessTableStyle = (borderlessOptions?.cellBorderless || borderlessOptions?.borderless) && { boxShadow: 'none' };
   return (
@@ -32,9 +34,10 @@ export const ModusTableSummaryRow: FunctionalComponent<ModusTableSummaryRowProps
           {group.headers.map((header) => (
             <td
               key={header.id}
-              class={
-                header.column.columnDef[PropertyDataType] === ModusTableColumnDataType.Integer ? 'text-align-right' : ''
-              }>
+              class={`
+                ${frozenColumns.includes(header.id) ? 'sticky-left' : ''}
+                ${header.column.columnDef[PropertyDataType] === ModusTableColumnDataType.Integer ? 'text-align-right' : ''}
+              `}>
               {header.column.columnDef[PropertyShowTotal] ? calculateSum(tableData, header) : header.column.columnDef.footer}
             </td>
           ))}


### PR DESCRIPTION
## Description
If the expanded column functionality and scroll are set to true, the first column will be sticking to the left.

References #1593 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
