### PR TITLE
Fix the non-accessible hyperlink cell content in Modus Table

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1195,14 +1195,14 @@ export declare interface ModusTableCellEditor extends Components.ModusTableCellE
 
 
 @ProxyCmp({
-  inputs: ['cell', 'cellIndex', 'linkClick', 'rowActions', 'valueChange']
+  inputs: ['cell', 'linkClick', 'rowActions', 'valueChange']
 })
 @Component({
   selector: 'modus-table-cell-main',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['cell', 'cellIndex', 'linkClick', 'rowActions', 'valueChange'],
+  inputs: ['cell', 'linkClick', 'rowActions', 'valueChange'],
 })
 export class ModusTableCellMain {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1086,7 +1086,6 @@ export namespace Components {
     }
     interface ModusTableCellMain {
         "cell": Cell<unknown, unknown>;
-        "cellIndex": number;
         "linkClick": (link: ModusTableCellLink) => void;
         "rowActions": RowActions;
         "valueChange": (props: ModusTableCellEdited) => void;
@@ -3142,7 +3141,6 @@ declare namespace LocalJSX {
     }
     interface ModusTableCellMain {
         "cell"?: Cell<unknown, unknown>;
-        "cellIndex"?: number;
         "linkClick"?: (link: ModusTableCellLink) => void;
         "rowActions"?: RowActions;
         "valueChange"?: (props: ModusTableCellEdited) => void;

--- a/stencil-workspace/src/components/modus-alert/modus-alert.scss
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.scss
@@ -5,12 +5,12 @@ div.alert {
   border: 1px solid;
   border-left-width: $alert-left-border-width;
   border-radius: 2px;
+  box-sizing: border-box;
   display: flex;
   font-family: $primary-font;
   height: 56px;
   padding: $rem-16px;
   position: relative;
-  box-sizing: border-box;
 
   &.type-error {
     background-color: $modus-alert-danger-bg;

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-link-element.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-link-element.tsx
@@ -3,6 +3,7 @@ import {
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
 import { ModusTableCellLink } from '../../models/modus-table.models';
+import { KEYBOARD_ENTER, KEYBOARD_SPACE } from '../../modus-table.constants';
 
 interface ModusTableCellLinkProps {
   link: ModusTableCellLink;
@@ -10,8 +11,16 @@ interface ModusTableCellLinkProps {
 }
 
 export const ModusTableCellLinkElement: FunctionalComponent<ModusTableCellLinkProps> = ({ link, onLinkClick }) => {
+  function handleLinkKeyDown(e: KeyboardEvent) {
+    const key = e.key.toLowerCase();
+    if (key === KEYBOARD_ENTER || key === KEYBOARD_SPACE) {
+      onLinkClick(link);
+      e.stopImmediatePropagation();
+    }
+  }
+
   return (
-    <div class="cell-link wrap-text" onClick={() => onLinkClick(link)}>
+    <div class="cell-link wrap-text" tabIndex={0} onClick={() => onLinkClick(link)} onKeyDown={handleLinkKeyDown}>
       {link.display}
     </div>
   );

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -34,7 +34,6 @@ import { ModusTableCellEdited } from '../../modus-table-body';
 export class ModusTableCellMain {
   @Element() el: HTMLElement;
   @Prop() cell: Cell<unknown, unknown>;
-  @Prop() cellIndex: number;
   @Prop() rowActions: RowActions;
   @Prop() valueChange: (props: ModusTableCellEdited) => void;
   @Prop() linkClick: (link: ModusTableCellLink) => void;
@@ -108,9 +107,8 @@ export class ModusTableCellMain {
       event.stopPropagation();
     } else {
       NavigateTableCells({
-        key: event.key,
+        eventKey: event.key,
         cellElement: this.cellEl,
-        cellIndex: this.cellIndex,
       });
     }
   };
@@ -133,9 +131,8 @@ export class ModusTableCellMain {
     if (key === KEYBOARD_ENTER) {
       this.handleCellEditorValueChange(newValue, oldValue);
       NavigateTableCells({
-        key: KEYBOARD_ENTER,
+        eventKey: KEYBOARD_ENTER,
         cellElement: this.cellEl,
-        cellIndex: this.cellIndex,
       });
     } else if (key === KEYBOARD_ESCAPE) {
       this.editMode = false;

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/readme.md
@@ -7,13 +7,12 @@
 
 ## Properties
 
-| Property      | Attribute    | Description | Type                                    | Default     |
-| ------------- | ------------ | ----------- | --------------------------------------- | ----------- |
-| `cell`        | --           |             | `Cell<unknown, unknown>`                | `undefined` |
-| `cellIndex`   | `cell-index` |             | `number`                                | `undefined` |
-| `linkClick`   | --           |             | `(link: ModusTableCellLink) => void`    | `undefined` |
-| `rowActions`  | --           |             | `RowActions`                            | `undefined` |
-| `valueChange` | --           |             | `(props: ModusTableCellEdited) => void` | `undefined` |
+| Property      | Attribute | Description | Type                                    | Default     |
+| ------------- | --------- | ----------- | --------------------------------------- | ----------- |
+| `cell`        | --        |             | `Cell<unknown, unknown>`                | `undefined` |
+| `linkClick`   | --        |             | `(link: ModusTableCellLink) => void`    | `undefined` |
+| `rowActions`  | --        |             | `RowActions`                            | `undefined` |
+| `valueChange` | --        |             | `(props: ModusTableCellEdited) => void` | `undefined` |
 
 
 ## Dependencies

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
@@ -9,19 +9,12 @@ import { ModusTableCellEdited } from '../modus-table-body';
 
 interface ModusTableCellProps {
   cell: Cell<unknown, unknown>;
-  cellIndex: number;
   rowActions: RowActions;
   linkClick: (link: ModusTableCellLink) => void;
   valueChange: (props: ModusTableCellEdited) => void;
 }
 
-export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({
-  cell,
-  cellIndex,
-  rowActions,
-  valueChange,
-  linkClick,
-}) => {
+export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({ cell, rowActions, valueChange, linkClick }) => {
   const { id } = cell;
   return (
     <td
@@ -34,7 +27,6 @@ export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({
       style={{ width: `${cell.column.getSize()}px` }}>
       <modus-table-cell-main
         cell={cell}
-        cellIndex={cellIndex}
         rowActions={rowActions}
         valueChange={valueChange}
         linkClick={linkClick}></modus-table-cell-main>

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
@@ -69,12 +69,11 @@ export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({
                 row={row}
                 isChecked={isChecked}></ModusTableCellCheckbox>
             )}
-            {getVisibleCells()?.map((cell, cellIndex) => {
+            {getVisibleCells()?.map((cell, index) => {
               return (
                 <ModusTableCell
                   cell={cell}
-                  cellIndex={cellIndex}
-                  rowActions={cellIndex === 0 && rowActions ? rowActions : null}
+                  rowActions={index === 0 && rowActions ? rowActions : null}
                   valueChange={handleCellValueChange}
                   linkClick={cellLinkClick}
                 />

--- a/stencil-workspace/src/components/modus-table/parts/row/selection/modus-table-cell-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/selection/modus-table-cell-checkbox.tsx
@@ -27,9 +27,8 @@ export const ModusTableCellCheckbox: FunctionalComponent<ModusTableCellCheckboxP
     }
 
     NavigateTableCells({
-      key: e.key,
+      eventKey: e.key,
       cellElement: cellEl,
-      cellIndex: -1,
     });
   }
   return (

--- a/stencil-workspace/src/components/modus-table/utilities/table-cell-navigation.utility.tsx
+++ b/stencil-workspace/src/components/modus-table/utilities/table-cell-navigation.utility.tsx
@@ -8,19 +8,20 @@ import {
 } from '../modus-table.constants';
 
 interface NavigateTableCellsProps {
-  key: string;
+  eventKey: string;
   cellElement: HTMLElement;
-  cellIndex: number;
 }
 export default function NavigateTableCells(props: NavigateTableCellsProps) {
-  const { key, cellElement: cell, cellIndex: index } = props;
+  const { eventKey: key, cellElement: cell } = props;
   let nextCell: HTMLElement;
+
+  const row = cell.closest('tr') as HTMLTableRowElement;
+  const index = Array.prototype.indexOf.call(row.children, cell);
 
   switch (key?.toLowerCase()) {
     case KEYBOARD_ENTER:
     case KEYBOARD_DOWN: // Moves to down cell
-      nextCell = (cell.parentElement.nextSibling as HTMLElement)?.children[index + 1] as HTMLElement;
-
+      nextCell = (cell.parentElement.nextSibling as HTMLElement)?.children[index] as HTMLElement;
       if (nextCell) nextCell.focus();
       else cell.focus();
       break;
@@ -36,7 +37,7 @@ export default function NavigateTableCells(props: NavigateTableCellsProps) {
       nextCell?.focus();
       break;
     case KEYBOARD_UP: // Moves to up cell
-      nextCell = (cell.parentElement.previousSibling as HTMLElement)?.children[index + 1] as HTMLElement;
+      nextCell = (cell.parentElement.previousSibling as HTMLElement)?.children[index] as HTMLElement;
       nextCell?.focus();
       break;
   }

--- a/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-data-table/modus-data-table.stories.tsx
@@ -33,11 +33,11 @@ export const Default = () => html`
   ${setDataTable()}
 `;
 
-export const Hodgepodge = () => html`
+export const RowActions = () => html`
   <div style="width: 800px">
     <modus-data-table />
   </div>
-  ${setDataTableHodgepodge()}
+  ${setDataTableRowActions()}
 `;
 
 // The <script> tag cannot be used in the MDX file, so we use this method to
@@ -52,7 +52,7 @@ const setDataTable = () => {
   return tag;
 };
 
-const setDataTableHodgepodge = () => {
+const setDataTableRowActions = () => {
   const tag = document.createElement('script');
   tag.innerHTML = `
     document.querySelector('modus-data-table').columns = [

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
@@ -125,7 +125,6 @@ This displays the highlighted row where the cursor is currently located.
 
 - Hover is disable by default, set `hover` to `true` to enable hover.
 
-<Story id="components-table--hover" height={'350px'} />
 
 ### Borderless
 
@@ -135,7 +134,6 @@ Table has two views one with border and another is borderless.
 - To eliminate the outer table border, set `borderless` to `true`.
 - Set `cellborderless` to `true` remove the innter table border i.e. for the border for cells.
 
-<Story id="components-table--borderless" height={'350px'} />
 
 ### Sorting
 
@@ -146,7 +144,6 @@ Users can arrange data in a table by sorting it in either ascending or descendin
 - When enabled, the sort icon's initial click will sort in ascending order, while its second click will sort in descending order.
 - Set `showSortIconOnHover` to `true` to enable sort on hover as well.
 
-<Story id="components-table--sorting" height={'350px'} />
 
 ### Value Formatter
 
@@ -185,7 +182,6 @@ User can take the data of a cell and apply any string-based formatting logic.
   // NOTE: One can use their own custom functions to format data as per their requirements.
 ```
 
-<Story id="components-table--value-formatter" height={'350px'} />
 
 ### Hyperlink
 
@@ -195,7 +191,6 @@ User can display hyperlink in a table column.
 - `_type: ModusTableColumnDataType.Link` is used to override the column data type in order to display a hyperlink only in a specific cell and not on the entire column.
 - As a link is an object, the default sorting is ineffective. We must pass `sortingFn:'sortForHyperlink'` along with the column information in order to sort a column with the `ModusTableCellLink` datatype or if '\_type' is used to override the datatype.
 
-<Story id="components-table--hyperlink" height={'350px'} />
 
 ### Column Resize
 
@@ -205,7 +200,6 @@ The column sizing feature allows users to dynamically change the width of all co
 - By setting `fullWidth` to true, a column can be resized with table responsiveness and other columns will be adjusted to fit within the confines of the table.
 - Optionally you can specify the width of each column using `size`, `minSize` and `maxSize` to limit the resizing of a column to a specific value.
 
-<Story id="components-table--column-resize" height={'350px'} />
 
 ```html
 <div style="width: 950px">
@@ -291,16 +285,12 @@ Users can rearrange the column headers.
 
 - Column reorder is disabled by default. The way to activate it is to set `columnReorder` to `true`.
 
-<Story id="components-table--column-reorder" height={'350px'} />
-
 ### Pagination
 
 Pagination allows users to navigate between pages
 
 - Modus Table uses `modus-pagination` component to navigate between pages.
 - Pagination can be enabled using the `pagination` prop. The `pageSizeList` takes an array for page size options.
-
-<Story id="components-table--pagination" height={'380px'} />
 
 ### Summary Row
 
@@ -310,13 +300,9 @@ User can opt for this summary row, which can be used as footer or a row to view 
 - Pass any text in `footer` property of `columns` to be display in the summary row.
 - Set `showTotal` as `true` in the `columns` array for the specific column to display the total value that column.
 
-<Story id="components-table--summary-row" height={'480px'} />
-
 ### Column Visibility
 
 A toolbar is used to perform operations like hiding/showing the columns. It is enabled by `toolbar` and is shown above the table. By setting `toolbarOptions.columnsVisibility` a meatball icon appears at the right corner, and clicking on it shows a dropdown menu with columns for selection. Additionally, users can use `slot='groupLeft'` and `slot='groupRight'` to add custom content to the toolbar.
-
-<Story id="components-table--column-visibility" height={'480px'} />
 
 ```html
 <div style="width: 950px">
@@ -369,16 +355,12 @@ User can expand rows to display as child/sub row data.
 - Expandable row is disabled by default. Set `rowsExpandable` to `true` to enable it.
 - Pass data to `subRows` property in `columns`.
 
-<Story id="components-table--expandable-rows" height={'480px'} />
-
 ### Checkbox Row Selection
 
 To select rows, users can use the checkbox provided on each row. Normally, the Modus Table permits selecting only one row at a time, but this can be modified to allow multiple selections by using `rowSelectionOptions` option.
 
   - To enable multiple row selection, set `multiple` to `true`.
   - Sub-rows will also be selected if the parent is selected by setting `subRowSelection` to `true`.
-
-<Story id="components-table--checkbox-row-selection" height={'480px'} />
 
 ### Inline Editing
 
@@ -404,8 +386,6 @@ Refer to the [Accessibility](#accessibility) section for how to use keyboard for
     },
   },
 ```
-
-<Story id="components-table--large-dataset" height={'480px'} />
 
 ### Types
 

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
@@ -91,7 +91,6 @@ const DefaultColumns = [
     size: 150,
     minSize: 80,
     footer: 'Total',
-    cellEditable:true,
   },
   {
     header: 'Last Name',
@@ -100,7 +99,6 @@ const DefaultColumns = [
     dataType: 'text',
     size: 150,
     minSize: 80,
-    cellEditable:true,
   },
   {
     header: 'Age',
@@ -109,7 +107,6 @@ const DefaultColumns = [
     dataType: 'integer',
     size: 80,
     minSize: 60,
-    cellEditable:true,
   },
   {
     header: 'Visits',
@@ -119,7 +116,6 @@ const DefaultColumns = [
     maxSize: 80,
     showTotal: true,
     minSize: 80,
-    cellEditable:true,
   },
   {
     header: 'Email',
@@ -135,15 +131,6 @@ const DefaultColumns = [
     id: 'status',
     dataType: 'text',
     minSize: 80,
-    cellEditable:true,
-    cellEditorType: 'dropdown',
-    cellEditorArgs: {
-      options:[
-      { display: 'Verified' },
-      { display: 'Pending' },
-      { display: 'Rejected' },
-      ]
-    },
   },
   {
     header: 'Profile Progress',
@@ -151,7 +138,6 @@ const DefaultColumns = [
     id: 'progress',
     dataType: 'integer',
     minSize: 100,
-    cellEditable:true,
   },
   {
     header: 'Created At',
@@ -344,7 +330,7 @@ export default {
       type: { required: false },
     },
     pageSizeList: {
-      name: 'toolbarOptions',
+      name: 'pageSizeList',
       description: 'To set page size options for the pagination.',
       table: {
         type: { summary: 'number[]' },
@@ -352,7 +338,7 @@ export default {
       type: { required: false },
     },
     rowSelectionOptions: {
-      name: 'toolbarOptions',
+      name: 'rowSelectionOptions',
       description: 'To control multiple row selection.',
       table: {
         type: { summary: 'ModusTableRowSelectionOptions' },
@@ -540,9 +526,29 @@ CheckboxRowSelection.args = {
   }, data: makeData(7)
 };
 
+const editableColumns =DefaultColumns.map(col =>{
+  if(col.dataType === 'link') return col;
+
+  if(col.accessorKey === 'status'){
+    return {...col,  cellEditable:true,
+      cellEditorType: 'dropdown',
+      cellEditorArgs: {
+        options:[
+        { display: 'Verified' },
+        { display: 'Pending' },
+        { display: 'Rejected' },
+        ]
+      } };
+  }
+  else return {...col, cellEditable: true};
+});
+
+export const InlineEditing = Template.bind({});
+InlineEditing.args = { ...DefaultArgs, columns: editableColumns, data: makeData(7) };
+
 export const LargeDataset = Template.bind({});
 
-LargeDataset.args = { ...DefaultArgs, columns: DefaultColumns, data: makeData(10000, 1,1 ),pagination: true, pageSizeList: [5, 10, 50], sort: true , hover: true, rowsExpandable: true, summaryRow: true , columnReorder:true, columnResize: true, toolbar:true,  toolbarOptions: {
+LargeDataset.args = { ...DefaultArgs, columns: editableColumns, data: makeData(10000, 1,1 ),pagination: true, pageSizeList: [5, 10, 50], sort: true , hover: true, rowsExpandable: true, summaryRow: true , columnReorder:true, columnResize: true, toolbar:true,  toolbarOptions: {
   columnsVisibility: {
     title: '',
     requiredColumns: ['age', 'visits'],


### PR DESCRIPTION
References #1811 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
https://deploy-preview-1812--modus-webcomponents.netlify.app/?path=/story/components-table--hyperlink
Navigate to any of the row cell with hyperlink using the Tab key and focus the hyperlink inside the cell and press Enter key to trigger cell link click event visible under Actions tab

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
