### PR TITLE
Fix the missing fallback colors for button component

### DIFF
--- a/stencil-workspace/src/components/modus-button/modus-button.vars.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.vars.scss
@@ -1,9 +1,9 @@
 // Default theme colors
 $btn-theme-colors: (
-  'primary': map-get($theme-colors, 'primary'),
-  'secondary': map-get($theme-colors, 'secondary'),
-  'tertiary': map-get($theme-colors, 'tertiary'),
-  'danger': map-get($theme-colors, 'danger'),
+  'primary': #0063a3,
+  'secondary': #6a6e79,
+  'tertiary': #cbcdd6,
+  'danger': #da212c,
 );
 $btn-hover-colors: (
   'primary': #0082d6,
@@ -20,7 +20,7 @@ $btn-active-colors: (
 
 // Default Outline
 $btn-outline-theme-colors: (
-  'primary': map-get($theme-colors, 'primary'),
+  'primary': #0063a3,
   'secondary': $col_trimble_gray,
 );
 $btn-outline-hover: (
@@ -46,7 +46,7 @@ $btn-outline-active: (
 
 // Default Borderless
 $modus-btn-borderless-bg: var(--modus-btn-text-primary-bg, transparent) !default;
-$modus-btn-borderless-color: var(--modus-btn-text-primary-color, map-get($theme-colors, 'primary')) !default;
+$modus-btn-borderless-color: var(--modus-btn-text-primary-color, #0063a3) !default;
 
 // Hover
 $btn-borderless-hover: (
@@ -87,7 +87,7 @@ $modus-btn-disabled-border-color: var(--modus-btn-disabled-border-color) !defaul
 
 // Default Icon-only
 $btn-icon-only-theme-colors: (
-  'primary': map-get($theme-colors, 'primary'),
+  'primary': #0063a3,
   'secondary': $col_trimble_gray,
   'tertiary': $col_gray_6,
 );

--- a/stencil-workspace/src/components/modus-toast/modus-toast.vars.scss
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.vars.scss
@@ -2,7 +2,6 @@ $modus-toast-bg: var(--modus-toast-bg, $col_white) !default;
 $modus-toast-border-color: var(--modus-toast-border-color, #252a2e4d) !default;
 $modus-toast-color: var(--modus-toast-color, #252a2e) !default;
 $modus-toast-close-btn-color: var(--modus-toast-close-btn-color, #252a2e) !default;
-$modus-toast-colors: map-remove($theme-colors, 'yellow');
 $modus-toast-variants: (
   'primary': (
     'bg': #dcedf9,


### PR DESCRIPTION
The issue was when the [theme css](./node_modules/@trimble-oss/modus-web-components/dist/modus-web-components/modus-web-components.css) is not referenced because of the missing fallback colours, some buttons did not have a proper background color, like secondary and danger buttons. The fix was to remove the usage of `$theme-colors` variable and replaced it with the color codes.

References #1694 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Not sure how to test this on the storybook because it has a reference to the theme file. Below shows the video taken from a localhost by commenting out the theme file in `index.html`,
![Code_bfWorQGyy8](https://github.com/trimble-oss/modus-web-components/assets/50131391/0445a69f-7a63-4570-b4f0-11665e1636ad)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
