### PR TITLE
Fix Accessibility Errors on the User Input Components

### DIFF
--- a/stencil-workspace/src/components/modus-date-input/modus-date-input.tsx
+++ b/stencil-workspace/src/components/modus-date-input/modus-date-input.tsx
@@ -229,12 +229,9 @@ export class ModusDateInput {
             this.size
           )}`}>
           <input
-            aria-disabled={this.disabled ? 'true' : undefined}
             aria-invalid={!!this.errorText}
             aria-label={this.ariaLabel}
-            aria-readonly={this.readOnly}
-            aria-required={this.required}
-            aria-placeholder={this.placeholder}
+            aria-required={this.required?.toString()}
             autofocus={this.autoFocusInput}
             class={{ 'has-right-icon': this.showCalendarIcon }}
             disabled={this.disabled}

--- a/stencil-workspace/src/components/modus-date-input/modus-date-input.tsx
+++ b/stencil-workspace/src/components/modus-date-input/modus-date-input.tsx
@@ -217,13 +217,7 @@ export class ModusDateInput {
   render() {
     const className = `modus-date-input ${this.disabled ? 'disabled' : ''}`;
     return (
-      <div
-        aria-disabled={this.disabled ? 'true' : undefined}
-        aria-invalid={!!this.errorText}
-        aria-label={this.ariaLabel}
-        aria-readonly={this.readOnly}
-        aria-required={this.required}
-        class={className}>
+      <div class={className}>
         {this.label || this.required ? (
           <div class="label-container">
             {this.label ? <label htmlFor="date-input">{this.label}</label> : null}
@@ -235,6 +229,11 @@ export class ModusDateInput {
             this.size
           )}`}>
           <input
+            aria-disabled={this.disabled ? 'true' : undefined}
+            aria-invalid={!!this.errorText}
+            aria-label={this.ariaLabel}
+            aria-readonly={this.readOnly}
+            aria-required={this.required}
             aria-placeholder={this.placeholder}
             autofocus={this.autoFocusInput}
             class={{ 'has-right-icon': this.showCalendarIcon }}

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
@@ -106,17 +106,7 @@ export class ModusNumberInput {
     };
 
     return (
-      <div
-        aria-disabled={this.disabled ? 'true' : undefined}
-        aria-label={this.ariaLabel}
-        aria-placeholder={this.placeholder}
-        aria-invalid={!!this.errorText}
-        aria-readonly={this.readOnly}
-        aria-required={this.required}
-        aria-valuemax={this.maxValue}
-        aria-valuemin={this.minValue}
-        aria-valuenow={this.value}
-        class={buildContainerClassNames()}>
+      <div class={buildContainerClassNames()}>
         {this.label || this.required ? (
           <div class="label-container">
             {this.label ? <label>{this.label}</label> : null}
@@ -125,6 +115,15 @@ export class ModusNumberInput {
         ) : null}
         <div class={buildInputContainerClassNames()}>
           <input
+            aria-disabled={this.disabled ? 'true' : undefined}
+            aria-label={this.ariaLabel}
+            aria-placeholder={this.placeholder}
+            aria-invalid={!!this.errorText}
+            aria-readonly={this.readOnly}
+            aria-required={this.required}
+            aria-valuemax={this.maxValue}
+            aria-valuemin={this.minValue}
+            aria-valuenow={this.value}
             class={textAlignClassName}
             disabled={this.disabled}
             max={this.maxValue}

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.tsx
@@ -115,12 +115,9 @@ export class ModusNumberInput {
         ) : null}
         <div class={buildInputContainerClassNames()}>
           <input
-            aria-disabled={this.disabled ? 'true' : undefined}
             aria-label={this.ariaLabel}
-            aria-placeholder={this.placeholder}
             aria-invalid={!!this.errorText}
-            aria-readonly={this.readOnly}
-            aria-required={this.required}
+            aria-required={this.required?.toString()}
             aria-valuemax={this.maxValue}
             aria-valuemin={this.minValue}
             aria-valuenow={this.value}

--- a/stencil-workspace/src/components/modus-select/modus-select.tsx
+++ b/stencil-workspace/src/components/modus-select/modus-select.tsx
@@ -111,14 +111,11 @@ export class ModusSelect {
       this.errorText ? 'error' : this.validText ? 'valid' : this.disabled ? 'disabled' : ''
     }`;
     return (
-      <div
-        aria-disabled={this.disabled ? 'true' : undefined}
-        aria-label={this.ariaLabel}
-        aria-required={this.required}
-        class={this.disabled ? 'disabled' : undefined}>
+      <div class={this.disabled ? 'disabled' : undefined}>
         {this.renderLabel()}
         <span class="input-container">
           <select
+            aria-disabled={this.disabled ? 'true' : undefined}
             disabled={this.disabled}
             class={selectClass}
             aria-label={this.ariaLabel}

--- a/stencil-workspace/src/components/modus-select/modus-select.tsx
+++ b/stencil-workspace/src/components/modus-select/modus-select.tsx
@@ -115,7 +115,6 @@ export class ModusSelect {
         {this.renderLabel()}
         <span class="input-container">
           <select
-            aria-disabled={this.disabled ? 'true' : undefined}
             disabled={this.disabled}
             class={selectClass}
             aria-label={this.ariaLabel}
@@ -123,7 +122,7 @@ export class ModusSelect {
               this.handleSelectChange(event);
             }}
             aria-invalid={!!this.errorText}
-            aria-required={this.required}>
+            aria-required={this.required?.toString()}>
             {this.renderOptions()}
           </select>
           {this.renderSubText()}

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -149,13 +149,7 @@ export class ModusTextInput {
     };
 
     return (
-      <div
-        aria-disabled={this.disabled ? 'true' : undefined}
-        aria-invalid={!!this.errorText}
-        aria-label={this.ariaLabel}
-        aria-readonly={this.readOnly}
-        aria-required={this.required}
-        class={buildContainerClassNames()}>
+      <div class={buildContainerClassNames()}>
         {this.label || this.required ? (
           <div class={'label-container'}>
             {this.label ? <label>{this.label}</label> : null}
@@ -163,11 +157,17 @@ export class ModusTextInput {
           </div>
         ) : null}
         <div
-          class={`input-container ${this.errorText ? 'error' : this.validText ? 'valid' : ''
-            } ${this.classBySize.get(this.size)}`}
+          class={`input-container ${this.errorText ? 'error' : this.validText ? 'valid' : ''} ${this.classBySize.get(
+            this.size
+          )}`}
           onClick={() => this.textInput.focus()}>
           {this.includeSearchIcon ? <IconSearch size="16" /> : null}
           <input
+            aria-disabled={this.disabled ? 'true' : undefined}
+            aria-invalid={!!this.errorText}
+            aria-label={this.ariaLabel}
+            aria-readonly={this.readOnly}
+            aria-required={this.required}
             aria-placeholder={this.placeholder}
             class={buildTextInputClassNames()}
             disabled={this.disabled}

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -163,12 +163,9 @@ export class ModusTextInput {
           onClick={() => this.textInput.focus()}>
           {this.includeSearchIcon ? <IconSearch size="16" /> : null}
           <input
-            aria-disabled={this.disabled ? 'true' : undefined}
             aria-invalid={!!this.errorText}
             aria-label={this.ariaLabel}
-            aria-readonly={this.readOnly}
-            aria-required={this.required}
-            aria-placeholder={this.placeholder}
+            aria-required={this.required?.toString()}
             class={buildTextInputClassNames()}
             disabled={this.disabled}
             inputmode={this.inputmode}
@@ -186,6 +183,7 @@ export class ModusTextInput {
           {showPasswordToggle && (
             <div
               class="icons toggle-password"
+              role="button"
               aria-label="Show password as plain text. Warning: this will display your password on the screen."
               ref={(el) => (this.buttonTogglePassword = el as HTMLDivElement)}
               onClick={() => this.handleTogglePassword()}>

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.tsx
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.tsx
@@ -170,10 +170,8 @@ export class ModusTimePicker {
 
   getAriaControls(): { [key: string]: boolean | string } {
     return {
-      'aria-disabled': this.disabled ? 'true' : undefined,
       'aria-invalid': !!this.errorText,
       'aria-label': this.ariaLabel,
-      'aria-readonly': this.readOnly,
       'aria-required': this.required,
     };
   }

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.tsx
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.tsx
@@ -206,8 +206,10 @@ export class ModusTimePicker {
 
   // Renderers
   private renderTimeInput() {
+    const ariaControls = this.getAriaControls();
     return (
       <input
+        {...ariaControls}
         id="time-input"
         aria-label={this.label ? null : this.ariaLabel}
         aria-placeholder={this.placeholder}
@@ -239,9 +241,8 @@ export class ModusTimePicker {
   }
 
   render() {
-    const ariaControls = this.getAriaControls();
     return (
-      <div {...ariaControls} class={{ 'modus-time-picker': true, disabled: this.disabled }}>
+      <div class={{ 'modus-time-picker': true, disabled: this.disabled }}>
         <div class="time-input-wrapper">
           {this.label || this.required ? (
             <div class={'label-container'}>

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
@@ -144,6 +144,7 @@ Each character as shown in the table below can be used for representing the date
 
 - Every element in Modus Date Input is accessible through keyboard. Use `Tab` key and `Shift + Tab` key to interact with the Date Input field and the calendar view.
 - Date Input gets an `aria-label` provided by the `aria-label` property input.
+- It is recommended to pass `aria-label` when there is no label used so the input is accessible to screen readers.
 - Date Input gets an `aria-disabled` provided by the `disabled` property input.
 - Date Input gets an `aria-placeholder` provided by the `placeholder` property input.
 - Date Input gets an `aria-invalid` from `invalid` property input.

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
@@ -2,8 +2,6 @@ import { Story } from '@storybook/addon-docs';
 
 # Date Input
 
-<modus-alert type="warning" message="This component is under construction!"></modus-alert>
-
 ---
 
 Modus Date Input web component is a wrapper around native `<input type="text">` element used to type the date. It is referenced using the `<modus-date-input>` custom HTML element.

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
@@ -139,7 +139,7 @@ export default {
 };
 
 const defaultArgs = {
-  ariaLabel: '',
+  ariaLabel: 'Date Input',
   allowedCharsRegex: '[\\d\\/]',
   autoFocusInput: true,
   disableValidation: false,

--- a/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input-storybook-docs.mdx
@@ -207,6 +207,7 @@ This component is compatible with Angular reactive forms. This can be achieved t
 ### Accessibility
 
 - Number Input gets an `aria-label` provided by the `aria-label` property input.
+- It is recommended to pass `aria-label` when there is no label used so the input is accessible to screen readers.
 - Number Input gets an `aria-disabled` set to whether Number Input is disabled.
 - Number Input gets an `aria-placeholder` provided by the `placeholder` property input.
 - Number Input gets an `aria-invalid` set to whether Number Input is invalid.

--- a/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input.stories.tsx
@@ -174,7 +174,7 @@ const Template = ({
 
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: '',
+  ariaLabel: 'Number Input',
   disabled: false,
   errorText: '',
   helperText: '',

--- a/stencil-workspace/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
@@ -105,6 +105,7 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 - Select has `role` of `listbox`.
 - Select gets an `aria-label` provided by the `aria-label` property input.
+- It is recommended to pass `aria-label` when there is no label used so the input is accessible to screen readers.
 - Select gets an `aria-disabled` set to whether Select is disabled.
 - Select gets an `aria-required` set to whether the Select is required.
 - When Select has focus:

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -108,6 +108,7 @@ This component is compatible with Angular reactive forms. This can be achieved t
 ### Accessibility
 
 - Text Input gets an `aria-label` provided by the `aria-label` property input.
+- It is recommended to pass `aria-label` when there is no label used so the input is accessible to screen readers.
 - Text Input gets an `aria-disabled` set to whether Text Input is disabled.
 - Text Input gets an `aria-placeholder` provided by the `placeholder` property input.
 - Text Input gets an `aria-invalid` set to whether Text Input is invalid.

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
@@ -240,7 +240,7 @@ const Template = ({
 
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: '',
+  ariaLabel: 'Text Input',
   autoFocusInput: true,
   clearable: false,
   disabled: false,

--- a/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker-storybook-docs.mdx
@@ -125,6 +125,7 @@ import { Story } from '@storybook/addon-docs';
 ### Accessibility
 
 - Time Input gets an `aria-label` provided by the `aria-label` property input.
+- It is recommended to pass `aria-label` when there is no label used so the input is accessible to screen readers.
 - Time Input gets an `aria-disabled` provided by the `disabled` property input.
 - Time Input gets an `aria-placeholder` provided by the `placeholder` property input.
 - Time Input gets an `aria-invalid` from `invalid` property input.

--- a/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-time-picker/modus-time-picker.stories.tsx
@@ -185,7 +185,7 @@ const Template = ({
 const defaultArgs = {
   ampm: false,
   autoFormat: false,
-  ariaLabel: '',
+  ariaLabel: 'Time Input',
   autoFocusInput: true,
   disableValidation: false,
   disabled: false,


### PR DESCRIPTION
The `aria-` attributes moved from the `div` to the `input` element. 

Note: 
Did not fix the `aria-placeholder` on the Number Input Component as it is not clear whether it is okay to remove the attribute.

References #1044

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
