### PR TITLE
Use `<a>` for Navbar apps menu apps. Fix Navbar doc snippets

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.scss
@@ -24,6 +24,7 @@
     cursor: default;
     display: flex;
     padding: $rem-4px;
+    text-decoration: none;
     width: 100%;
 
     &:hover {

--- a/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.tsx
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.tsx
@@ -21,7 +21,8 @@ export class ModusNavbarAppsMenu {
 
   @Event() appOpen: EventEmitter<ModusNavbarApp>;
 
-  clickAppHandler(app: ModusNavbarApp): void {
+  clickAppHandler(event: MouseEvent, app: ModusNavbarApp): void {
+    event.preventDefault();
     window.open(app.url, '_blank');
     this.appOpen.emit(app);
   }
@@ -34,13 +35,13 @@ export class ModusNavbarAppsMenu {
         {this.apps?.map((app) => (
           <div class="app-div">
             {app.showCategory ? <div class="category">{app.category}</div> : null}
-            <div class="app" onClick={() => this.clickAppHandler(app)}>
+            <a class="app" href={app.url} onClick={(event) => this.clickAppHandler(event, app)}>
               <img src={app.logoUrl} />
               <div class="right">
                 <div class="name">{app.name}</div>
                 {app.description ? <div class="description">{app.description}</div> : null}
               </div>
-            </div>
+            </a>
           </div>
         ))}
       </div>

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -37,17 +37,10 @@ This component utilizes the slot element, allowing you to render your own HTML i
   const element = document.querySelector('modus-navbar');
   element.apps = [
     {
-      description: [
-        {
-          description: 'The One Trimble Design System',
-          logoUrl: 'https://modus.trimble.com/favicon.svg',
-          name: 'Trimble Modus',
-          url: 'https://modus.trimble.com/',
-        },
-      ],
-      logoUrl: '',
-      name: '',
-      url: ''
+        description: 'The One Trimble Design System',
+        logoUrl: 'https://modus.trimble.com/favicon.svg',
+        name: 'Trimble Modus',
+        url: 'https://modus.trimble.com/',
     },
   ];
   element.logoOptions = {
@@ -89,17 +82,10 @@ This component utilizes the slot element, allowing you to render your own HTML i
   const element = document.querySelector('modus-navbar');
   element.apps = [
     {
-      description: [
-        {
-          description: 'The One Trimble Design System',
-          logoUrl: 'https://modus.trimble.com/favicon.svg',
-          name: 'Trimble Modus',
-          url: 'https://modus.trimble.com/',
-        },
-      ],
-      logoUrl: '',
-      name: '',
-      url: ''
+        description: 'The One Trimble Design System',
+        logoUrl: 'https://modus.trimble.com/favicon.svg',
+        name: 'Trimble Modus',
+        url: 'https://modus.trimble.com/',
     },
   ];
   element.logoOptions = {
@@ -140,17 +126,10 @@ Use the `variant` prop to choose a blue background navbar.
   const element = document.querySelector('modus-navbar');
   element.apps = [
     {
-      description: [
-        {
-          description: 'The One Trimble Design System',
-          logoUrl: 'https://modus.trimble.com/favicon.svg',
-          name: 'Trimble Modus',
-          url: 'https://modus.trimble.com/',
-        },
-      ],
-      logoUrl: '',
-      name: '',
-      url: ''
+        description: 'The One Trimble Design System',
+        logoUrl: 'https://modus.trimble.com/favicon.svg',
+        name: 'Trimble Modus',
+        url: 'https://modus.trimble.com/',
     },
   ];
   element.logoOptions = {


### PR DESCRIPTION
## Description

Replace the Navbar's Apps menu apps' `<div>` elements with `<a>` elements for better accessibility and semantics

Fix navbar doc snippets

Closes #1665 

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## How Has This Been Tested?

Manually
