### PR TITLE
Select Component: Set and emit value by object ref instead of display prop

### DIFF
--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.1.51",
+      "version": "0.1.52",
       "license": "MIT",
       "dependencies": {
         "@stencil/core": "^3.3.0"

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {

--- a/stencil-workspace/src/components/modus-select/modus-select.e2e.ts
+++ b/stencil-workspace/src/components/modus-select/modus-select.e2e.ts
@@ -108,6 +108,7 @@ describe('modus-select', () => {
     const required = await page.find('modus-select >>> span.required');
     expect(required).not.toBeNull();
   });
+
   it('renders changes to value', async () => {
     const page = await newE2EPage();
 
@@ -123,18 +124,19 @@ describe('modus-select', () => {
     const button = await page.find('modus-select >>> select');
     expect(await button.getProperty('textContent')).toEqual(options[0].display);
   });
+
   it('emits valueChange event', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-select></modus-select>');
 
-    const options = [{ display: 'Option 1' }, { display: 'Option 2' }, { display: 'Option 3' }];
+    const options = [{ display: 'Option 0' }, { display: 'Option 1 - Select me!' }, { display: 'Option 2' }];
     const select = await page.find('modus-select');
     select.setProperty('optionsDisplayProp', 'display');
     select.setProperty('options', options);
     await page.waitForChanges();
 
-    const valueChange = await page.spyOnEvent('valueChange');
+    const valueChangeSpy = await page.spyOnEvent('valueChange');
     const selectElement = await page.find('modus-select >>> select');
     await selectElement.focus();
     await page.waitForChanges();
@@ -144,7 +146,7 @@ describe('modus-select', () => {
     await page.keyboard.press('Enter');
     await page.waitForChanges();
 
-    expect(valueChange).toHaveReceivedEvent();
-    expect(valueChange).toHaveReceivedEventDetail('Option 2');
+    expect(valueChangeSpy).toHaveReceivedEvent();
+    expect(valueChangeSpy).toHaveReceivedEventDetail(options[1]);
   });
 });

--- a/stencil-workspace/src/components/modus-select/modus-select.tsx
+++ b/stencil-workspace/src/components/modus-select/modus-select.tsx
@@ -45,11 +45,11 @@ export class ModusSelect {
     this.internalValue = newValue;
   }
 
-  /** The input value state. */
-  @State() internalValue: unknown;
-
   /** An event that fires on input value change. */
   @Event() valueChange: EventEmitter<unknown>;
+
+  @State() internalValue: unknown;
+  @State() optionIdMap: Map<string, unknown> = new Map();
 
   classBySize: Map<string, string> = new Map([
     ['medium', 'medium'],
@@ -60,14 +60,15 @@ export class ModusSelect {
     this.internalValue = this.value;
   }
 
-  handleItemSelect(option: unknown): void {
+  handleOptionSelect(option: unknown): void {
     this.valueChange.emit(option);
   }
 
   handleSelectChange(event: Event): void {
     const target = event.target as HTMLSelectElement;
-    const selectedValue = target.value;
-    this.handleItemSelect(selectedValue);
+    const selectedId = target.value;
+    const option = this.optionIdMap.get(selectedId);
+    this.handleOptionSelect(option);
   }
 
   renderSubText(): JSX.Element | null {
@@ -91,19 +92,15 @@ export class ModusSelect {
   }
 
   renderOptions(): JSX.Element[] {
-    return this.options?.map((option) => (
-      <option
-        value={option[this.optionsDisplayProp]}
-        key={createGuid()}
-        selected={
-          this.internalValue &&
-          (typeof option[this.optionsDisplayProp] === 'number'
-            ? Number(option[this.optionsDisplayProp]) === Number(this.internalValue)
-            : option[this.optionsDisplayProp] === this.internalValue)
-        }>
-        {option[this.optionsDisplayProp]}
-      </option>
-    ));
+    return this.options?.map((option) => {
+      const optionId = createGuid();
+      this.optionIdMap.set(optionId, option);
+      return (
+        <option value={optionId} key={optionId} selected={option === this.internalValue}>
+          {option[this.optionsDisplayProp]}
+        </option>
+      );
+    });
   }
 
   render(): unknown {

--- a/stencil-workspace/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-select/modus-select-storybook-docs.mdx
@@ -18,37 +18,14 @@ This component is compatible with Angular reactive forms. This can be achieved t
   id="select-demo-1"
   label="Select Demo 1"
   options-display-prop="display"></modus-select>
-<script>
-  const modusSelect = document.querySelector('#select-demo-1');
-  modusSelect.options = [
-    { display: 'Option 1' },
-    { display: 'Option 2' },
-    { display: 'Option 3' },
-  ];
-  const handleChange = (event) => {
-      const selectedValue = event.detail;
-      event.target.value = selectedValue;
-    };
-  modusSelect.addEventListener('valueChange', handleChange)
-</script>
 
 <!-- Disabled with helper text and preset value -->
 <modus-select
+  id="select-demo-2"
   disabled
   helper-text="Helper demo"
-  id="select-demo-2"
   label="Select Demo 2"
   options-display-prop="display"></modus-select>
-<script>
-  const modusSelect = document.querySelector('#select-demo-2');
-  const options = [
-    { display: 'Option 1' },
-    { display: 'Option 2' },
-    { display: 'Option 3' },
-  ];
-  modusSelect.options = options;
-  modusSelect.value = options[1];
-</script>
 
 <!-- Error -->
 <modus-select error-text="Error demo" label="Select Demo 3"></modus-select>
@@ -56,26 +33,43 @@ This component is compatible with Angular reactive forms. This can be achieved t
 <!-- Valid -->
 <modus-select label="Select Demo 4" valid-text="Valid demo"></modus-select>
 
-<!-- 'Large select -->
+<!-- Large select -->
 <modus-select
   id="select-demo-5"
   label="Select Demo 5"
   size="large"
   options-display-prop="display"></modus-select>
+
 <script>
-  const modusSelect = document.querySelector('#select-demo-5');
-  modusSelect.options = [
+  const options = [
     { display: 'Option 1' },
     { display: 'Option 2' },
     { display: 'Option 3' },
   ];
-  modusSelect.options = options;
-  modusSelect.value = options[1];
-  const handleChange = (event) => {
-      const selectedValue = event.detail;
-      event.target.value = selectedValue;
-    };
-  modusSelect.addEventListener('valueChange', handleChange)
+
+  const select1 = document.querySelector('#select-demo-1');
+  select1.options = options;
+  select1.value = options[0];
+  select1.addEventListener('valueChange', function handleValueChange(e) {
+     const selectedOption = e.detail;
+     select1.value = selectedOption;
+  });
+
+  const select2 = document.querySelector('#select-demo-2');
+  select2.options = options;
+  select2.value = options[1];
+  select2.addEventListener('valueChange', function handleValueChange(e) {
+     const selectedOption = e.detail;
+     select2.value = selectedOption;
+  });
+
+  const select5 = document.querySelector('#select-demo-5');
+  select5.options = options;
+  select5.value = options[2];
+  select5.addEventListener('valueChange', function handleValueChange(e) {
+     const selectedOption = e.detail;
+     select5.value = selectedOption;
+  });
 </script>
 ```
 

--- a/stencil-workspace/storybook/stories/components/modus-select/modus-select.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-select/modus-select.stories.tsx
@@ -16,15 +16,14 @@ export default {
       disabled: true,
     },
     viewMode: 'docs',
+    actions: {
+      handles: ['valueChange'],
+    },
   },
 };
 
 const Template = () => html`
-  <modus-select
-    id="select-demo-1"
-    label="Select Demo 1"
-    aria-label="select"
-    options-display-prop="display"></modus-select>
+  <modus-select id="select-demo-1" label="Select Demo 1" aria-label="select" options-display-prop="display"></modus-select>
   <modus-select
     disabled
     helper-text="Helper demo"
@@ -32,46 +31,39 @@ const Template = () => html`
     id="select-demo-2"
     label="Select Demo 2"
     options-display-prop="display"></modus-select>
+  <modus-select error-text="Error demo" aria-label="select" label="Select Demo 3"></modus-select>
+  <modus-select label="Select Demo 4" aria-label="select" valid-text="Valid demo"></modus-select>
   <modus-select
-    error-text="Error demo"
-    aria-label="select"
-    label="Select Demo 3"></modus-select>
-  <modus-select
-    label="Select Demo 4"
-    aria-label="select"
-    valid-text="Valid demo"></modus-select>
-    <modus-select
     id="select-demo-5"
     label="Select Demo 5"
     size="large"
     aria-label="select"
     options-display-prop="display"></modus-select>
   ${setSelects()}
-  `;
+`;
 
 export const Default = Template.bind({});
 
 const setSelects = () => {
   const tag = document.createElement('script');
   tag.innerHTML = `
-    const modusSelect = document.querySelector('#select-demo-1');
-    modusSelect.options = [ { display: 'Option 1' }, { display: 'Option 2' }, { display: 'Option 3' } ];
+      const options = [
+        { display: 'Option 1' },
+        { display: 'Option 2' },
+        { display: 'Option 3' },
+      ];
 
-    const modusSelect2 = document.querySelector('#select-demo-2');
-    const options = [ { display: 'Option 1' }, { display: 'Option 2' }, { display: 'Option 3' } ];
-    modusSelect2.options = options;
-    modusSelect2.value = options[1]
+      const select1 = document.querySelector('#select-demo-1');
+      select1.options = options;
+      select1.value = options[0];
 
-    const modusSelect3 = document.querySelector('#select-demo-5');
-    const options3 = [ { display: 'Option 1' }, { display: 'Option 2' }, { display: 'Option 3' } ];
-    modusSelect3.options = options3;
-    modusSelect3.value = options3[1]
+      const select2 = document.querySelector('#select-demo-2');
+      select2.options = options;
+      select2.value = options[1];
 
-    const handleChange = (event) => {
-      const selectedValue = event.detail;
-      event.target.value = selectedValue;
-    };
-    modusSelect.addEventListener('valueChange', handleChange)
+      const select5 = document.querySelector('#select-demo-5');
+      select5.options = options;
+      select5.value = options[2];
   `;
 
   return tag;


### PR DESCRIPTION
## Description

This fixes an issue where the setter and emitter for the current value was using the object's display property rather than the object itself.

Closes #1643

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

## How Has This Been Tested?

Manually installing into our project, and e2e tests.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
