### PR TITLE
Modus Cards - Remove `backgroundColor` prop and encourage using CSS variable `--modus-card-bg`

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -203,14 +203,14 @@ export declare interface ModusButton extends Components.ModusButton {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'backgroundColor', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width']
+  inputs: ['ariaLabel', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width']
 })
 @Component({
   selector: 'modus-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'backgroundColor', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width'],
+  inputs: ['ariaLabel', 'borderRadius', 'height', 'showCardBorder', 'showShadowOnHover', 'width'],
 })
 export class ModusCard {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -202,10 +202,6 @@ export namespace Components {
          */
         "ariaLabel": string | null;
         /**
-          * (optional) The color of the card.
-         */
-        "backgroundColor": string;
-        /**
           * (optional) The border radius of the card.
          */
         "borderRadius": string;
@@ -1842,10 +1838,6 @@ declare namespace LocalJSX {
           * (optional) The card's aria-label.
          */
         "ariaLabel"?: string | null;
-        /**
-          * (optional) The color of the card.
-         */
-        "backgroundColor"?: string;
         /**
           * (optional) The border radius of the card.
          */

--- a/stencil-workspace/src/components/modus-card/modus-card.e2e.ts
+++ b/stencil-workspace/src/components/modus-card/modus-card.e2e.ts
@@ -65,21 +65,6 @@ describe('modus-card', () => {
     expect(computedStyle['borderRadius']).toEqual('10px');
   });
 
-  it('renders changes to the backgroundColor prop', async () => {
-    const page = await newE2EPage();
-
-    await page.setContent('<modus-card></modus-card>');
-    const component = await page.find('modus-card');
-    const element = await page.find('modus-card >>> article');
-    let computedStyle = await element.getComputedStyle();
-    expect(computedStyle['backgroundColor']).toEqual('rgb(255, 255, 255)');
-
-    component.setProperty('backgroundColor', 'red');
-    await page.waitForChanges();
-    computedStyle = await element.getComputedStyle();
-    expect(computedStyle['backgroundColor']).toEqual('rgb(255, 0, 0)');
-  });
-
   it('should remove class "shadow" when showShadowOnHover flag is set on "false"', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-card/modus-card.tsx
+++ b/stencil-workspace/src/components/modus-card/modus-card.tsx
@@ -16,9 +16,6 @@ export class ModusCard {
   /** (optional) The width of the card. */
   @Prop() width = '240px';
 
-  /** (optional) The color of the card. */
-  @Prop() backgroundColor: string;
-
   /** (optional) The border radius of the card. */
   @Prop() borderRadius: string;
 
@@ -36,7 +33,6 @@ export class ModusCard {
         style={{
           height: this.height,
           width: this.width,
-          'background-color': this.backgroundColor,
           'border-radius': this.borderRadius,
         }}>
         <slot />

--- a/stencil-workspace/src/components/modus-card/readme.md
+++ b/stencil-workspace/src/components/modus-card/readme.md
@@ -10,7 +10,6 @@
 | Property            | Attribute              | Description                                                                            | Type      | Default     |
 | ------------------- | ---------------------- | -------------------------------------------------------------------------------------- | --------- | ----------- |
 | `ariaLabel`         | `aria-label`           | (optional) The card's aria-label.                                                      | `string`  | `undefined` |
-| `backgroundColor`   | `background-color`     | (optional) The color of the card.                                                      | `string`  | `undefined` |
 | `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `undefined` |
 | `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `'269px'`   |
 | `showCardBorder`    | `show-card-border`     | (optional) A flag that controls the display of border.                                 | `boolean` | `true`      |

--- a/stencil-workspace/storybook/stories/components/modus-card/modus-card-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-card/modus-card-storybook-docs.mdx
@@ -6,34 +6,35 @@ import { Story } from '@storybook/addon-docs';
 
 [Modus Card](https://modus.trimble.com/components/cards/) web components are wrappers around native `<article>` elements. They are referenced using the `<modus-card>` custom HTML element.
 
-This component utilizes the slot element, allowing you to render your own HTML in the card.
+This component utilizes the slot element, allowing you to render your own HTML in the card. You can change the background color using the CSS variable `--modus-card-bg`.
 
 ### Default
 
 <Story id="components-card--default" height={'150px'} />
 
 ```html
-<modus-card>
-  <div style="padding:10px">
-    <h4 id="card-title">Card title</h4>
-    <h5 id="card-subtitle">Card subtitle</h5>
-    <p>Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-    <modus-button color="primary">Go somewhere</modus-button>
-  </div>
-</modus-card>
+<modus-card aria-label="Card" height="270px" width="250px" border-radius="1px" show-card-border="true" show-shadow-on-hover="true">
+    <!-- Render anything here -->
+    <div style="padding:10px">
+      <h4 id="card-title">Card title</h4>
+      <h5 id="card-subtitle">Card subtitle</h5>
+      <p>Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+      <modus-button color="primary">Go somewhere</modus-button>
+    </div>
+  </modus-card>
 ```
 
 ### Properties
 
-| Property            | Attribute              | Description                                                                            | Type      | Default     | Required |
-| ------------------- | ---------------------- | -------------------------------------------------------------------------------------- | --------- | ----------- | -------- |
-| `ariaLabel`         | `aria-label`           | (optional) The card's aria-label.                                                      | `string`  | `undefined` |          |
-| `backgroundColor`   | `background-color`     | (optional) The color of the card.                                                      | `string`  | `undefined` |          |
-| `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `undefined` |          |
-| `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `'269px'`   |          |
-| `showCardBorder`    | `show-card-border`     | (optional) A flag that controls the display of border.                                 | `boolean` | `true`      |          |
-| `showShadowOnHover` | `show-shadow-on-hover` | (optional) A flag that controls the display of shadow box when the element is hovered. | `boolean` | `true`      |          |
-| `width`             | `width`                | (optional) The width of the card.                                                      | `string`  | `'240px'`   |          |
+
+| Property            | Attribute              | Description                                                                            | Type      | Default     |
+| ------------------- | ---------------------- | -------------------------------------------------------------------------------------- | --------- | ----------- |
+| `ariaLabel`         | `aria-label`           | (optional) The card's aria-label.                                                      | `string`  | `undefined` |
+| `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `undefined` |
+| `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `'269px'`   |
+| `showCardBorder`    | `show-card-border`     | (optional) A flag that controls the display of border.                                 | `boolean` | `true`      |
+| `showShadowOnHover` | `show-shadow-on-hover` | (optional) A flag that controls the display of shadow box when the element is hovered. | `boolean` | `true`      |
+| `width`             | `width`                | (optional) The width of the card.                                                      | `string`  | `'240px'`   |
 
 ---
 

--- a/stencil-workspace/storybook/stories/components/modus-card/modus-card.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-card/modus-card.stories.tsx
@@ -3,22 +3,67 @@ import docs from './modus-card-storybook-docs.mdx';
 import { html } from 'lit-html';
 
 export default {
-  title: 'Components/Card',
+  title: 'Components/Card',argTypes: {
+    ariaLabel: {
+      name: 'aria-label',
+      description: "The card's aria-label",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    height: {
+      height: 'The height of the card',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'string' },
+      },
+    },
+    width: {
+      description: 'The width of the card',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'string' },
+      },
+    },
+    borderRadius: {
+      description: 'The border radius of the card',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'string' },
+      },
+    },
+    showCardBorder: {
+      description: "A flag that controls the display of border",
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    showShadowOnHover: {
+      description: 'A flag that controls the display of shadow box when the element is hovered',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+  },
   parameters: {
     docs: {
       page: docs,
     },
-    controls: {
-      disabled: true,
-    },
+    controls: { expanded: true, sort: 'requiredFirst' },
     options: {
       isToolshown: true,
     },
   },
 };
 
-const Template = () => html`
-  <modus-card>
+const Template = ({
+  ariaLabel,
+  height,
+  width,
+  borderRadius,
+  showCardBorder,
+  showShadowOnHover,}) => html`
+  <modus-card aria-label=${ariaLabel} height=${height} width=${width} border-radius=${borderRadius} show-card-border=${showCardBorder} show-shadow-on-hover=${showShadowOnHover}>
     <!-- Render anything here -->
     <div style="padding:10px">
       <h4 id="card-title">Card title</h4>
@@ -29,3 +74,11 @@ const Template = () => html`
   </modus-card>
 `;
 export const Default = Template.bind({});
+Default.args = {
+  ariaLabel: 'Card',
+  height: '270px',
+  width: '250px',
+  borderRadius: '2px',
+  showCardBorder: true,
+  showShadowOnHover: true
+};


### PR DESCRIPTION
Since we already have a CSS variable to customize the background colour for Cards, we removed the `backgroundColor` prop from Modus Cards component as it unnecessarily complicates the code.

Also enabled the controls tab for testing the properties on Storybook. 

References #1166 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## How Has This Been Tested?

Please navigate to the Modus Cards page on Storybook. Once there, you can adjust the values of various properties using the controls tab. Please note that the background colour property is no longer available.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
