### PR TITLE
Fix Modus Content Tree UI issues with drag and drop

### DIFF
--- a/stencil-workspace/src/components/modus-content-tree/modus-content-tree-drag-item.tsx
+++ b/stencil-workspace/src/components/modus-content-tree/modus-content-tree-drag-item.tsx
@@ -1,20 +1,22 @@
 // eslint-disable-next-line
 import { FunctionalComponent, h } from '@stencil/core';
 import { TreeViewItemDragState } from './modus-content-tree.types';
+import { TREE_ITEM_SIZE_CLASS } from './modus-content-tree.constants';
 
-export const ModusContentTreeDragItem: FunctionalComponent<{ draggingState: TreeViewItemDragState }> = ({
+export const ModusContentTreeDragItem: FunctionalComponent<{ draggingState: TreeViewItemDragState; size?: string }> = ({
   draggingState,
+  size,
 }) => {
   if (!draggingState) return null;
 
-  const { width, height, translation, dragContent, validTarget, targetId } = draggingState;
+  const { width, translation, dragContent, validTarget, targetId } = draggingState;
   const dragContainerStyle = {
     width: width,
-    height: height,
     transform: `translate(calc(${translation.x}px - 10%), calc(${translation.y}px - 50%))`,
     msTransform: `translateX(${translation.x}px) translateX(-10%) translateY(${translation.y}px) translateY(-50%)`,
   };
-  const className = `drag-content${targetId && !validTarget ? ' drop-block' : ' drop-allow'}`;
+  const sizeClass = `${TREE_ITEM_SIZE_CLASS.get(size || 'standard')}`;
+  const className = `drag-content${targetId && !validTarget ? ' drop-block' : ' drop-allow'} ${sizeClass}`;
 
   return <div style={{ ...dragContainerStyle }} ref={(el) => el && el.appendChild(dragContent)} class={className}></div>;
 };

--- a/stencil-workspace/src/components/modus-content-tree/modus-content-tree.constants.tsx
+++ b/stencil-workspace/src/components/modus-content-tree/modus-content-tree.constants.tsx
@@ -1,0 +1,5 @@
+export const TREE_ITEM_SIZE_CLASS: Map<string, string> = new Map([
+  ['condensed', 'small'],
+  ['standard', 'standard'],
+  ['large', 'large'],
+]);

--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item/modus-tree-view-item.tsx
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item/modus-tree-view-item.tsx
@@ -12,6 +12,7 @@ import {
 } from '@stencil/core';
 import { IconMap } from '../../icons/IconMap';
 import { TreeViewItemOptions } from '../modus-content-tree.types';
+import { TREE_ITEM_SIZE_CLASS } from '../modus-content-tree.constants';
 
 /**
  * @slot collapseIcon - Slot for custom collapse icon
@@ -68,11 +69,6 @@ export class ModusTreeViewItem {
   @State() forceUpdate = {};
   @State() slots: Map<string, boolean> = new Map();
 
-  private classBySize: Map<string, string> = new Map([
-    ['condensed', 'small'],
-    ['standard', 'standard'],
-    ['large', 'large'],
-  ]);
   private refItemContent: HTMLDivElement;
   private refLabelInput: HTMLModusTextInputElement;
   private refCheckbox: HTMLModusCheckboxElement;
@@ -381,7 +377,7 @@ export class ModusTreeViewItem {
       ...(expandable ? { 'aria-expanded': expanded ? 'true' : 'false' } : {}),
       role: 'treeitem',
     };
-    const sizeClass = `${this.classBySize.get(size || 'standard')}`;
+    const sizeClass = `${TREE_ITEM_SIZE_CLASS.get(size || 'standard')}`;
     const tabIndex: string | number = isDisabled ? -1 : this.tabIndexValue;
     const treeItemClass = `tree-item ${selected ? 'selected' : ''} ${sizeClass} ${isDisabled ? 'disabled' : ''} `;
     const treeItemChildrenClass = `tree-item-group ${sizeClass} ${expanded ? 'expanded' : ''}`;

--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view/modus-tree-view.scss
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view/modus-tree-view.scss
@@ -8,14 +8,6 @@
   top: 0;
   z-index: 99999;
 
-  &.drop-allow {
-    outline: 2px dashed $modus-tree-view-item-drag-allow !important;
-  }
-
-  &.drop-block {
-    outline: 2px dashed $modus-tree-view-item-drag-error !important;
-  }
-
   .tree-item {
     align-items: center;
     background-color: $modus-tree-view-item-bg;
@@ -24,12 +16,29 @@
     display: flex;
     font-family: $primary-font;
     font-size: $rem-16px;
-    min-height: $list-group-item-height;
+    height: $list-group-item-height;
     width: 100%;
 
     .icon-slot {
       visibility: hidden;
     }
+
+    &.large {
+      height: $list-group-item-height-lg;
+    }
+
+    &.small {
+      font-size: $rem-12px;
+      height: $list-group-item-height-sm;
+    }
+  }
+
+  &.drop-allow .tree-item {
+    border: 2px dashed $modus-tree-view-item-drag-allow !important;
+  }
+
+  &.drop-block .tree-item {
+    border: 2px dashed $modus-tree-view-item-drag-error !important;
   }
 }
 

--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view/modus-tree-view.tsx
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view/modus-tree-view.tsx
@@ -89,11 +89,12 @@ export class ModusTreeView {
   handleItemDragStart(itemId: string, dragContent: HTMLElement, event: MouseEvent) {
     const { clientX, clientY, currentTarget } = event;
     const parent = (currentTarget as HTMLElement)?.parentElement;
+    const initialDragPosition = { x: clientX, y: clientY };
     this.clearItemDropState();
     this.itemDragState = {
       dragContent,
-      origin: { x: clientX, y: clientY },
-      translation: this.INITIAL_DRAG_POSITION,
+      origin: initialDragPosition,
+      translation: initialDragPosition,
       itemId,
       width: `${parent?.offsetWidth}px`,
       height: `${parent?.offsetHeight}px`,

--- a/stencil-workspace/storybook/stories/components/modus-content-tree/modus-content-tree.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-content-tree/modus-content-tree.stories.tsx
@@ -35,12 +35,17 @@ export default {
       },
     },
     size: {
+      control: {
+        options: ['condensed', 'standard', 'large'],
+        type: 'select',
+      },
       name: 'size',
       description: 'The default size of all tree items.',
       table: {
-        type: { summary: 'string' },
+        defaultValue: { summary: `'standard'` },
+        type: { summary: `'condensed' | 'standard' | 'large' ` },
       },
-    },
+    }
   },
   parameters: {
     docs: {
@@ -89,8 +94,19 @@ const Template = ({
   </modus-tree-view>
 `;
 
-const SlotIconTemplate = () => html`
-  <modus-tree-view style="width:400px;">
+const SlotIconTemplate = ({
+  checkboxSelection,
+  multiCheckboxSelection,
+  multiSelection,
+  disableTabbing,
+  size,
+}) => html`
+  <modus-tree-view style="width:400px;"
+  checkbox-selection=${checkboxSelection ? 'true' : 'false'}
+  disable-tabbing=${disableTabbing ? 'true' : 'false'}
+  multi-checkbox-selection=${multiCheckboxSelection ? 'true' : 'false'}
+  multi-selection=${multiSelection ? 'true' : 'false'}
+  size=${size}>
     <modus-tree-view-item node-Id="1" label="Inbox">
       <svg
         slot="itemIcon"
@@ -115,25 +131,33 @@ Default.args = {
   checkboxSelection: false,
   disableTabbing: false,
   multiCheckboxSelection: false,
-  multiSelection: true,
+  multiSelection: false,
   size: 'standard',
 };
 
 export const WithIcon = SlotIconTemplate.bind({});
+WithIcon.args = {...Default.args,
+};
 
 // export const Borderless = Template.bind({});
 
 export const Condensed = Template.bind({});
-Condensed.args = { checkboxSelection: true, size: 'condensed' };
+Condensed.args = { ...Default.args, checkboxSelection: true, size: 'condensed' };
 
 export const MultiSelection = Template.bind({});
-MultiSelection.args = {
+MultiSelection.args = {...Default.args,
   multiSelection: true,
   checkboxSelection: true,
   multiCheckboxSelection: true,
 };
 
-const ActionBarTemplate = () => html`
+const ActionBarTemplate = ({
+  checkboxSelection,
+  multiCheckboxSelection,
+  multiSelection,
+  disableTabbing,
+  size,
+}) => html`
   <div
     id="tree-with-action-bar"
     style="display: flex; flex-direction: column; width: 400px;">
@@ -270,7 +294,11 @@ const ActionBarTemplate = () => html`
         </svg>
       </modus-button>
     </div>
-    <modus-tree-view>
+    <modus-tree-view checkbox-selection=${checkboxSelection ? 'true' : 'false'}
+    disable-tabbing=${disableTabbing ? 'true' : 'false'}
+    multi-checkbox-selection=${multiCheckboxSelection ? 'true' : 'false'}
+    multi-selection=${multiSelection ? 'true' : 'false'}
+    size=${size}>
       <modus-tree-view-item node-Id="1" label="Inbox">
         <modus-tree-view-item
           node-Id="2"
@@ -439,8 +467,16 @@ const ActionBarScript = () => {
 };
 
 export const CustomActionBar = ActionBarTemplate.bind({});
+CustomActionBar.args = {...Default.args,
+};
 
-const FilterTemplate = () => html`
+const FilterTemplate = ({
+  checkboxSelection,
+  multiCheckboxSelection,
+  multiSelection,
+  disableTabbing,
+  size,
+}) => html`
   <div
     id="tree-with-filter"
     style="display: flex; flex-direction: column; width: 400px;">
@@ -450,7 +486,11 @@ const FilterTemplate = () => html`
       placeholder="Search"
       disabled="true"
       include-search-icon></modus-text-input>
-    <modus-tree-view>
+    <modus-tree-view checkbox-selection=${checkboxSelection ? 'true' : 'false'}
+    disable-tabbing=${disableTabbing ? 'true' : 'false'}
+    multi-checkbox-selection=${multiCheckboxSelection ? 'true' : 'false'}
+    multi-selection=${multiSelection ? 'true' : 'false'}
+    size=${size}>
       <modus-tree-view-item node-Id="1">
         <div slot="label">Inbox</div>
         <modus-tree-view-item node-Id="2">
@@ -548,3 +588,6 @@ const FilterScript = () => {
 };
 
 export const CustomFilter = FilterTemplate.bind({});
+CustomFilter.args = {...Default.args,
+};
+


### PR DESCRIPTION
- Fixed border line for dragging content 
- Fixed dragging content initial positioning 
- Fixed and add missing controls for Storybook

References #1414 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Goto Modus Content tree - Actions bar page on the storybook and click on the drag action button to enable dragging on the tree items and click on expand action button to expand all the items. 
Now try dragging a tree item and dropping it in another location inside the tree.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
