### PR TITLE
Added a space filler column to Modus Table

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1181,6 +1181,28 @@ export declare interface ModusTableDropdownMenu extends Components.ModusTableDro
 
 
 @ProxyCmp({
+  inputs: ['cellBorderless', 'summaryRow', 'targetTable']
+})
+@Component({
+  selector: 'modus-table-filler-column',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['cellBorderless', 'summaryRow', 'targetTable'],
+})
+export class ModusTableFillerColumn {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface ModusTableFillerColumn extends Components.ModusTableFillerColumn {}
+
+
+@ProxyCmp({
   inputs: ['options', 'table']
 })
 @Component({

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
@@ -42,6 +42,7 @@ export const DIRECTIVES = [
   d.ModusTable,
   d.ModusTableColumnsVisibility,
   d.ModusTableDropdownMenu,
+  d.ModusTableFillerColumn,
   d.ModusTableToolbar,
   d.ModusTabs,
   d.ModusTextInput,

--- a/react-workspace/react-17/src/components/stencil-generated/index.ts
+++ b/react-workspace/react-17/src/components/stencil-generated/index.ts
@@ -48,6 +48,7 @@ export const ModusSwitch = /*@__PURE__*/createReactComponent<JSX.ModusSwitch, HT
 export const ModusTable = /*@__PURE__*/createReactComponent<JSX.ModusTable, HTMLModusTableElement>('modus-table');
 export const ModusTableColumnsVisibility = /*@__PURE__*/createReactComponent<JSX.ModusTableColumnsVisibility, HTMLModusTableColumnsVisibilityElement>('modus-table-columns-visibility');
 export const ModusTableDropdownMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableDropdownMenu, HTMLModusTableDropdownMenuElement>('modus-table-dropdown-menu');
+export const ModusTableFillerColumn = /*@__PURE__*/createReactComponent<JSX.ModusTableFillerColumn, HTMLModusTableFillerColumnElement>('modus-table-filler-column');
 export const ModusTableToolbar = /*@__PURE__*/createReactComponent<JSX.ModusTableToolbar, HTMLModusTableToolbarElement>('modus-table-toolbar');
 export const ModusTabs = /*@__PURE__*/createReactComponent<JSX.ModusTabs, HTMLModusTabsElement>('modus-tabs');
 export const ModusTextInput = /*@__PURE__*/createReactComponent<JSX.ModusTextInput, HTMLModusTextInputElement>('modus-text-input');

--- a/react-workspace/react-18/src/components/stencil-generated/index.ts
+++ b/react-workspace/react-18/src/components/stencil-generated/index.ts
@@ -48,6 +48,7 @@ export const ModusSwitch = /*@__PURE__*/createReactComponent<JSX.ModusSwitch, HT
 export const ModusTable = /*@__PURE__*/createReactComponent<JSX.ModusTable, HTMLModusTableElement>('modus-table');
 export const ModusTableColumnsVisibility = /*@__PURE__*/createReactComponent<JSX.ModusTableColumnsVisibility, HTMLModusTableColumnsVisibilityElement>('modus-table-columns-visibility');
 export const ModusTableDropdownMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableDropdownMenu, HTMLModusTableDropdownMenuElement>('modus-table-dropdown-menu');
+export const ModusTableFillerColumn = /*@__PURE__*/createReactComponent<JSX.ModusTableFillerColumn, HTMLModusTableFillerColumnElement>('modus-table-filler-column');
 export const ModusTableToolbar = /*@__PURE__*/createReactComponent<JSX.ModusTableToolbar, HTMLModusTableToolbarElement>('modus-table-toolbar');
 export const ModusTabs = /*@__PURE__*/createReactComponent<JSX.ModusTabs, HTMLModusTabsElement>('modus-tabs');
 export const ModusTextInput = /*@__PURE__*/createReactComponent<JSX.ModusTextInput, HTMLModusTextInputElement>('modus-text-input');

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1074,6 +1074,14 @@ export namespace Components {
          */
         "table": Table<unknown>;
     }
+    /**
+     * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
+     */
+    interface ModusTableFillerColumn {
+        "cellBorderless": boolean;
+        "summaryRow": boolean;
+        "targetTable"?: HTMLTableElement;
+    }
     interface ModusTableToolbar {
         /**
           * (Optional) Table Panel options.
@@ -1737,6 +1745,15 @@ declare global {
         prototype: HTMLModusTableDropdownMenuElement;
         new (): HTMLModusTableDropdownMenuElement;
     };
+    /**
+     * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
+     */
+    interface HTMLModusTableFillerColumnElement extends Components.ModusTableFillerColumn, HTMLStencilElement {
+    }
+    var HTMLModusTableFillerColumnElement: {
+        prototype: HTMLModusTableFillerColumnElement;
+        new (): HTMLModusTableFillerColumnElement;
+    };
     interface HTMLModusTableToolbarElement extends Components.ModusTableToolbar, HTMLStencilElement {
     }
     var HTMLModusTableToolbarElement: {
@@ -1826,6 +1843,7 @@ declare global {
         "modus-table": HTMLModusTableElement;
         "modus-table-columns-visibility": HTMLModusTableColumnsVisibilityElement;
         "modus-table-dropdown-menu": HTMLModusTableDropdownMenuElement;
+        "modus-table-filler-column": HTMLModusTableFillerColumnElement;
         "modus-table-toolbar": HTMLModusTableToolbarElement;
         "modus-tabs": HTMLModusTabsElement;
         "modus-text-input": HTMLModusTextInputElement;
@@ -3044,6 +3062,14 @@ declare namespace LocalJSX {
          */
         "table"?: Table<unknown>;
     }
+    /**
+     * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
+     */
+    interface ModusTableFillerColumn {
+        "cellBorderless"?: boolean;
+        "summaryRow"?: boolean;
+        "targetTable"?: HTMLTableElement;
+    }
     interface ModusTableToolbar {
         /**
           * (Optional) Table Panel options.
@@ -3393,6 +3419,7 @@ declare namespace LocalJSX {
         "modus-table": ModusTable;
         "modus-table-columns-visibility": ModusTableColumnsVisibility;
         "modus-table-dropdown-menu": ModusTableDropdownMenu;
+        "modus-table-filler-column": ModusTableFillerColumn;
         "modus-table-toolbar": ModusTableToolbar;
         "modus-tabs": ModusTabs;
         "modus-text-input": ModusTextInput;
@@ -3447,6 +3474,10 @@ declare module "@stencil/core" {
             "modus-table": LocalJSX.ModusTable & JSXBase.HTMLAttributes<HTMLModusTableElement>;
             "modus-table-columns-visibility": LocalJSX.ModusTableColumnsVisibility & JSXBase.HTMLAttributes<HTMLModusTableColumnsVisibilityElement>;
             "modus-table-dropdown-menu": LocalJSX.ModusTableDropdownMenu & JSXBase.HTMLAttributes<HTMLModusTableDropdownMenuElement>;
+            /**
+             * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
+             */
+            "modus-table-filler-column": LocalJSX.ModusTableFillerColumn & JSXBase.HTMLAttributes<HTMLModusTableFillerColumnElement>;
             "modus-table-toolbar": LocalJSX.ModusTableToolbar & JSXBase.HTMLAttributes<HTMLModusTableToolbarElement>;
             "modus-tabs": LocalJSX.ModusTabs & JSXBase.HTMLAttributes<HTMLModusTabsElement>;
             "modus-text-input": LocalJSX.ModusTextInput & JSXBase.HTMLAttributes<HTMLModusTextInputElement>;

--- a/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
@@ -43,26 +43,26 @@ describe('modus-table', () => {
 
   it('Renders changes to column prop', async () => {
     const component = await page.find('modus-table');
-    let header = await page.findAll('modus-table >>> th');
+    let header = await page.findAll('modus-table >>> [data-test-id="main-table"] th');
     expect(header.length).toBe(0);
 
     component.setProperty('columns', MockColumns);
     await page.waitForChanges();
-    header = await page.findAll('modus-table >>> th');
+    header = await page.findAll('modus-table >>> [data-test-id="main-table"] th');
     expect(header.length).toBeGreaterThan(0);
     expect(header[0].textContent).toBe(MockColumns[0].header);
   });
 
   it('Renders changes to data prop', async () => {
     const component = await page.find('modus-table');
-    let row = await page.findAll('modus-table >>> td');
+    let row = await page.findAll('modus-table >>> [data-test-id="main-table"] td');
     expect(row.length).toBe(0);
 
     component.setProperty('columns', MockColumns);
     component.setProperty('data', MockData);
 
     await page.waitForChanges();
-    row = await page.findAll('modus-table >>> td');
+    row = await page.findAll('modus-table >>> [data-test-id="main-table"] td');
     expect(row.length).toBeGreaterThan(0);
     expect(row[0].textContent).toBe(MockData[0].mockColumnOne);
   });
@@ -341,7 +341,7 @@ describe('modus-table', () => {
     component.setProperty('data', MockData);
     component.setProperty('summaryRow', false);
     await page.waitForChanges();
-    let footerContainer = await page.find('modus-table >>> summary-row');
+    let footerContainer = await page.find('modus-table >>> [data-test-id="main-table"] .summary-row');
     expect(footerContainer).toBeNull();
 
     component.setProperty('summaryRow', true);

--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -2,6 +2,7 @@
 
 .table-container {
   border: $rem-1px $modus-table-border-color solid;
+  display: flex;
   overflow: auto;
 
   &::-webkit-scrollbar {
@@ -34,8 +35,8 @@ table {
     th,
     td,
     tr {
-      border: none;
-      box-shadow: none;
+      border: none !important;
+      box-shadow: none !important;
     }
   }
 
@@ -292,6 +293,10 @@ table {
       }
     }
   }
+}
+
+modus-table-filler-column {
+  width: 100%;
 }
 
 .pagination-container {

--- a/stencil-workspace/src/components/modus-table/modus-table.spec.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.spec.tsx
@@ -12,12 +12,13 @@ describe('modus-table', () => {
       <mock:shadow-root>
         <div>
           <div class="table-container">
-            <table style="table-layout: fixed;">
+            <table data-test-id="main-table" style="table-layout: fixed;">
               <thead>
                 <tr></tr>
               </thead>
               <tbody></tbody>
             </table>
+            <modus-table-filler-column></modus-table-filler-column>
           </div>
           <slot name="customFooter"></slot>
         </div>

--- a/stencil-workspace/src/components/modus-table/parts/fillerColumn/modus-table-filler-column.scss
+++ b/stencil-workspace/src/components/modus-table/parts/fillerColumn/modus-table-filler-column.scss
@@ -1,0 +1,3 @@
+.d-none {
+  display: none;
+}

--- a/stencil-workspace/src/components/modus-table/parts/fillerColumn/modus-table-filler-column.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/fillerColumn/modus-table-filler-column.tsx
@@ -1,0 +1,95 @@
+import { State, Watch } from '@stencil/core';
+import {
+  Component,
+  Prop,
+  h, // eslint-disable-line @typescript-eslint/no-unused-vars
+} from '@stencil/core';
+
+/**
+ * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
+ */
+@Component({
+  tag: 'modus-table-filler-column',
+  styleUrl: './modus-table-filler-column.scss',
+})
+export class ModusTableFillerColumn {
+  @Prop() cellBorderless: boolean;
+
+  @Prop() summaryRow: boolean;
+
+  @Prop() targetTable?: HTMLTableElement;
+  @Watch('targetTable') targetTableChange(): void {
+    if (this.targetTable) {
+      this.updateContainerLayout();
+      this.connectDOMObserver();
+    }
+  }
+
+  @State() showFillerTable = false;
+  private fillerTableRef: HTMLTableElement;
+  private observer: ResizeObserver | null = null;
+
+  disconnectedCallback(): void {
+    this.disconnectDOMObserver();
+  }
+
+  connectDOMObserver(): void {
+    this.observer = new ResizeObserver(this.updateContainerLayout);
+    this.observer.observe(this.targetTable);
+  }
+
+  disconnectDOMObserver(): void {
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  }
+
+  updateContainerLayout = (): void => {
+    const tableWidth = this.targetTable?.getBoundingClientRect()?.width;
+    const parentWidth = this.targetTable?.parentElement?.getBoundingClientRect()?.width;
+
+    this.showFillerTable = tableWidth < parentWidth;
+    if (!this.showFillerTable) return;
+
+    if (this.fillerTableRef) {
+      this.fillerTableRef.querySelector('thead').style.height = `${this.targetTable
+        .querySelector('thead')
+        ?.getBoundingClientRect().height}px`;
+
+      if (this.summaryRow) {
+        this.fillerTableRef.querySelector('tfoot').style.height = `${this.targetTable
+          .querySelector('tfoot')
+          ?.getBoundingClientRect().height}px`;
+      }
+      this.fillerTableRef.querySelector('tbody').style.height = `${this.targetTable
+        .querySelector('tbody')
+        ?.getBoundingClientRect().height}px`;
+    }
+  };
+
+  render(): void {
+    return (
+      <table
+        class={{ 'cell-borderless': this.cellBorderless, 'd-none': !this.showFillerTable }}
+        ref={(el) => (this.fillerTableRef = el)}>
+        <thead>
+          <tr>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td></td>
+          </tr>
+        </tbody>
+        {this.summaryRow && (
+          <tfoot>
+            <tr class="summary-row">
+              <td></td>
+            </tr>
+          </tfoot>
+        )}
+      </table>
+    );
+  }
+}

--- a/stencil-workspace/src/components/modus-table/parts/fillerColumn/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/fillerColumn/readme.md
@@ -1,0 +1,36 @@
+# modus-table-filler-column
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
+
+## Properties
+
+| Property         | Attribute         | Description | Type               | Default     |
+| ---------------- | ----------------- | ----------- | ------------------ | ----------- |
+| `cellBorderless` | `cell-borderless` |             | `boolean`          | `undefined` |
+| `summaryRow`     | `summary-row`     |             | `boolean`          | `undefined` |
+| `targetTable`    | --                |             | `HTMLTableElement` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [modus-table](../..)
+
+### Graph
+```mermaid
+graph TD;
+  modus-table --> modus-table-filler-column
+  style modus-table-filler-column fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-summary-row.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-summary-row.tsx
@@ -3,7 +3,6 @@ import {
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
 import { HeaderGroup } from '@tanstack/table-core';
-import { ModusTableDisplayOptions } from '../models/modus-table.models';
 import {
   COLUMN_DEF_DATATYPE_KEY,
   COLUMN_DEF_SHOWTOTAL,
@@ -15,7 +14,6 @@ import {
 interface ModusTableSummaryRowProps {
   footerGroups: HeaderGroup<unknown>[];
   tableData: unknown[];
-  borderlessOptions: ModusTableDisplayOptions;
   frozenColumns: string[];
   rowSelection: boolean;
 }
@@ -29,15 +27,13 @@ function calculateTotal(tableData: unknown[], header): number | string {
 export const ModusTableSummaryRow: FunctionalComponent<ModusTableSummaryRowProps> = ({
   footerGroups,
   tableData,
-  borderlessOptions,
   frozenColumns,
   rowSelection,
 }) => {
-  const borderLessTableStyle = (borderlessOptions?.cellBorderless || borderlessOptions?.borderless) && { boxShadow: 'none' };
   return (
     <tfoot>
       {footerGroups.map((group) => (
-        <tr class="summary-row" style={borderLessTableStyle}>
+        <tr class="summary-row">
           {rowSelection && (
             <td id={COLUMN_DEF_ROW_SELECTION_ID} key={COLUMN_DEF_ROW_SELECTION_ID} class={COLUMN_DEF_ROW_SELECTION_CSS}></td>
           )}

--- a/stencil-workspace/src/components/modus-table/readme.md
+++ b/stencil-workspace/src/components/modus-table/readme.md
@@ -75,8 +75,9 @@ Type: `Promise<void>`
 
 ### Depends on
 
-- [modus-checkbox](../modus-checkbox)
 - [modus-table-toolbar](./parts/panel/modus-table-toolbar)
+- [modus-table-filler-column](./parts/fillerColumn)
+- [modus-checkbox](../modus-checkbox)
 - [modus-tooltip](../modus-tooltip)
 - [modus-select](../modus-select)
 - [modus-pagination](../modus-pagination)
@@ -84,8 +85,9 @@ Type: `Promise<void>`
 ### Graph
 ```mermaid
 graph TD;
-  modus-table --> modus-checkbox
   modus-table --> modus-table-toolbar
+  modus-table --> modus-table-filler-column
+  modus-table --> modus-checkbox
   modus-table --> modus-tooltip
   modus-table --> modus-select
   modus-table --> modus-pagination


### PR DESCRIPTION
When there are not too many columns in the table to occupy the full width that is set, we show a filler column inside the table after the last column.

References #1529 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
