### PR TITLE
Modus Date Picker Storybook page - Remove "under construction" warning message

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
@@ -2,8 +2,6 @@ import { Story } from '@storybook/addon-docs';
 
 # Date Input
 
-<modus-alert type="warning" message="This component is under construction!"></modus-alert>
-
 ---
 
 Modus Date Input web component is a wrapper around native `<input type="text">` element used to type the date. It is referenced using the `<modus-date-input>` custom HTML element.


### PR DESCRIPTION
Fixes #1606 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Go to Date Picker page on Storybook and should not see any warning message.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
