### PR TITLE
Fix incorrect triggering of disabled button events in Modal

### DIFF
--- a/stencil-workspace/src/components/modus-modal/modus-modal.e2e.ts
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.e2e.ts
@@ -118,6 +118,46 @@ describe('modus-modal', () => {
     expect(secondaryButtonClick).toHaveReceivedEvent();
   });
 
+  it('should not emit primaryButtonClick on click when disabled', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-modal primary-button-text="Primary Text"></modus-modal>');
+    const modal = await page.find('modus-modal');
+    await modal.callMethod('open');
+    await page.waitForChanges();
+    const element = await page.find('modus-modal >>> modus-button');
+    const primaryButtonClick = await page.spyOnEvent('primaryButtonClick');
+
+    modal.setProperty('primaryButtonDisabled', true);
+    await page.waitForChanges();
+
+    expect(await element.getProperty('disabled')).toBeTruthy();
+
+    await element.click();
+    await page.waitForChanges();
+    expect(primaryButtonClick).not.toHaveReceivedEvent();
+  });
+
+  it('should not emit secondaryButtonClick on click when disabled', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-modal secondary-button-text="Secondary Text"></modus-modal>');
+    const modal = await page.find('modus-modal');
+    await modal.callMethod('open');
+    await page.waitForChanges();
+    const element = await page.find('modus-modal >>> modus-button');
+    const secondaryButtonClick = await page.spyOnEvent('secondaryButtonClick');
+
+    modal.setProperty('secondaryButtonDisabled', true);
+    await page.waitForChanges();
+
+    expect(await element.getProperty('disabled')).toBeTruthy();
+
+    await element.click();
+    await page.waitForChanges();
+    expect(secondaryButtonClick).not.toHaveReceivedEvent();
+  });
+
   it('emits opened on open call', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-modal/modus-modal.tsx
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.tsx
@@ -172,7 +172,7 @@ export class ModusModal {
             button-style="outline"
             color="secondary"
             ariaLabel={this.secondaryButtonAriaLabel}
-            onClick={() => this.secondaryButtonClick.emit()}
+            onButtonClick={() => this.secondaryButtonClick.emit()}
             onKeyDown={(event) => this.handlePrimaryKeydown(event)}>
             {this.secondaryButtonText}
           </modus-button>
@@ -182,7 +182,7 @@ export class ModusModal {
             disabled={this.primaryButtonDisabled}
             color="primary"
             ariaLabel={this.primaryButtonAriaLabel}
-            onClick={() => this.primaryButtonClick.emit()}
+            onButtonClick={() => this.primaryButtonClick.emit()}
             onKeyDown={(event) => this.handleSecondaryKeydown(event)}>
             {this.primaryButtonText}
           </modus-button>

--- a/stencil-workspace/storybook/stories/components/modus-modal/modus-modal.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-modal/modus-modal.stories.tsx
@@ -78,7 +78,7 @@ export default {
   },
   parameters: {
     actions: {
-      handles: ['closed'],
+      handles: ['closed', 'primaryButtonClick', 'secondaryButtonClick'],
     },
     docs: {
       inlineStories: false,


### PR DESCRIPTION
References #1591 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Added Actions for `primaryButtonClicked` and `secodnaryButtonClicked` in Storybook canvas page. We can click on the buttons to see if the actions are showing up.

https://deploy-preview-1592--modus-webcomponents.netlify.app/?path=/story/components-modal--default&args=primaryButtonDisabled:true;secondaryButtonDisabled:true

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
