### PR TITLE
Fix date picker setDate iso8601 compliance

### DIFF
--- a/stencil-workspace/src/components/modus-date-picker/utils/modus-date-picker.state.tsx
+++ b/stencil-workspace/src/components/modus-date-picker/utils/modus-date-picker.state.tsx
@@ -19,8 +19,8 @@ export default class ModusDatePickerState {
     // Converting to ISO8601 'yyyy-mm-dd' format
     if (Number(val)) {
       const year = val.getFullYear();
-      const month = val.getMonth() + 1; // Zero based number system for months
-      const date = val.getDate();
+      const month = (val.getMonth() + 1).toString().padStart(2, '0'); // Zero based number system for months
+      const date = val.getDate().toString().padStart(2, '0');
 
       this.element.value = `${year}-${month}-${date}`;
       this.element.focusInput();


### PR DESCRIPTION
## Description

Add left padding to month/day values less than 10 in order to comply with ISO 8601 format.

References #1753

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

console inspection and npm run test

## Checklist

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ X] Any dependent changes have been merged and published in downstream modules
- [ X] I have checked my code and corrected any misspellings
