### PR TITLE
Add support for Icon(s) in Modus Button component

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -174,7 +174,7 @@ export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'size'],
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'showCaret', 'size'],
   methods: ['focusButton']
 })
 @Component({
@@ -182,7 +182,7 @@ export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'size'],
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'showCaret', 'size'],
 })
 export class ModusButton {
   protected el: HTMLElement;

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -174,7 +174,7 @@ export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'size'],
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'size'],
   methods: ['focusButton']
 })
 @Component({
@@ -182,7 +182,7 @@ export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'size'],
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'size'],
 })
 export class ModusButton {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -204,6 +204,10 @@ export namespace Components {
          */
         "rightIcon": string;
         /**
+          * (optional) Shows a caret icon right side of the button.
+         */
+        "showCaret": boolean;
+        /**
           * (optional) The size of the button.
          */
         "size": 'small' | 'medium' | 'large';
@@ -1852,6 +1856,10 @@ declare namespace LocalJSX {
           * (optional) Takes the icon name and shows the icon aligned to the right of the button text.
          */
         "rightIcon"?: string;
+        /**
+          * (optional) Shows a caret icon right side of the button.
+         */
+        "showCaret"?: boolean;
         /**
           * (optional) The size of the button.
          */

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -180,9 +180,9 @@ export namespace Components {
          */
         "buttonStyle": 'borderless' | 'fill' | 'outline';
         /**
-          * (optional) The color of the button. Note: `dark` is supported only on icon-only buttons.
+          * (optional) The color of the button
          */
-        "color": 'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark';
+        "color": 'danger' | 'primary' | 'secondary' | 'tertiary';
         /**
           * (optional) Disables the button.
          */
@@ -1829,9 +1829,9 @@ declare namespace LocalJSX {
          */
         "buttonStyle"?: 'borderless' | 'fill' | 'outline';
         /**
-          * (optional) The color of the button. Note: `dark` is supported only on icon-only buttons.
+          * (optional) The color of the button
          */
-        "color"?: 'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark';
+        "color"?: 'danger' | 'primary' | 'secondary' | 'tertiary';
         /**
           * (optional) Disables the button.
          */

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -180,9 +180,9 @@ export namespace Components {
          */
         "buttonStyle": 'borderless' | 'fill' | 'outline';
         /**
-          * (optional) The color of the button.
+          * (optional) The color of the button. Note: `dark` is supported only on icon-only buttons.
          */
-        "color": 'danger' | 'primary' | 'secondary' | 'tertiary';
+        "color": 'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark';
         /**
           * (optional) Disables the button.
          */
@@ -191,6 +191,18 @@ export namespace Components {
           * Focus the Button
          */
         "focusButton": () => Promise<void>;
+        /**
+          * (optional) Takes the icon name and renders an icon-only button.
+         */
+        "iconOnly": string;
+        /**
+          * (optional) Takes the icon name and shows the icon aligned to the left of the button text.
+         */
+        "leftIcon": string;
+        /**
+          * (optional) Takes the icon name and shows the icon aligned to the right of the button text.
+         */
+        "rightIcon": string;
         /**
           * (optional) The size of the button.
          */
@@ -1817,17 +1829,29 @@ declare namespace LocalJSX {
          */
         "buttonStyle"?: 'borderless' | 'fill' | 'outline';
         /**
-          * (optional) The color of the button.
+          * (optional) The color of the button. Note: `dark` is supported only on icon-only buttons.
          */
-        "color"?: 'danger' | 'primary' | 'secondary' | 'tertiary';
+        "color"?: 'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark';
         /**
           * (optional) Disables the button.
          */
         "disabled"?: boolean;
         /**
+          * (optional) Takes the icon name and renders an icon-only button.
+         */
+        "iconOnly"?: string;
+        /**
+          * (optional) Takes the icon name and shows the icon aligned to the left of the button text.
+         */
+        "leftIcon"?: string;
+        /**
           * (optional) An event that fires on button click.
          */
         "onButtonClick"?: (event: ModusButtonCustomEvent<any>) => void;
+        /**
+          * (optional) Takes the icon name and shows the icon aligned to the right of the button text.
+         */
+        "rightIcon"?: string;
         /**
           * (optional) The size of the button.
          */

--- a/stencil-workspace/src/components/icons/IconMap.tsx
+++ b/stencil-workspace/src/components/icons/IconMap.tsx
@@ -4,6 +4,7 @@ import { IconAdd } from './icon-add';
 import { IconApps } from './icon-apps';
 import { IconCalendar } from './icon-calendar';
 import { IconCancel } from './icon-cancel';
+import { IconCaretDown } from './icon-caret-down';
 import { IconCheck } from './icon-check';
 import { IconCheckCircle } from './icon-check-circle';
 import { IconCheckCircleOutline } from './icon-check-circle-outline';
@@ -61,6 +62,8 @@ export const IconMap: FunctionalComponent<IconMapProps> = (props: IconMapProps) 
       return <IconCalendar color={props.color} onClick={props.onClick} size={props.size} />;
     case 'cancel':
       return <IconCancel color={props.color} onClick={props.onClick} size={props.size} />;
+    case 'caret-down':
+      return <IconCaretDown color={props.color} onClick={props.onClick} size={props.size} />;
     case 'check':
       return <IconCheck color={props.color} onClick={props.onClick} size={props.size} />;
     case 'check-circle':
@@ -104,7 +107,7 @@ export const IconMap: FunctionalComponent<IconMapProps> = (props: IconMapProps) 
     case 'menu':
       return <IconMenu color={props.color} onClick={props.onClick} size={props.size} />;
     case 'notifications':
-      return <IconNotifications color={props.color} onClick={props.onClick} size={props.size} pressed={props.pressed}/>;
+      return <IconNotifications color={props.color} onClick={props.onClick} size={props.size} pressed={props.pressed} />;
     case 'remove':
       return <IconRemove color={props.color} onClick={props.onClick} size={props.size} />;
     case 'search':

--- a/stencil-workspace/src/components/icons/icon-caret-down.tsx
+++ b/stencil-workspace/src/components/icons/icon-caret-down.tsx
@@ -1,0 +1,21 @@
+// eslint-disable-next-line
+import { FunctionalComponent, h } from '@stencil/core';
+
+interface IconProps {
+  color?: string;
+  onClick?: () => void;
+  size?: string;
+}
+
+export const IconCaretDown: FunctionalComponent<IconProps> = (props: IconProps) => (
+  <svg
+    class="icon-caret-down"
+    xmlns="http://www.w3.org/2000/svg"
+    fill={props.color ?? 'currentColor'}
+    height={props.size ?? 16}
+    width={props.size ?? 16}
+    onClick={props.onClick}
+    viewBox="0 0 24 24">
+    <path d="m12.6 14.74 4.22-4.58c.43-.46.06-1.16-.6-1.16H7.78c-.66 0-1.03.7-.6 1.16l4.22 4.58c.31.34.89.34 1.2 0Z" />
+  </svg>
+);

--- a/stencil-workspace/src/components/modus-button/modus-button.e2e.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.e2e.ts
@@ -35,6 +35,54 @@ describe('modus-button', () => {
     expect(element).toHaveClass('color-primary');
   });
 
+  it('renders changes to the iconOnly prop', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-button></modus-button>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-button');
+    const element = await page.find('modus-button >>> button');
+    expect(element).not.toHaveClass('icon-only');
+
+    component.setProperty('iconOnly', 'add');
+    await page.waitForChanges();
+    const icon = await page.find('modus-button >>> .icon-add');
+    expect(icon).toBeTruthy();
+  });
+
+  it('renders changes to the leftIcon prop', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-button></modus-button>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-button');
+    let icon = await page.find('modus-button >>> .left-icon');
+    expect(icon).toBeFalsy();
+
+    component.setProperty('leftIcon', 'add');
+    await page.waitForChanges();
+    icon = await page.find('modus-button >>> .left-icon');
+    expect(icon).toBeTruthy();
+  });
+
+  it('renders changes to the rightIcon prop', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-button></modus-button>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-button');
+    let icon = await page.find('modus-button >>> .right-icon');
+    expect(icon).toBeFalsy();
+
+    component.setProperty('rightIcon', 'add');
+    await page.waitForChanges();
+    icon = await page.find('modus-button >>> .right-icon');
+    expect(icon).toBeTruthy();
+  });
+
   it('renders changes to the disabled prop', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-button/modus-button.e2e.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.e2e.ts
@@ -83,6 +83,41 @@ describe('modus-button', () => {
     expect(icon).toBeTruthy();
   });
 
+  it('renders changes to the showCaret prop', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-button></modus-button>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-button');
+    let icon = await page.find('modus-button >>> .icon-caret-down');
+    expect(icon).toBeFalsy();
+
+    component.setProperty('showCaret', true);
+    await page.waitForChanges();
+    icon = await page.find('modus-button >>> .icon-caret-down');
+    expect(icon).toBeTruthy();
+  });
+
+  it('should not render right icon when caret icon is visible', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-button right-icon="add"></modus-button>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-button');
+    await page.waitForChanges();
+    let icon = await page.find('modus-button >>> .right-icon');
+    expect(icon).toBeTruthy();
+
+    component.setProperty('showCaret', true);
+    await page.waitForChanges();
+    icon = await page.find('modus-button >>> .icon-caret-down');
+    expect(icon).toBeTruthy();
+    icon = await page.find('modus-button >>> .right-icon');
+    expect(icon).toBeFalsy();
+  });
+
   it('renders changes to the disabled prop', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -226,12 +226,7 @@ button {
   // Outline variants
   &.style-outline {
     @each $color, $value in $btn-outline-theme-colors {
-      $alias: $color;
-
-      @if $color == 'dark' {
-        $alias: 'secondary';
-      }
-      &.color-#{$alias} {
+      &.color-#{$color} {
         $btn-color: var(--modus-btn-outline-#{$color}-color, $value);
 
         background-color: var(--modus-btn-outline-#{$color}-bg, transparent);
@@ -244,7 +239,7 @@ button {
       }
 
       // Hover state
-      &.color-#{$alias}:hover:not([disabled]) {
+      &.color-#{$color}:hover:not([disabled]) {
         $btn-color: var(--modus-btn-outline-#{$color}-hover-color, map-get($btn-outline-hover, $color, 'color'));
 
         background-color: var(--modus-btn-outline-#{$color}-hover-bg, map-get($btn-outline-hover, $color, 'bg'));
@@ -257,7 +252,7 @@ button {
       }
 
       // Active state
-      &.color-#{$alias}:active:not([disabled]) {
+      &.color-#{$color}:active:not([disabled]) {
         $btn-color: var(--modus-btn-outline-#{$color}-active-color, map-get($btn-outline-active, $color, 'color'));
 
         background-color: var(--modus-btn-outline-#{$color}-active-bg, map-get($btn-outline-active, $color, 'bg'));

--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -64,11 +64,19 @@ button {
 
     &.icon-only {
       height: 32px;
-      padding: 0 4px;
+      padding: 0;
 
-      .icon svg {
-        height: 24px;
-        width: 24px;
+      &.has-caret {
+        padding: 0 4px;
+      }
+
+      .icon {
+        padding: 0 4px;
+
+        svg {
+          height: 24px;
+          width: 24px;
+        }
       }
     }
   }
@@ -89,11 +97,19 @@ button {
 
     &.icon-only {
       height: 40px;
-      padding: 0 8px;
+      padding: 0;
 
-      .icon svg {
-        height: 24px;
-        width: 24px;
+      &.has-caret {
+        padding: 0 4px;
+      }
+
+      .icon {
+        padding: 0 8px;
+
+        svg {
+          height: 24px;
+          width: 24px;
+        }
       }
     }
   }
@@ -114,11 +130,19 @@ button {
 
     &.icon-only {
       height: 48px;
-      padding: 0 8px;
+      padding: 0;
 
-      .icon svg {
-        height: 32px;
-        width: 32px;
+      &.has-caret {
+        padding: 0 8px 0 4px;
+      }
+
+      .icon {
+        padding: 0 8px;
+
+        svg {
+          height: 32px;
+          width: 32px;
+        }
       }
     }
   }

--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -1,5 +1,12 @@
 @import './modus-button.vars';
 
+:host {
+  cursor: pointer;
+  display: inline-block;
+  position: relative;
+  width: auto;
+}
+
 button {
   align-items: center;
   border: $rem-1px solid transparent;
@@ -14,7 +21,16 @@ button {
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out,
     box-shadow 0.15s ease-in-out;
   user-select: none;
+  vertical-align: middle;
   white-space: nowrap;
+  width: 100%;
+
+  .icon {
+    align-items: center;
+    display: flex;
+    flex: 0 0 auto;
+    pointer-events: none;
+  }
 
   &:hover {
     cursor: pointer;
@@ -33,27 +49,83 @@ button {
   }
 
   &.size-small {
-    font-size: 12px;
     height: 24px;
     padding: 0 8px;
+
+    .label {
+      font-size: $rem-12px;
+      padding: 0 4px;
+    }
+
+    .icon svg {
+      height: 16px;
+      width: 16px;
+    }
+
+    &.icon-only {
+      height: 32px;
+      padding: 0 4px;
+
+      .icon svg {
+        height: 24px;
+        width: 24px;
+      }
+    }
   }
 
   &.size-medium {
-    font-size: 14px;
     height: 32px;
-    padding: 0 16px;
+    padding: 0 8px;
+
+    .label {
+      font-size: $rem-14px;
+      padding: 0 8px;
+    }
+
+    .icon svg {
+      height: 24px;
+      width: 24px;
+    }
+
+    &.icon-only {
+      height: 40px;
+      padding: 0 8px;
+
+      .icon svg {
+        height: 24px;
+        width: 24px;
+      }
+    }
   }
 
   &.size-large {
-    font-size: 16px;
     height: 48px;
-    padding: 0 24px;
+    padding: 0 12px;
+
+    .label {
+      font-size: $rem-16px;
+      padding: 0 8px;
+    }
+
+    .icon svg {
+      height: 24px;
+      width: 24px;
+    }
+
+    &.icon-only {
+      height: 48px;
+      padding: 0 8px;
+
+      .icon svg {
+        height: 32px;
+        width: 32px;
+      }
+    }
   }
 
-  &.style-borderless {
+  &.style-borderless:not(.icon-only) {
     background-color: $modus-btn-borderless-bg;
     color: $modus-btn-borderless-color;
-    fill: $modus-btn-borderless-color !important;
 
     svg path {
       fill: $modus-btn-borderless-color !important;
@@ -62,13 +134,59 @@ button {
     &:hover:not([disabled]) {
       background-color: $modus-btn-borderless-hover-bg;
       color: $modus-btn-borderless-hover-color;
-      fill: $modus-btn-borderless-hover-color;
+
+      svg path {
+        fill: $modus-btn-borderless-hover-color;
+      }
     }
 
     &:active:not([disabled]) {
       background-color: $modus-btn-borderless-active-bg;
       color: $modus-btn-borderless-active-color;
-      fill: $modus-btn-borderless-active-color;
+
+      svg path {
+        fill: $modus-btn-borderless-active-color;
+      }
+    }
+  }
+
+  &.style-borderless.icon-only {
+    background: transparent;
+
+    @each $color, $value in $btn-icon-only-theme-colors {
+      &.color-#{$color} {
+        $btn-color: var(--modus-btn-icon-only-#{$color}-color, $value);
+
+        color: $btn-color;
+
+        svg path {
+          fill: $btn-color;
+        }
+      }
+
+      // Hover state
+      &.color-#{$color}:hover:not([disabled]) {
+        $btn-color: var(--modus-btn-icon-only-#{$color}-hover-color, map-get($btn-icon-only-hover, $color, 'color'));
+
+        background-color: var(--modus-btn-icon-only-#{$color}-hover-bg, map-get($btn-icon-only-hover, $color, 'bg'));
+        color: $btn-color;
+
+        svg path {
+          fill: $btn-color;
+        }
+      }
+
+      // Active state
+      &.color-#{$color}:active:not([disabled]) {
+        $btn-color: var(--modus-btn-icon-only-#{$color}-active-color, map-get($btn-icon-only-active, $color, 'color'));
+
+        background-color: var(--modus-btn-icon-only-#{$color}-active-bg, map-get($btn-icon-only-active, $color, 'bg'));
+        color: $btn-color;
+
+        svg path {
+          fill: $btn-color;
+        }
+      }
     }
   }
 
@@ -85,7 +203,10 @@ button {
         background-color: var(--modus-btn-#{$color}-bg, $value);
         border-color: var(--modus-btn-#{$color}-border-color, $value);
         color: var(--modus-btn-#{$color}-color, $default-text-color);
-        fill: var(--modus-btn-#{$color}-color, $default-text-color);
+
+        svg path {
+          fill: var(--modus-btn-#{$color}-color, $default-text-color);
+        }
       }
 
       // Hover state
@@ -116,7 +237,10 @@ button {
         background-color: var(--modus-btn-outline-#{$color}-bg, transparent);
         border-color: $btn-color;
         color: $btn-color;
-        fill: $btn-color;
+
+        svg path {
+          fill: $btn-color;
+        }
       }
 
       // Hover state
@@ -126,7 +250,10 @@ button {
         background-color: var(--modus-btn-outline-#{$color}-hover-bg, map-get($btn-outline-hover, $color, 'bg'));
         border-color: $btn-color;
         color: $btn-color;
-        fill: $btn-color;
+
+        svg path {
+          fill: $btn-color;
+        }
       }
 
       // Active state
@@ -136,7 +263,10 @@ button {
         background-color: var(--modus-btn-outline-#{$color}-active-bg, map-get($btn-outline-active, $color, 'bg'));
         border-color: $btn-color;
         color: $btn-color;
-        fill: $btn-color;
+
+        svg path {
+          fill: $btn-color;
+        }
       }
     }
   }

--- a/stencil-workspace/src/components/modus-button/modus-button.spec.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.spec.ts
@@ -83,6 +83,9 @@ describe('modus-button', () => {
 
     className = modusButton.classByColor.get('tertiary');
     expect(className).toEqual('color-tertiary');
+
+    className = modusButton.classByColor.get('dark');
+    expect(className).toEqual('color-dark');
   });
 
   it('should get the correct class by size', async () => {

--- a/stencil-workspace/src/components/modus-button/modus-button.spec.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.spec.ts
@@ -11,7 +11,9 @@ describe('modus-button', () => {
       <modus-button>
         <mock:shadow-root>
           <button class="size-medium color-primary style-fill" role="button">
-            <slot></slot>
+            <span class="label">
+               <slot></slot>
+            </span>
           </button>
         </mock:shadow-root>
       </modus-button>
@@ -27,10 +29,28 @@ describe('modus-button', () => {
       <modus-button>
         <mock:shadow-root>
           <button class="size-medium color-primary style-fill" role="button">
-            <slot></slot>
+            <span class="label">
+                <slot></slot>
+            </span>
           </button>
         </mock:shadow-root>
         Button
+      </modus-button>
+    `);
+  });
+
+  it('renders icon only', async () => {
+    const { root } = await newSpecPage({
+      components: [ModusButton],
+      html: `<modus-button icon-only="add"></modus-button>`,
+    });
+    expect(root).toEqualHtml(`
+      <modus-button icon-only="add">
+        <mock:shadow-root>
+          <button class="size-medium color-primary style-fill icon-only" role="button">
+            <span class="icon"><svg class="icon-add" height="16" width="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M19,13H13v6H11V13H5V11h6V5h2v6h6Z" fill="#6A6976"></path></svg></span>
+          </button>
+        </mock:shadow-root>
       </modus-button>
     `);
   });
@@ -63,6 +83,9 @@ describe('modus-button', () => {
 
     className = modusButton.classByColor.get('tertiary');
     expect(className).toEqual('color-tertiary');
+
+    className = modusButton.classByColor.get('dark');
+    expect(className).toEqual('color-dark');
   });
 
   it('should get the correct class by size', async () => {

--- a/stencil-workspace/src/components/modus-button/modus-button.spec.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.spec.ts
@@ -83,9 +83,6 @@ describe('modus-button', () => {
 
     className = modusButton.classByColor.get('tertiary');
     expect(className).toEqual('color-tertiary');
-
-    className = modusButton.classByColor.get('dark');
-    expect(className).toEqual('color-dark');
   });
 
   it('should get the correct class by size', async () => {

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -15,8 +15,8 @@ export class ModusButton {
   /** (optional) The style of the button */
   @Prop() buttonStyle: 'borderless' | 'fill' | 'outline' = 'fill';
 
-  /** (optional) The color of the button. Note: `dark` is supported only on icon-only buttons. */
-  @Prop() color: 'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark' = 'primary';
+  /** (optional) The color of the button */
+  @Prop() color: 'danger' | 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   /** (optional) Disables the button. */
   @Prop() disabled: boolean;
@@ -54,7 +54,6 @@ export class ModusButton {
     ['primary', 'color-primary'],
     ['secondary', 'color-secondary'],
     ['tertiary', 'color-tertiary'],
-    ['dark', 'color-dark'],
   ]);
 
   classBySize: Map<string, string> = new Map([

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -34,7 +34,7 @@ export class ModusButton {
   @Prop() size: 'small' | 'medium' | 'large' = 'medium';
 
   /** (optional) Shows a caret icon right side of the button. */
-  // @Prop() showCaret: boolean;
+  @Prop() showCaret: boolean;
 
   /** (optional) An event that fires on button click. */
   @Event() buttonClick: EventEmitter;
@@ -93,7 +93,7 @@ export class ModusButton {
           <slot />
         </span>
 
-        {this.rightIcon && (
+        {this.rightIcon && !this.showCaret && (
           <span class="icon right-icon">
             <IconMap icon={this.rightIcon}></IconMap>
           </span>
@@ -113,7 +113,7 @@ export class ModusButton {
   render(): unknown {
     const className = `${this.classBySize.get(this.size)} ${this.classByColor.get(this.color)} ${this.classByButtonStyle.get(
       this.buttonStyle
-    )} ${this.iconOnly ? 'icon-only' : ''}`;
+    )} ${this.iconOnly ? 'icon-only' : ''} ${this.showCaret ? 'has-caret' : ''}`;
 
     return (
       <button
@@ -130,6 +130,7 @@ export class ModusButton {
         role="button"
         ref={(el) => (this.buttonRef = el)}>
         {this.iconOnly ? this.renderIconOnly() : this.renderIconWithText()}
+        {this.showCaret && <IconMap size="24" icon="caret-down"></IconMap>}
       </button>
     );
   }

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -1,5 +1,7 @@
 // eslint-disable-next-line
-import { Component, Prop, h, Event, EventEmitter, Element, State, Listen, Method } from '@stencil/core';
+import { Component, Prop, h, Event, EventEmitter, Element, State, Listen, Method, Fragment } from '@stencil/core';
+import { IconMap } from '../icons/IconMap';
+import { JSX } from '@stencil/core/internal';
 
 @Component({
   tag: 'modus-button',
@@ -13,14 +15,26 @@ export class ModusButton {
   /** (optional) The style of the button */
   @Prop() buttonStyle: 'borderless' | 'fill' | 'outline' = 'fill';
 
-  /** (optional) The color of the button. */
-  @Prop() color: 'danger' | 'primary' | 'secondary' | 'tertiary' = 'primary';
+  /** (optional) The color of the button. Note: `dark` is supported only on icon-only buttons. */
+  @Prop() color: 'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark' = 'primary';
 
   /** (optional) Disables the button. */
   @Prop() disabled: boolean;
 
+  /** (optional) Takes the icon name and renders an icon-only button. */
+  @Prop() iconOnly: string;
+
+  /** (optional) Takes the icon name and shows the icon aligned to the left of the button text. */
+  @Prop() leftIcon: string;
+
+  /** (optional) Takes the icon name and shows the icon aligned to the right of the button text. */
+  @Prop() rightIcon: string;
+
   /** (optional) The size of the button. */
   @Prop() size: 'small' | 'medium' | 'large' = 'medium';
+
+  /** (optional) Shows a caret icon right side of the button. */
+  // @Prop() showCaret: boolean;
 
   /** (optional) An event that fires on button click. */
   @Event() buttonClick: EventEmitter;
@@ -40,6 +54,7 @@ export class ModusButton {
     ['primary', 'color-primary'],
     ['secondary', 'color-secondary'],
     ['tertiary', 'color-tertiary'],
+    ['dark', 'color-dark'],
   ]);
 
   classBySize: Map<string, string> = new Map([
@@ -66,10 +81,39 @@ export class ModusButton {
     }
   }
 
+  renderIconWithText(): JSX.Element {
+    return (
+      <Fragment>
+        {this.leftIcon && (
+          <span class="icon left-icon">
+            <IconMap icon={this.leftIcon}></IconMap>
+          </span>
+        )}
+        <span class="label">
+          <slot />
+        </span>
+
+        {this.rightIcon && (
+          <span class="icon right-icon">
+            <IconMap icon={this.rightIcon}></IconMap>
+          </span>
+        )}
+      </Fragment>
+    );
+  }
+
+  renderIconOnly(): JSX.Element {
+    return (
+      <span class="icon">
+        <IconMap icon={this.iconOnly}></IconMap>
+      </span>
+    );
+  }
+
   render(): unknown {
     const className = `${this.classBySize.get(this.size)} ${this.classByColor.get(this.color)} ${this.classByButtonStyle.get(
       this.buttonStyle
-    )}`;
+    )} ${this.iconOnly ? 'icon-only' : ''}`;
 
     return (
       <button
@@ -85,7 +129,7 @@ export class ModusButton {
         onMouseUp={() => (this.pressed = false)}
         role="button"
         ref={(el) => (this.buttonRef = el)}>
-        <slot />
+        {this.iconOnly ? this.renderIconOnly() : this.renderIconWithText()}
       </button>
     );
   }

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -54,6 +54,7 @@ export class ModusButton {
     ['primary', 'color-primary'],
     ['secondary', 'color-secondary'],
     ['tertiary', 'color-tertiary'],
+    ['dark', 'color-dark'],
   ]);
 
   classBySize: Map<string, string> = new Map([

--- a/stencil-workspace/src/components/modus-button/modus-button.vars.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.vars.scss
@@ -1,5 +1,10 @@
 // Default theme colors
-$btn-theme-colors: map-remove($theme-colors, 'success', 'warning', 'yellow', 'dark');
+$btn-theme-colors: (
+  'primary': map-get($theme-colors, 'primary'),
+  'secondary': map-get($theme-colors, 'secondary'),
+  'tertiary': map-get($theme-colors, 'tertiary'),
+  'danger': map-get($theme-colors, 'danger'),
+);
 $btn-hover-colors: (
   'primary': #0082d6,
   'secondary': #838793,
@@ -13,8 +18,11 @@ $btn-active-colors: (
   'danger': #c41e28,
 );
 
-// Outline
-$btn-outline-theme-colors: map-remove($theme-colors, 'success', 'warning', 'yellow', 'secondary', 'tertiary', 'danger');
+// Default Outline
+$btn-outline-theme-colors: (
+  'primary': map-get($theme-colors, 'primary'),
+  'dark': map-get($theme-colors, 'dark'),
+);
 $btn-outline-hover: (
   'primary': (
     'bg': rgba(0, 99, 163, 0.15),
@@ -36,7 +44,7 @@ $btn-outline-active: (
   ),
 );
 
-// Borderless
+// Default Borderless
 $modus-btn-borderless-bg: var(--modus-btn-text-primary-bg, transparent) !default;
 $modus-btn-borderless-color: var(--modus-btn-text-primary-color, map-get($theme-colors, 'primary')) !default;
 
@@ -76,3 +84,29 @@ $modus-btn-borderless-active-color: var(
 $modus-btn-disabled-color: var(--modus-btn-disabled-color) !default;
 $modus-btn-disabled-bg: var(--modus-btn-disabled-bg) !default;
 $modus-btn-disabled-border-color: var(--modus-btn-disabled-border-color) !default;
+
+// Default Icon-only
+$btn-icon-only-theme-colors: (
+  'dark': map-get($theme-colors, 'dark'),
+  'secondary': map-get($theme-colors, 'secondary'),
+);
+$btn-icon-only-hover: (
+  'secondary': (
+    'bg': #e0e1e9,
+    'color': map-get($theme-colors, 'secondary'),
+  ),
+  'dark': (
+    'bg': #e0e1e9,
+    'color': map-get($theme-colors, 'dark'),
+  ),
+);
+$btn-icon-only-active: (
+  'secondary': (
+    'bg': #cbcdd6,
+    'color': map-get($theme-colors, 'dark'),
+  ),
+  'dark': (
+    'bg': #cbcdd6,
+    'color': map-get($theme-colors, 'dark'),
+  ),
+);

--- a/stencil-workspace/src/components/modus-button/modus-button.vars.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.vars.scss
@@ -21,14 +21,14 @@ $btn-active-colors: (
 // Default Outline
 $btn-outline-theme-colors: (
   'primary': map-get($theme-colors, 'primary'),
-  'dark': map-get($theme-colors, 'dark'),
+  'secondary': $col_trimble_gray,
 );
 $btn-outline-hover: (
   'primary': (
     'bg': rgba(0, 99, 163, 0.15),
     'color': #0082d6,
   ),
-  'dark': (
+  'secondary': (
     'bg': rgba(33, 42, 50, 0.15),
     'color': #3c444a,
   ),
@@ -38,7 +38,7 @@ $btn-outline-active: (
     'bg': rgba(0, 99, 163, 0.2),
     'color': #00548a,
   ),
-  'dark': (
+  'secondary': (
     'bg': rgba(33, 42, 50, 0.2),
     'color': #1a1d20,
   ),
@@ -87,26 +87,35 @@ $modus-btn-disabled-border-color: var(--modus-btn-disabled-border-color) !defaul
 
 // Default Icon-only
 $btn-icon-only-theme-colors: (
-  'dark': map-get($theme-colors, 'dark'),
-  'secondary': map-get($theme-colors, 'secondary'),
+  'primary': map-get($theme-colors, 'primary'),
+  'secondary': $col_trimble_gray,
+  'tertiary': $col_gray_6,
 );
 $btn-icon-only-hover: (
   'secondary': (
     'bg': #e0e1e9,
-    'color': map-get($theme-colors, 'secondary'),
+    'color': $col_gray_6,
   ),
-  'dark': (
+  'tertiary': (
     'bg': #e0e1e9,
-    'color': map-get($theme-colors, 'dark'),
+    'color': $col_trimble_gray,
+  ),
+  'primary': (
+    'bg': #dcedf9,
+    'color': #217cbb,
   ),
 );
 $btn-icon-only-active: (
+  'tertiary': (
+    'bg': #cbcdd6,
+    'color': $col_trimble_gray,
+  ),
   'secondary': (
     'bg': #cbcdd6,
-    'color': map-get($theme-colors, 'dark'),
+    'color': $col_trimble_gray,
   ),
-  'dark': (
-    'bg': #cbcdd6,
-    'color': map-get($theme-colors, 'dark'),
+  'primary': (
+    'bg': rgba(0, 99, 163, 0.18),
+    'color': #004f83,
   ),
 );

--- a/stencil-workspace/src/components/modus-button/readme.md
+++ b/stencil-workspace/src/components/modus-button/readme.md
@@ -16,6 +16,7 @@
 | `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                            | `string`                                             | `undefined` |
 | `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.  | `string`                                             | `undefined` |
 | `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                             | `undefined` |
+| `showCaret`   | `show-caret`   | (optional) Shows a caret icon right side of the button.                                    | `boolean`                                            | `undefined` |
 | `size`        | `size`         | (optional) The size of the button.                                                         | `"large" \| "medium" \| "small"`                     | `'medium'`  |
 
 

--- a/stencil-workspace/src/components/modus-button/readme.md
+++ b/stencil-workspace/src/components/modus-button/readme.md
@@ -7,13 +7,16 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                         | Type                                                 | Default     |
-| ------------- | -------------- | ----------------------------------- | ---------------------------------------------------- | ----------- |
-| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label. | `string`                                             | `undefined` |
-| `buttonStyle` | `button-style` | (optional) The style of the button  | `"borderless" \| "fill" \| "outline"`                | `'fill'`    |
-| `color`       | `color`        | (optional) The color of the button. | `"danger" \| "primary" \| "secondary" \| "tertiary"` | `'primary'` |
-| `disabled`    | `disabled`     | (optional) Disables the button.     | `boolean`                                            | `undefined` |
-| `size`        | `size`         | (optional) The size of the button.  | `"large" \| "medium" \| "small"`                     | `'medium'`  |
+| Property      | Attribute      | Description                                                                                | Type                                                           | Default     |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ----------- |
+| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                        | `string`                                                       | `undefined` |
+| `buttonStyle` | `button-style` | (optional) The style of the button                                                         | `"borderless" \| "fill" \| "outline"`                          | `'fill'`    |
+| `color`       | `color`        | (optional) The color of the button. Note: `dark` is supported only on icon-only buttons.   | `"danger" \| "dark" \| "primary" \| "secondary" \| "tertiary"` | `'primary'` |
+| `disabled`    | `disabled`     | (optional) Disables the button.                                                            | `boolean`                                                      | `undefined` |
+| `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                            | `string`                                                       | `undefined` |
+| `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.  | `string`                                                       | `undefined` |
+| `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                                       | `undefined` |
+| `size`        | `size`         | (optional) The size of the button.                                                         | `"large" \| "medium" \| "small"`                               | `'medium'`  |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-button/readme.md
+++ b/stencil-workspace/src/components/modus-button/readme.md
@@ -7,16 +7,16 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                | Type                                                           | Default     |
-| ------------- | -------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ----------- |
-| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                        | `string`                                                       | `undefined` |
-| `buttonStyle` | `button-style` | (optional) The style of the button                                                         | `"borderless" \| "fill" \| "outline"`                          | `'fill'`    |
-| `color`       | `color`        | (optional) The color of the button. Note: `dark` is supported only on icon-only buttons.   | `"danger" \| "dark" \| "primary" \| "secondary" \| "tertiary"` | `'primary'` |
-| `disabled`    | `disabled`     | (optional) Disables the button.                                                            | `boolean`                                                      | `undefined` |
-| `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                            | `string`                                                       | `undefined` |
-| `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.  | `string`                                                       | `undefined` |
-| `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                                       | `undefined` |
-| `size`        | `size`         | (optional) The size of the button.                                                         | `"large" \| "medium" \| "small"`                               | `'medium'`  |
+| Property      | Attribute      | Description                                                                                | Type                                                 | Default     |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------- | ----------- |
+| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                        | `string`                                             | `undefined` |
+| `buttonStyle` | `button-style` | (optional) The style of the button                                                         | `"borderless" \| "fill" \| "outline"`                | `'fill'`    |
+| `color`       | `color`        | (optional) The color of the button                                                         | `"danger" \| "primary" \| "secondary" \| "tertiary"` | `'primary'` |
+| `disabled`    | `disabled`     | (optional) Disables the button.                                                            | `boolean`                                            | `undefined` |
+| `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                            | `string`                                             | `undefined` |
+| `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.  | `string`                                             | `undefined` |
+| `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                             | `undefined` |
+| `size`        | `size`         | (optional) The size of the button.                                                         | `"large" \| "medium" \| "small"`                     | `'medium'`  |
 
 
 ## Events

--- a/stencil-workspace/src/global/modus-light-theme.scss
+++ b/stencil-workspace/src/global/modus-light-theme.scss
@@ -81,12 +81,6 @@ $theme-colors: () !default;
 $theme-colors: map-merge(
   (
     'primary': $primary,
-    'secondary': $secondary,
-    'tertiary': $tertiary,
-    'success': $success,
-    'warning': $warning,
-    'yellow': $theme-yellow,
-    'danger': $danger,
     'dark': $dark,
   ),
   $theme-colors

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -505,13 +505,6 @@
   --modus-btn-icon-only-tertiary-active-bg: var(--modus-gray-4);
   --modus-btn-icon-only-tertiary-active-color: var(--modus-gray-9);
 
-  // Secondary
-  --modus-btn-icon-only-secondary-color: var(--modus-gray-4);
-  --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-1);
-  --modus-btn-icon-only-secondary-hover-color: var(--modus-gray-5);
-  --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-4);
-  --modus-btn-icon-only-secondary-active-color: var(--modus-gray-9);
-
   // Input
   --modus-input-bg: var(--modus-gray-10);
   --modus-input-color: var(--modus-body-color);

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -152,11 +152,19 @@
   --modus-btn-text-primary-active-color: var(--modus-trimble-blue-dark);
 
   // Icon only Button
+  // Dark
   --modus-btn-icon-only-dark-color: var(--modus-dark);
   --modus-btn-icon-only-dark-hover-bg: var(--modus-gray-0);
-  --modus-btn-icon-only-dark-hover-color: var(--modus-gray-9);
+  --modus-btn-icon-only-dark-hover-color: var(--modus-dark);
   --modus-btn-icon-only-dark-active-bg: var(--modus-gray-1);
-  --modus-btn-icon-only-dark-active-color: #2b2a37;
+  --modus-btn-icon-only-dark-active-color: var(--modus-dark);
+
+  // Secondary
+  --modus-btn-icon-only-secondary-color: var(--modus-secondary);
+  --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-0);
+  --modus-btn-icon-only-secondary-hover-color: var(--modus-secondary);
+  --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-1);
+  --modus-btn-icon-only-secondary-active-color: var(--modus-gray-10);
 
   // Input
   --modus-input-bg: var(--modus-white);
@@ -469,11 +477,19 @@
   --modus-btn-text-primary-active-color: var(--modus-primary);
 
   // Icon only Button
-  --modus-btn-icon-only-dark-color: var(--modus-gray-light);
+  // Dark
+  --modus-btn-icon-only-dark-color: var(--modus-white);
   --modus-btn-icon-only-dark-hover-bg: var(--modus-gray-4);
   --modus-btn-icon-only-dark-hover-color: var(--modus-white);
   --modus-btn-icon-only-dark-active-bg: var(--modus-gray-6);
   --modus-btn-icon-only-dark-active-color: var(--modus-white);
+
+  // Secondary
+  --modus-btn-icon-only-secondary-color: var(--modus-gray-4);
+  --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-1);
+  --modus-btn-icon-only-secondary-hover-color: var(--modus-gray-5);
+  --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-4);
+  --modus-btn-icon-only-secondary-active-color: var(--modus-gray-9);
 
   // Input
   --modus-input-bg: var(--modus-gray-10);

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -137,12 +137,12 @@
   --modus-btn-outline-primary-active-bg: #cce0ed;
   --modus-btn-outline-primary-active-color: var(--modus-trimble-blue-dark);
 
-  // Dark Outline
-  --modus-btn-outline-dark-color: var(--modus-dark);
-  --modus-btn-outline-dark-hover-bg: var(--modus-gray-0);
-  --modus-btn-outline-dark-hover-color: var(--modus-gray-9);
-  --modus-btn-outline-dark-active-bg: var(--modus-gray-1);
-  --modus-btn-outline-dark-active-color: var(--modus-dark);
+  // Secondary Outline
+  --modus-btn-outline-secondary-color: var(--modus-gray-10);
+  --modus-btn-outline-secondary-hover-bg: var(--modus-gray-0);
+  --modus-btn-outline-secondary-hover-color: var(--modus-gray-9);
+  --modus-btn-outline-secondary-active-bg: var(--modus-gray-1);
+  --modus-btn-outline-secondary-active-color: var(--modus-gray-10);
 
   // Text only Button variant
   // Primary
@@ -152,19 +152,26 @@
   --modus-btn-text-primary-active-color: var(--modus-trimble-blue-dark);
 
   // Icon only Button
-  // Dark
-  --modus-btn-icon-only-dark-color: var(--modus-dark);
-  --modus-btn-icon-only-dark-hover-bg: var(--modus-gray-0);
-  --modus-btn-icon-only-dark-hover-color: var(--modus-dark);
-  --modus-btn-icon-only-dark-active-bg: var(--modus-gray-1);
-  --modus-btn-icon-only-dark-active-color: var(--modus-dark);
+  // Primary
+  --modus-btn-icon-only-primary-color: var(--modus-primary);
+  --modus-btn-icon-only-primary-hover-bg: var(--modus-blue-pale);
+  --modus-btn-icon-only-primary-hover-color: var(--modus-blue-light);
+  --modus-btn-icon-only-primary-active-bg: rgba(0, 99, 163, 0.18);
+  --modus-btn-icon-only-primary-active-color: var(--modus-blue-dark);
 
   // Secondary
-  --modus-btn-icon-only-secondary-color: var(--modus-secondary);
+  --modus-btn-icon-only-secondary-color: var(--modus-gray-10);
   --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-0);
-  --modus-btn-icon-only-secondary-hover-color: var(--modus-secondary);
+  --modus-btn-icon-only-secondary-hover-color: var(--modus-gray-10);
   --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-1);
   --modus-btn-icon-only-secondary-active-color: var(--modus-gray-10);
+
+  // Tertiary
+  --modus-btn-icon-only-tertiary-color: var(--modus-gray-6);
+  --modus-btn-icon-only-tertiary-hover-bg: var(--modus-gray-0);
+  --modus-btn-icon-only-tertiary-hover-color: var(--modus-gray-6);
+  --modus-btn-icon-only-tertiary-active-bg: var(--modus-gray-1);
+  --modus-btn-icon-only-tertiary-active-color: var(--modus-gray-10);
 
   // Input
   --modus-input-bg: var(--modus-white);
@@ -462,12 +469,12 @@
   --modus-btn-outline-primary-active-bg: #019aeb4c;
   --modus-btn-outline-primary-active-color: var(--modus-primary);
 
-  // Dark Outline
-  --modus-btn-outline-dark-color: var(--modus-gray-1);
-  --modus-btn-outline-dark-hover-bg: #cbcdd61f;
-  --modus-btn-outline-dark-hover-color: var(--modus-gray-1);
-  --modus-btn-outline-dark-active-bg: #cbcdd64d;
-  --modus-btn-outline-dark-active-color: var(--modus-gray-1);
+  // Secondary Outline
+  --modus-btn-outline-secondary-color: var(--modus-gray-1);
+  --modus-btn-outline-secondary-hover-bg: #cbcdd61f;
+  --modus-btn-outline-secondary-hover-color: var(--modus-gray-1);
+  --modus-btn-outline-secondary-active-bg: #cbcdd64d;
+  --modus-btn-outline-secondary-active-color: var(--modus-gray-1);
 
   // Text only Button
   // Primary
@@ -477,19 +484,26 @@
   --modus-btn-text-primary-active-color: var(--modus-primary);
 
   // Icon only Button
-  // Dark
-  --modus-btn-icon-only-dark-color: var(--modus-white);
-  --modus-btn-icon-only-dark-hover-bg: var(--modus-gray-4);
-  --modus-btn-icon-only-dark-hover-color: var(--modus-white);
-  --modus-btn-icon-only-dark-active-bg: var(--modus-gray-6);
-  --modus-btn-icon-only-dark-active-color: var(--modus-white);
+  // Primary
+  --modus-btn-icon-only-primary-color: var(--modus-blue);
+  --modus-btn-icon-only-primary-hover-bg: rgba(1, 154, 235, 0.12);
+  --modus-btn-icon-only-primary-hover-color: var(--modus-blue);
+  --modus-btn-icon-only-primary-active-bg: rgba(1, 154, 235, 0.3);
+  --modus-btn-icon-only-primary-active-color: var(--modus-blue);
 
   // Secondary
-  --modus-btn-icon-only-secondary-color: var(--modus-gray-4);
-  --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-1);
-  --modus-btn-icon-only-secondary-hover-color: var(--modus-gray-5);
-  --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-4);
-  --modus-btn-icon-only-secondary-active-color: var(--modus-gray-9);
+  --modus-btn-icon-only-secondary-color: var(--modus-white);
+  --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-4);
+  --modus-btn-icon-only-secondary-hover-color: var(--modus-white);
+  --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-6);
+  --modus-btn-icon-only-secondary-active-color: var(--modus-white);
+
+  // Tertiary
+  --modus-btn-icon-only-tertiary-color: var(--modus-gray-4);
+  --modus-btn-icon-only-tertiary-hover-bg: var(--modus-gray-1);
+  --modus-btn-icon-only-tertiary-hover-color: var(--modus-gray-5);
+  --modus-btn-icon-only-tertiary-active-bg: var(--modus-gray-4);
+  --modus-btn-icon-only-tertiary-active-color: var(--modus-gray-9);
 
   // Input
   --modus-input-bg: var(--modus-gray-10);
@@ -784,7 +798,7 @@ modus-breadcrumb {
 }
 
 $btn-theme-colors: 'primary', 'secondary', 'tertiary', 'danger';
-$btn-outline-variants: 'primary', 'dark';
+$btn-outline-variants: 'primary', 'secondary';
 
 modus-button[disabled] {
   --modus-btn-disabled-color: ;
@@ -832,12 +846,7 @@ modus-button[disabled] {
 }
 
 @each $color in $btn-outline-variants {
-  $alias: $color;
-
-  @if $color == 'dark' {
-    $alias: 'secondary';
-  }
-  modus-button[button-style='outline'][color='#{$alias}'] {
+  modus-button[button-style='outline'][color='#{$color}'] {
     @include button-variant('outline', $color);
   }
 }

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -505,6 +505,13 @@
   --modus-btn-icon-only-tertiary-active-bg: var(--modus-gray-4);
   --modus-btn-icon-only-tertiary-active-color: var(--modus-gray-9);
 
+  // Secondary
+  --modus-btn-icon-only-secondary-color: var(--modus-gray-4);
+  --modus-btn-icon-only-secondary-hover-bg: var(--modus-gray-1);
+  --modus-btn-icon-only-secondary-hover-color: var(--modus-gray-5);
+  --modus-btn-icon-only-secondary-active-bg: var(--modus-gray-4);
+  --modus-btn-icon-only-secondary-active-color: var(--modus-gray-9);
+
   // Input
   --modus-input-bg: var(--modus-gray-10);
   --modus-input-color: var(--modus-body-color);

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -16,6 +16,37 @@
 
   </head>
   <body>
-    <!-- Test components here -->
+    <modus-button color="primary" left-icon="add" >Primary</modus-button>
+    <modus-button color="secondary"  right-icon="add">Secondary</modus-button>
+    <modus-button left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
+    <modus-button left-icon="add" color="danger"  right-icon="add">Tertiary</modus-button>
+
+    <modus-button color="primary" icon-only="add" ></modus-button>
+    <modus-button color="secondary" icon-only="add" ></modus-button>
+    <modus-button color="tertiary" icon-only="add" ></modus-button>
+
+    <modus-button size="small" color="primary" left-icon="add" >Primary</modus-button>
+    <modus-button size="small" color="secondary"  right-icon="add">Secondary</modus-button>
+    <modus-button size="small" left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
+
+    <modus-button color="primary" size="small" icon-only="add" ></modus-button>
+    <modus-button color="secondary" size="small" icon-only="add" ></modus-button>
+    <modus-button color="tertiary" size="small" icon-only="add" ></modus-button>
+
+    <modus-button size="large" color="primary" left-icon="add" >Primary</modus-button>
+    <modus-button size="large" color="secondary"  right-icon="add">Secondary</modus-button>
+    <modus-button size="large" left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
+
+    <modus-button color="primary" size="large" icon-only="add" ></modus-button>
+    <modus-button color="secondary" size="large" icon-only="add" ></modus-button>
+    <modus-button color="tertiary" size="large" icon-only="add" ></modus-button>
+
+    <modus-button left-icon="add"  button-style="borderless">Borderless</modus-button>
+    <modus-button right-icon="add" button-style="borderless">Borderless</modus-button>
+    <modus-button left-icon="add" right-icon="add" button-style="borderless">Borderless</modus-button>
+
+    <modus-button left-icon="add" button-style="outline" color="primary">Outline</modus-button>
+    <modus-button right-icon="add" button-style="outline" color="secondary">Outline</modus-button>
+    <modus-button left-icon="add" right-icon="add" button-style="outline" color="secondary">Outline</modus-button>
   </body>
 </html>

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -14,39 +14,72 @@
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
     <link rel="stylesheet" src="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" />
 
+    <style>
+      .flex-column{
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      .flex-row{
+        display: flex;
+        flex-direction: row;
+        gap: 10px;
+      }
+    </style>
   </head>
+
   <body>
-    <modus-button color="primary" left-icon="add" >Primary</modus-button>
-    <modus-button color="secondary"  right-icon="add">Secondary</modus-button>
-    <modus-button left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
-    <modus-button left-icon="add" color="danger"  right-icon="add">Tertiary</modus-button>
-
-    <modus-button color="primary" icon-only="add" ></modus-button>
-    <modus-button color="secondary" icon-only="add" ></modus-button>
-    <modus-button color="tertiary" icon-only="add" ></modus-button>
-
-    <modus-button size="small" color="primary" left-icon="add" >Primary</modus-button>
-    <modus-button size="small" color="secondary"  right-icon="add">Secondary</modus-button>
-    <modus-button size="small" left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
-
-    <modus-button color="primary" size="small" icon-only="add" ></modus-button>
-    <modus-button color="secondary" size="small" icon-only="add" ></modus-button>
-    <modus-button color="tertiary" size="small" icon-only="add" ></modus-button>
-
-    <modus-button size="large" color="primary" left-icon="add" >Primary</modus-button>
-    <modus-button size="large" color="secondary"  right-icon="add">Secondary</modus-button>
-    <modus-button size="large" left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
-
-    <modus-button color="primary" size="large" icon-only="add" ></modus-button>
-    <modus-button color="secondary" size="large" icon-only="add" ></modus-button>
-    <modus-button color="tertiary" size="large" icon-only="add" ></modus-button>
-
-    <modus-button left-icon="add"  button-style="borderless">Borderless</modus-button>
-    <modus-button right-icon="add" button-style="borderless">Borderless</modus-button>
-    <modus-button left-icon="add" right-icon="add" button-style="borderless">Borderless</modus-button>
-
-    <modus-button left-icon="add" button-style="outline" color="primary">Outline</modus-button>
-    <modus-button right-icon="add" button-style="outline" color="secondary">Outline</modus-button>
-    <modus-button left-icon="add" right-icon="add" button-style="outline" color="secondary">Outline</modus-button>
-  </body>
+    <div class="flex-column">
+       <div class="flex-row">
+          <modus-button color="primary" left-icon="add" >Primary</modus-button>
+          <modus-button color="secondary"  right-icon="add">Secondary</modus-button>
+          <modus-button left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
+          <modus-button left-icon="add" color="danger"  right-icon="add">Tertiary</modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button size="small" color="primary" left-icon="add" >Primary</modus-button>
+          <modus-button size="small" color="secondary"  right-icon="add">Secondary</modus-button>
+          <modus-button size="small" left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button size="large" color="primary" left-icon="add" >Primary</modus-button>
+          <modus-button size="large" color="secondary"  right-icon="add">Secondary</modus-button>
+          <modus-button size="large" left-icon="add" color="tertiary"  right-icon="add">Tertiary</modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button left-icon="add"  button-style="borderless">Borderless</modus-button>
+          <modus-button right-icon="add" button-style="borderless">Borderless</modus-button>
+          <modus-button left-icon="add" right-icon="add" button-style="borderless">Borderless</modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button left-icon="add" button-style="outline" color="primary">Outline</modus-button>
+          <modus-button right-icon="add" button-style="outline" color="secondary">Outline</modus-button>
+          <modus-button left-icon="add" right-icon="add" button-style="outline" color="secondary">Outline</modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button color="primary" icon-only="add" ></modus-button>
+          <modus-button color="secondary" icon-only="add" ></modus-button>
+          <modus-button color="tertiary" icon-only="add" ></modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button color="primary" size="small" icon-only="add" ></modus-button>
+          <modus-button color="secondary" size="small" icon-only="add" ></modus-button>
+          <modus-button color="tertiary" size="small" icon-only="add" ></modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button color="primary" size="large" icon-only="add" ></modus-button>
+          <modus-button color="secondary" size="large" icon-only="add" ></modus-button>
+          <modus-button color="tertiary" size="large" icon-only="add" ></modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button button-style="outline" color="primary" icon-only="notifications"></modus-button>
+          <modus-button button-style="outline" color="secondary" icon-only="notifications"></modus-button>
+       </div>
+       <div class="flex-row">
+          <modus-button button-style="borderless" color="primary" icon-only="notifications"></modus-button>
+          <modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
+          <modus-button button-style="borderless" color="tertiary" icon-only="notifications"></modus-button>
+       </div>
+    </div>
+ </body>
 </html>

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
@@ -17,7 +17,7 @@ For Text Buttons and Icon with Text Buttons,
 For Icon only Buttons,
 - Solid buttons supports all the given colors except `danger`.
 - Outline buttons only support `primary` and `secondary` colors.
-- Borderless buttons only support `primary`, `secondary` and `tertiary` colors.
+- Borderless buttons supports all the given colors except `danger`.
 
 
 <Anchor storyId="components-button--default" />
@@ -34,6 +34,13 @@ For Icon only Buttons,
 <modus-button size="small" color="primary">Small</modus-button>
 <modus-button size="large" color="primary">Large</modus-button>
 
+### Loading Button
+
+<modus-button color="primary" disabled>
+  <modus-spinner color="white" size=".5rem"></modus-spinner>
+  &nbsp;Loading...
+</modus-button>
+
 <Anchor storyId="components-button--borderless" />
 
 ### Borderless
@@ -48,8 +55,6 @@ For Icon only Buttons,
 <modus-button button-style="outline" color="secondary">Outline</modus-button>
 
 
-
-
 ```html
 <modus-button color="primary">Primary</modus-button>
 <modus-button color="secondary">Secondary</modus-button>
@@ -60,6 +65,11 @@ For Icon only Buttons,
 
 <modus-button size="small" color="primary">Small</modus-button>
 <modus-button size="large" color="primary">Large</modus-button>
+
+<modus-button color="primary" disabled>
+  <modus-spinner color="white" size=".5rem"></modus-spinner>
+  &nbsp;Loading...
+</modus-button>
 
 <modus-button button-style="borderless">Borderless</modus-button>
 
@@ -119,19 +129,34 @@ For Icon only Buttons,
 <modus-button button-style="borderless" color="tertiary" icon-only="notifications"></modus-button>
 ```
 
+<Anchor storyId="components-button--with-caret" />
+
+### With Caret Icon
+
+Users can choose to show a caret icon at the right side of the button using  `show-caret`. Note: Only one icon should be added to the right position, which means if `show-caret` is `true`, `right-icon` will not be effective.
+
+<modus-button color="primary" show-caret="true">Primary</modus-button>
+<modus-button color="secondary" button-style="borderless"  icon-only="notifications" show-caret="true"></modus-button>
+
+
+```html
+<modus-button color="primary" show-caret="true">Primary</modus-button>
+<modus-button color="secondary" button-style="borderless"  icon-only="notifications" show-caret="true"></modus-button>
+```
+
 ### Properties
 
-| Property      | Attribute      | Description                                                                              | Type                                                           | Default     |
-| ------------- | -------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------- |
-| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                      | `string`                                                       | `undefined` |
-| `buttonStyle` | `button-style` | (optional) The style of the button                                                       | `"borderless" , "fill" , "outline"`                          | `'fill'`    |
-| `color`       | `color`        | (optional) The color of the button. | `"danger" , "primary" , "secondary" , "tertiary"` | `'primary'` |
-| `disabled`    | `disabled`     | (optional) Disables the button.                                                          | `boolean`                                                      | `undefined` |
-| `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                          | `string`                                                       | `undefined` |
-| `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.                        | `string`                                                       | `undefined` |
-| `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text.                       | `string`                                                       | `undefined` |
-| `size`        | `size`         | (optional) The size of the button.                                                       | `"large" , "medium" , "small"`                               | `'medium'`  |
-
+| Property      | Attribute      | Description                                                                                | Type                                                 | Default     |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------- | ----------- |
+| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                        | `string`                                             | `undefined` |
+| `buttonStyle` | `button-style` | (optional) The style of the button                                                         | `"borderless" , "fill" , "outline"`                | `'fill'`    |
+| `color`       | `color`        | (optional) The color of the button                                                         | `"danger" ,"primary" , "secondary" , "tertiary"` | `'primary'` |
+| `disabled`    | `disabled`     | (optional) Disables the button.                                                            | `boolean`                                            | `undefined` |
+| `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                            | `string`                                             | `undefined` |
+| `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.  | `string`                                             | `undefined` |
+| `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                             | `undefined` |
+| `showCaret`   | `show-caret`   | (optional) Shows a caret icon right side of the button.                                    | `boolean`                                            | `undefined` |
+| `size`        | `size`         | (optional) The size of the button.                                                         | `"large" ,"medium" , "small"`                     | `'medium'`  |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
@@ -9,8 +9,16 @@ This component utilizes the slot element, allowing you to render your own HTML i
 
 #### Implementation Details
 
-- Outline buttons only support 'primary' and 'secondary' colors.
-- Borderless buttons only support a single color.
+For Text Buttons and Icon with Text Buttons,
+- Solid buttons supports all the given colors except `dark`.
+- Outline buttons only support `primary` and `secondary` colors.
+- Borderless buttons only support `primary` color.
+
+For Icon only Buttons,
+- Solid buttons supports all the given colors except `dark` and `danger`.
+- Outline buttons only support `primary` and `secondary` colors.
+- Borderless buttons only support `dark` and `secondary` colors.
+
 
 <Anchor storyId="components-button--default" />
 
@@ -39,6 +47,9 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <modus-button button-style="outline" color="primary">Outline</modus-button>
 <modus-button button-style="outline" color="secondary">Outline</modus-button>
 
+
+
+
 ```html
 <modus-button color="primary">Primary</modus-button>
 <modus-button color="secondary">Secondary</modus-button>
@@ -56,85 +67,75 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <modus-button button-style="outline" color="secondary">Outline</modus-button>
 ```
 
+<Anchor storyId="components-button--icon-with-text" />
+
+### Icon with Text Button
+
+<modus-button size="small" left-icon="notifications" >Primary</modus-button>
+<modus-button color="secondary" right-icon="notifications">Secondary</modus-button>
+<modus-button size="large" left-icon="notifications" color="tertiary"  right-icon="notifications">Tertiary</modus-button>
+<modus-button size="large" left-icon="add" color="danger"  right-icon="remove">Danger</modus-button>
+
+<Anchor storyId="components-button--icon-only" />
+
+### Icon Only Button
+
+#### Solid
+
+<modus-button size="small" color="primary" icon-only="notifications"></modus-button>
+<modus-button color="secondary" icon-only="notifications"></modus-button>
+<modus-button size="large" color="tertiary" icon-only="notifications"></modus-button>
+
+#### Outline
+
+<modus-button button-style="outline" color="primary" icon-only="notifications"></modus-button>
+<modus-button button-style="outline" color="secondary" icon-only="notifications"></modus-button>
+
+#### Borderless
+
+<modus-button button-style="borderless" color="dark" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
+
+```html
+<!-- Icon with Text Buttons -->
+<modus-button size="small" left-icon="notifications" >Primary</modus-button>
+<modus-button color="secondary" right-icon="notifications">Secondary</modus-button>
+<modus-button size="large" left-icon="notifications" color="tertiary"  right-icon="notifications">Tertiary</modus-button>
+<modus-button size="large" left-icon="add" color="danger"  right-icon="remove">Danger</modus-button>
+
+<!-- Icon only Buttons - Default(Fill) -->
+<modus-button size="small" color="primary" icon-only="notifications"></modus-button>
+<modus-button color="secondary" icon-only="notifications"></modus-button>
+<modus-button size="large" color="tertiary" icon-only="notifications"></modus-button>
+
+<!-- Icon only Buttons - Outline -->
+<modus-button button-style="outline" color="primary" icon-only="notifications"></modus-button>
+<modus-button button-style="outline" color="secondary" icon-only="notifications"></modus-button>
+
+<!-- Icon only Buttons - Borderless -->
+<modus-button button-style="borderless" color="dark" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
+```
+
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>aria-label</td>
-        <td>The button's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>button-style</td>
-        <td>The style of the button</td>
-        <td>string</td>
-        <td>'borderless', 'fill', 'outline'</td>
-        <td>'fill'</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>color</td>
-        <td>The color of the button</td>
-        <td>string</td>
-        <td>'danger', 'primary', 'secondary', 'tertiary'</td>
-        <td>'primary'</td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>disabled</td>
-        <td>Disables the button</td>
-        <td>boolean</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>size</td>
-        <td>The size of the button</td>
-        <td>string</td>
-        <td>'small', 'medium', 'large'</td>
-        <td>'medium'</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Property      | Attribute      | Description                                                                              | Type                                                           | Default     |
+| ------------- | -------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------- |
+| `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                      | `string`                                                       | `undefined` |
+| `buttonStyle` | `button-style` | (optional) The style of the button                                                       | `"borderless" , "fill" , "outline"`                          | `'fill'`    |
+| `color`       | `color`        | (optional) The color of the button. Note: `dark` is supported only on icon-only buttons. | `"danger" , "dark" , "primary" , "secondary" , "tertiary"` | `'primary'` |
+| `disabled`    | `disabled`     | (optional) Disables the button.                                                          | `boolean`                                                      | `undefined` |
+| `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                          | `string`                                                       | `undefined` |
+| `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.                        | `string`                                                       | `undefined` |
+| `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text.                       | `string`                                                       | `undefined` |
+| `size`        | `size`         | (optional) The size of the button.                                                       | `"large" , "medium" , "small"`                               | `'medium'`  |
+
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>buttonClick</td>
-        <td>Fires on button click</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Event         | Description                                     | Type               |
+| ------------- | ----------------------------------------------- | ------------------ |
+| `buttonClick` | (optional) An event that fires on button click. | `CustomEvent<any>` |
 
 ### Methods
 

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
@@ -10,14 +10,14 @@ This component utilizes the slot element, allowing you to render your own HTML i
 #### Implementation Details
 
 For Text Buttons and Icon with Text Buttons,
-- Solid buttons supports all the given colors except `dark`.
+- Solid buttons supports all the given colors.
 - Outline buttons only support `primary` and `secondary` colors.
 - Borderless buttons only support `primary` color.
 
 For Icon only Buttons,
-- Solid buttons supports all the given colors except `dark` and `danger`.
+- Solid buttons supports all the given colors except `danger`.
 - Outline buttons only support `primary` and `secondary` colors.
-- Borderless buttons only support `dark` and `secondary` colors.
+- Borderless buttons only support `primary`, `secondary` and `tertiary` colors.
 
 
 <Anchor storyId="components-button--default" />
@@ -93,8 +93,9 @@ For Icon only Buttons,
 
 #### Borderless
 
-<modus-button button-style="borderless" color="dark" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="primary" icon-only="notifications"></modus-button>
 <modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="tertiary" icon-only="notifications"></modus-button>
 
 ```html
 <!-- Icon with Text Buttons -->
@@ -113,8 +114,9 @@ For Icon only Buttons,
 <modus-button button-style="outline" color="secondary" icon-only="notifications"></modus-button>
 
 <!-- Icon only Buttons - Borderless -->
-<modus-button button-style="borderless" color="dark" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="primary" icon-only="notifications"></modus-button>
 <modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="tertiary" icon-only="notifications"></modus-button>
 ```
 
 ### Properties
@@ -123,7 +125,7 @@ For Icon only Buttons,
 | ------------- | -------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ----------- |
 | `ariaLabel`   | `aria-label`   | (optional) The button's aria-label.                                                      | `string`                                                       | `undefined` |
 | `buttonStyle` | `button-style` | (optional) The style of the button                                                       | `"borderless" , "fill" , "outline"`                          | `'fill'`    |
-| `color`       | `color`        | (optional) The color of the button. Note: `dark` is supported only on icon-only buttons. | `"danger" , "dark" , "primary" , "secondary" , "tertiary"` | `'primary'` |
+| `color`       | `color`        | (optional) The color of the button. | `"danger" , "primary" , "secondary" , "tertiary"` | `'primary'` |
 | `disabled`    | `disabled`     | (optional) Disables the button.                                                          | `boolean`                                                      | `undefined` |
 | `iconOnly`    | `icon-only`    | (optional) Takes the icon name and renders an icon-only button.                          | `string`                                                       | `undefined` |
 | `leftIcon`    | `left-icon`    | (optional) Takes the icon name and shows the icon aligned to the left of the button text.                        | `string`                                                       | `undefined` |

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
@@ -26,13 +26,13 @@ export default {
     },
     color: {
       control: {
-        options: ['danger', 'primary', 'secondary', 'tertiary'],
+        options: ['danger', 'primary', 'secondary', 'tertiary', 'dark'],
         type: 'select',
       },
-      description: 'The color of the button',
+      description: 'The color of the button. Note: `dark` is supported only on icon-only buttons.',
       table: {
         defaultValue: { summary: `'primary'` },
-        type: { summary: `'danger' | 'primary' | 'secondary' | 'tertiary'` },
+        type: { summary: `'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark'` },
       },
     },
     disabled: {
@@ -51,6 +51,27 @@ export default {
       table: {
         defaultValue: { summary: `'medium'` },
         type: { summary: `'small' | 'medium' | 'large'` },
+      },
+    },
+    iconOnly: {
+      name: 'icon-only',
+      description: "Takes the icon name and renders an icon-only button",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    leftIcon: {
+      name: 'left-icon',
+      description: "Takes the icon name and shows the icon aligned to the left of the button text",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    rightIcon: {
+      name: 'right-icon',
+      description: "Takes the icon name and shows the icon aligned to the right of the button text",
+      table: {
+        type: { summary: 'string' },
       },
     },
   },
@@ -74,13 +95,16 @@ export const Default = ({
   color,
   disabled,
   size,
+  leftIcon,
+  rightIcon,
+  iconOnly
 }) => html`
   <modus-button
     aria-label=${ariaLabel}
     button-style=${buttonStyle}
     color=${color}
     disabled=${disabled}
-    size=${size}>
+    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
     Default
   </modus-button>
 `;
@@ -98,13 +122,16 @@ export const Borderless = ({
   color,
   disabled,
   size,
+  leftIcon,
+  rightIcon,
+  iconOnly
 }) => html`
   <modus-button
     aria-label=${ariaLabel}
     button-style=${buttonStyle}
     color=${color}
     disabled=${disabled}
-    size=${size}>
+    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
     Borderless
   </modus-button>
 `;
@@ -122,13 +149,16 @@ export const Outline = ({
   color,
   disabled,
   size,
+  leftIcon,
+  rightIcon,
+  iconOnly
 }) => html`
   <modus-button
     aria-label=${ariaLabel}
     button-style=${buttonStyle}
     color=${color}
     disabled=${disabled}
-    size=${size}>
+    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
     Outline
   </modus-button>
 `;
@@ -138,4 +168,59 @@ Outline.args = {
   color: 'default',
   disabled: false,
   size: 'medium',
+};
+
+export const IconWithText = ({
+  ariaLabel,
+  buttonStyle,
+  color,
+  disabled,
+  size,
+  leftIcon,
+  rightIcon,
+  iconOnly
+}) => html`
+  <modus-button
+    aria-label=${ariaLabel}
+    button-style=${buttonStyle}
+    color=${color}
+    disabled=${disabled}
+    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
+    Default
+  </modus-button>
+`;
+IconWithText.args = {
+  ariaLabel: '',
+  buttonStyle: 'fill',
+  color: 'primary',
+  disabled: false,
+  size: 'medium',
+  leftIcon: 'notifications'
+};
+
+export const IconOnly = ({
+  ariaLabel,
+  buttonStyle,
+  color,
+  disabled,
+  size,
+  leftIcon,
+  rightIcon,
+  iconOnly
+}) => html`
+  <modus-button
+    aria-label=${ariaLabel}
+    button-style=${buttonStyle}
+    color=${color}
+    disabled=${disabled}
+    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} icon-only=${iconOnly}>
+  </modus-button>
+`;
+IconOnly.args = {
+  ariaLabel: '',
+  buttonStyle: 'borderless',
+  color: 'dark',
+  disabled: false,
+  size: 'large',
+  iconOnly: 'notifications'
 };

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
@@ -53,6 +53,13 @@ export default {
         type: { summary: `'small' | 'medium' | 'large'` },
       },
     },
+    showCaret: {
+      description: 'Shows a caret icon right side of the button',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
     iconOnly: {
       name: 'icon-only',
       description: "Takes the icon name and renders an icon-only button",
@@ -89,7 +96,7 @@ export default {
   },
 };
 
-export const Default = ({
+const DefaultTemplate = ({
   ariaLabel,
   buttonStyle,
   color,
@@ -97,130 +104,65 @@ export const Default = ({
   size,
   leftIcon,
   rightIcon,
-  iconOnly
+  iconOnly,
+  showCaret,
+  label
 }) => html`
   <modus-button
     aria-label=${ariaLabel}
     button-style=${buttonStyle}
     color=${color}
     disabled=${disabled}
-    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
-    Default
+    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} icon-only=${iconOnly} show-caret=${showCaret}>
+    ${label}
   </modus-button>
 `;
-Default.args = {
+
+const DefaultTemplateArgs = {
   ariaLabel: '',
   buttonStyle: 'fill',
   color: 'primary',
   disabled: false,
   size: 'medium',
+  leftIcon: '',
+  rightIcon: '',
+  iconOnly: '',
+  showCaret: false,
+  label: 'Default'
 };
 
-export const Borderless = ({
-  ariaLabel,
-  buttonStyle,
-  color,
-  disabled,
-  size,
-  leftIcon,
-  rightIcon,
-  iconOnly
-}) => html`
-  <modus-button
-    aria-label=${ariaLabel}
-    button-style=${buttonStyle}
-    color=${color}
-    disabled=${disabled}
-    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
-    Borderless
-  </modus-button>
-`;
-Borderless.args = {
-  ariaLabel: '',
-  buttonStyle: 'borderless',
-  color: 'default',
-  disabled: false,
-  size: 'medium',
+
+export const Default = DefaultTemplate.bind({});
+Default.args = { ...DefaultTemplateArgs
 };
 
-export const Outline = ({
-  ariaLabel,
-  buttonStyle,
-  color,
-  disabled,
-  size,
-  leftIcon,
-  rightIcon,
-  iconOnly
-}) => html`
-  <modus-button
-    aria-label=${ariaLabel}
-    button-style=${buttonStyle}
-    color=${color}
-    disabled=${disabled}
-    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
-    Outline
-  </modus-button>
-`;
-Outline.args = {
-  ariaLabel: '',
-  buttonStyle: 'outline',
-  color: 'default',
-  disabled: false,
-  size: 'medium',
+export const Borderless = DefaultTemplate.bind({});
+Borderless.args = {...DefaultTemplateArgs,
+  buttonStyle: 'borderless', label: 'Borderless',
 };
 
-export const IconWithText = ({
-  ariaLabel,
-  buttonStyle,
-  color,
-  disabled,
-  size,
-  leftIcon,
-  rightIcon,
-  iconOnly
-}) => html`
-  <modus-button
-    aria-label=${ariaLabel}
-    button-style=${buttonStyle}
-    color=${color}
-    disabled=${disabled}
-    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} iconOnly=${iconOnly}>
-    Default
-  </modus-button>
-`;
-IconWithText.args = {
-  ariaLabel: '',
-  buttonStyle: 'fill',
-  color: 'primary',
-  disabled: false,
-  size: 'medium',
+export const Outline = DefaultTemplate.bind({});
+Outline.args = {...DefaultTemplateArgs,
+  buttonStyle: 'outline', label: 'Outline',
+};
+
+export const IconWithText = DefaultTemplate.bind({});
+IconWithText.args = {...DefaultTemplateArgs,  label: 'Default',
   leftIcon: 'notifications'
 };
 
-export const IconOnly = ({
-  ariaLabel,
-  buttonStyle,
-  color,
-  disabled,
-  size,
-  leftIcon,
-  rightIcon,
-  iconOnly
-}) => html`
-  <modus-button
-    aria-label=${ariaLabel}
-    button-style=${buttonStyle}
-    color=${color}
-    disabled=${disabled}
-    size=${size} left-icon=${leftIcon} right-icon=${rightIcon} icon-only=${iconOnly}>
-  </modus-button>
-`;
-IconOnly.args = {
-  ariaLabel: '',
-  buttonStyle: 'borderless',
-  color: 'secondary',
-  disabled: false,
-  size: 'large',
-  iconOnly: 'notifications'
+export const IconOnly = DefaultTemplate.bind({});
+IconOnly.args = {...DefaultTemplateArgs,  label: '', buttonStyle: 'borderless',
+color: 'secondary',
+size: 'large',
+iconOnly: 'notifications',
+showCaret: false
 };
+
+export const WithCaret = DefaultTemplate.bind({});
+WithCaret.args = {...DefaultTemplateArgs,  label: 'Primary',
+color: 'primary',
+disabled: false,
+showCaret: true
+};
+

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button.stories.tsx
@@ -26,13 +26,13 @@ export default {
     },
     color: {
       control: {
-        options: ['danger', 'primary', 'secondary', 'tertiary', 'dark'],
+        options: ['danger', 'primary', 'secondary', 'tertiary'],
         type: 'select',
       },
-      description: 'The color of the button. Note: `dark` is supported only on icon-only buttons.',
+      description: 'The color of the button',
       table: {
         defaultValue: { summary: `'primary'` },
-        type: { summary: `'danger' | 'primary' | 'secondary' | 'tertiary' | 'dark'` },
+        type: { summary: `'danger' | 'primary' | 'secondary' | 'tertiary'` },
       },
     },
     disabled: {
@@ -219,7 +219,7 @@ export const IconOnly = ({
 IconOnly.args = {
   ariaLabel: '',
   buttonStyle: 'borderless',
-  color: 'dark',
+  color: 'secondary',
   disabled: false,
   size: 'large',
   iconOnly: 'notifications'

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
@@ -14,7 +14,7 @@
 ### Default
 
 <modus-dropdown toggle-element-id="toggleElement">
-  <modus-button id="toggleElement" slot="dropdownToggle">
+  <modus-button id="toggleElement" slot="dropdownToggle" show-caret="true">
     Dropdown
   </modus-button>
   <modus-list slot="dropdownList">
@@ -26,7 +26,7 @@
 
 ```html
 <modus-dropdown toggle-element-id="toggleElement">
-  <modus-button id="toggleElement" slot="dropdownToggle">Dropdown</modus-button>
+  <modus-button id="toggleElement" slot="dropdownToggle" show-caret="true">Dropdown</modus-button>
   <modus-list slot="dropdownList">
     <modus-list-item size="condensed">Item 1</modus-list-item>
     <modus-list-item size="condensed">Item 2</modus-list-item>

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
@@ -22,7 +22,7 @@ export default {
 
 const Template = () => html`
   <modus-dropdown toggle-element-id="toggleElement">
-    <modus-button id="toggleElement" slot="dropdownToggle"
+    <modus-button id="toggleElement" slot="dropdownToggle" show-caret="true"
       >Dropdown</modus-button
     >
     <modus-list slot="dropdownList">

--- a/stencil-workspace/storybook/stories/components/modus-spinner/modus-spinner-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-spinner/modus-spinner-storybook-docs.mdx
@@ -12,11 +12,6 @@
 
 <modus-spinner color="tertiary"></modus-spinner>
 
-<modus-button color="primary" disabled>
-  <modus-spinner color="white" size=".5rem"></modus-spinner>
-  &nbsp;Loading...
-</modus-button>
-
 ```html
 <!-- Spinner -->
 <modus-spinner></modus-spinner>
@@ -24,12 +19,6 @@
 <modus-spinner color="secondary"></modus-spinner>
 
 <modus-spinner color="tertiary"></modus-spinner>
-
-<!-- Render in another element with different color and size -->
-<modus-button color="primary" disabled>
-  <modus-spinner color="white" size=".5rem"></modus-spinner>
-  &nbsp;Loading...
-</modus-button>
 ```
 
 ### Properties


### PR DESCRIPTION
Added support for Icon with Text Buttons, Icon-only Buttons, and Buttons with Caret Icon.

Note: The only breaking change is `--modus-btn-outline-dark-color:` replaced by `--modus-btn-outline-secondary-color:` to make it in sync with Figma.

Fixes #806,  #1539, #274, #1126

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Buttons:
https://icy-ground-0374a1310-1590.centralus.1.azurestaticapps.net/?path=/docs/components-button--default

Dropdown (added caret icon):
https://icy-ground-0374a1310-1590.centralus.1.azurestaticapps.net/?path=/docs/components-dropdown--default

Spinner (removed loading button as part of Animations Issue #1126 ):
https://icy-ground-0374a1310-1590.centralus.1.azurestaticapps.net/?path=/docs/components-spinner--default


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
