### PR TITLE
Dev/modus table row actions v2

### DIFF
--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -14,9 +14,9 @@ import { ModusNavbarButton, ModusNavbarLogoOptions, ModusNavbarProfileMenuLink, 
 import { ModusNavbarApp as ModusNavbarApp1 } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
 import { RadioButton } from "./components/modus-radio-group/modus-radio-button";
 import { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/modus-side-navigation.models";
-import { ModusTableCellEditorArgs, ModusTableCellLink, ModusTableCellValueChange, ModusTableColumn, ModusTableColumnOrderState, ModusTableColumnSizingState, ModusTableColumnsVisibilityOptions, ModusTableColumnVisibilityState, ModusTableDisplayOptions, ModusTableExpandedState, ModusTablePaginationState, ModusTableRowActions, ModusTableRowSelectionOptions, ModusTableSortingState, ModusTableToolbarOptions } from "./components/modus-table/models/modus-table.models";
-import { Cell, Column, Table } from "@tanstack/table-core";
-import { ModusTableCellEdited } from "./components/modus-table/parts/modus-table-body";
+import { ModusTableCellEditorArgs, ModusTableCellLink, ModusTableCellValueChange, ModusTableColumn, ModusTableColumnOrderState, ModusTableColumnSizingState, ModusTableColumnsVisibilityOptions, ModusTableColumnVisibilityState, ModusTableDisplayOptions, ModusTableExpandedState, ModusTablePaginationState, ModusTableRowAction, ModusTableRowActionClick, ModusTableRowSelectionOptions, ModusTableSortingState, ModusTableToolbarOptions } from "./components/modus-table/models/modus-table.models";
+import { Cell, Column, Row } from "@tanstack/table-core";
+import { TableCellEdited, TableRowActionsMenuEvent } from "./components/modus-table/models/table-context.model";
 import { Tab } from "./components/modus-tabs/modus-tabs";
 import { ModusTimePickerEventDetails } from "./components/modus-time-picker/modus-time-picker.models";
 import { TreeViewItemOptions } from "./components/modus-content-tree/modus-content-tree.types";
@@ -29,9 +29,9 @@ export { ModusNavbarButton, ModusNavbarLogoOptions, ModusNavbarProfileMenuLink, 
 export { ModusNavbarApp as ModusNavbarApp1 } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
 export { RadioButton } from "./components/modus-radio-group/modus-radio-button";
 export { ModusSideNavigationItemInfo } from "./components/modus-side-navigation/modus-side-navigation.models";
-export { ModusTableCellEditorArgs, ModusTableCellLink, ModusTableCellValueChange, ModusTableColumn, ModusTableColumnOrderState, ModusTableColumnSizingState, ModusTableColumnsVisibilityOptions, ModusTableColumnVisibilityState, ModusTableDisplayOptions, ModusTableExpandedState, ModusTablePaginationState, ModusTableRowActions, ModusTableRowSelectionOptions, ModusTableSortingState, ModusTableToolbarOptions } from "./components/modus-table/models/modus-table.models";
-export { Cell, Column, Table } from "@tanstack/table-core";
-export { ModusTableCellEdited } from "./components/modus-table/parts/modus-table-body";
+export { ModusTableCellEditorArgs, ModusTableCellLink, ModusTableCellValueChange, ModusTableColumn, ModusTableColumnOrderState, ModusTableColumnSizingState, ModusTableColumnsVisibilityOptions, ModusTableColumnVisibilityState, ModusTableDisplayOptions, ModusTableExpandedState, ModusTablePaginationState, ModusTableRowAction, ModusTableRowActionClick, ModusTableRowSelectionOptions, ModusTableSortingState, ModusTableToolbarOptions } from "./components/modus-table/models/modus-table.models";
+export { Cell, Column, Row } from "@tanstack/table-core";
+export { TableCellEdited, TableRowActionsMenuEvent } from "./components/modus-table/models/table-context.model";
 export { Tab } from "./components/modus-tabs/modus-tabs";
 export { ModusTimePickerEventDetails } from "./components/modus-time-picker/modus-time-picker.models";
 export { TreeViewItemOptions } from "./components/modus-content-tree/modus-content-tree.types";
@@ -546,6 +546,7 @@ export namespace Components {
           * (optional) Disables the list item
          */
         "disabled": boolean;
+        "focusItem": () => Promise<void>;
         /**
           * (optional) The selected state of the list item
          */
@@ -1039,6 +1040,10 @@ export namespace Components {
         "pageSizeList": number[];
         "pagination": boolean;
         /**
+          * (Optional) Actions that can be performed on each row. A maximum of 4 icons will be shown, including overflow menu and expand icons.
+         */
+        "rowActions": ModusTableRowAction[];
+        /**
           * (Optional) To display checkbox.
          */
         "rowSelection": boolean;
@@ -1086,32 +1091,25 @@ export namespace Components {
     }
     interface ModusTableCellMain {
         "cell": Cell<unknown, unknown>;
-        "linkClick": (link: ModusTableCellLink) => void;
-        "rowActions": ModusTableRowActions;
-        "valueChange": (props: ModusTableCellEdited) => void;
+        "context": TableContext;
+        "hasRowActions": boolean;
+        "valueChange": (props: TableCellEdited) => void;
     }
     interface ModusTableColumnsVisibility {
         /**
           * Column visibility options
          */
         "columnsVisibility": ModusTableColumnsVisibilityOptions;
-        "menuIconContainerRef": HTMLDivElement;
-        "showDropdown": boolean;
         /**
           * Table data.
          */
-        "table": Table<unknown>;
+        "getColumnsFn": () => Column<unknown, unknown>[];
+        "menuIconContainerRef": HTMLDivElement;
+        "showDropdown": boolean;
         "toggleDropdown": (show: boolean) => void;
     }
     interface ModusTableDropdownMenu {
-        /**
-          * dropdown menu options.
-         */
-        "options": ModusTableToolbarOptions;
-        /**
-          * Table data.
-         */
-        "table": Table<unknown>;
+        "context": TableContext;
     }
     /**
      * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
@@ -1121,15 +1119,18 @@ export namespace Components {
         "container"?: HTMLElement;
         "summaryRow": boolean;
     }
+    interface ModusTableRowActions {
+        "context": TableContext;
+        "row": Row<unknown>;
+    }
+    interface ModusTableRowActionsMenu {
+        "context": TableContext;
+    }
     interface ModusTableToolbar {
-        /**
-          * (Optional) Table Panel options.
-         */
-        "options": ModusTableToolbarOptions;
         /**
           * Table data.
          */
-        "table": Table<unknown>;
+        "context": TableContext;
     }
     interface ModusTabs {
         "ariaLabel": string | null;
@@ -1523,6 +1524,10 @@ export interface ModusTableCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusTableElement;
 }
+export interface ModusTableRowActionsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusTableRowActionsElement;
+}
 export interface ModusTabsCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusTabsElement;
@@ -1805,6 +1810,18 @@ declare global {
         prototype: HTMLModusTableFillerColumnElement;
         new (): HTMLModusTableFillerColumnElement;
     };
+    interface HTMLModusTableRowActionsElement extends Components.ModusTableRowActions, HTMLStencilElement {
+    }
+    var HTMLModusTableRowActionsElement: {
+        prototype: HTMLModusTableRowActionsElement;
+        new (): HTMLModusTableRowActionsElement;
+    };
+    interface HTMLModusTableRowActionsMenuElement extends Components.ModusTableRowActionsMenu, HTMLStencilElement {
+    }
+    var HTMLModusTableRowActionsMenuElement: {
+        prototype: HTMLModusTableRowActionsMenuElement;
+        new (): HTMLModusTableRowActionsMenuElement;
+    };
     interface HTMLModusTableToolbarElement extends Components.ModusTableToolbar, HTMLStencilElement {
     }
     var HTMLModusTableToolbarElement: {
@@ -1897,6 +1914,8 @@ declare global {
         "modus-table-columns-visibility": HTMLModusTableColumnsVisibilityElement;
         "modus-table-dropdown-menu": HTMLModusTableDropdownMenuElement;
         "modus-table-filler-column": HTMLModusTableFillerColumnElement;
+        "modus-table-row-actions": HTMLModusTableRowActionsElement;
+        "modus-table-row-actions-menu": HTMLModusTableRowActionsMenuElement;
         "modus-table-toolbar": HTMLModusTableToolbarElement;
         "modus-tabs": HTMLModusTabsElement;
         "modus-text-input": HTMLModusTextInputElement;
@@ -3086,6 +3105,10 @@ declare namespace LocalJSX {
          */
         "onPaginationChange"?: (event: ModusTableCustomEvent<ModusTablePaginationState>) => void;
         /**
+          * An event that fires when a row action is clicked.
+         */
+        "onRowActionClick"?: (event: ModusTableCustomEvent<ModusTableRowActionClick>) => void;
+        /**
           * Emits expanded state of the columns
          */
         "onRowExpanded"?: (event: ModusTableCustomEvent<ModusTableExpandedState>) => void;
@@ -3099,6 +3122,10 @@ declare namespace LocalJSX {
         "onSortChange"?: (event: ModusTableCustomEvent<ModusTableSortingState>) => void;
         "pageSizeList"?: number[];
         "pagination"?: boolean;
+        /**
+          * (Optional) Actions that can be performed on each row. A maximum of 4 icons will be shown, including overflow menu and expand icons.
+         */
+        "rowActions"?: ModusTableRowAction[];
         /**
           * (Optional) To display checkbox.
          */
@@ -3141,32 +3168,25 @@ declare namespace LocalJSX {
     }
     interface ModusTableCellMain {
         "cell"?: Cell<unknown, unknown>;
-        "linkClick"?: (link: ModusTableCellLink) => void;
-        "rowActions"?: ModusTableRowActions;
-        "valueChange"?: (props: ModusTableCellEdited) => void;
+        "context"?: TableContext;
+        "hasRowActions"?: boolean;
+        "valueChange"?: (props: TableCellEdited) => void;
     }
     interface ModusTableColumnsVisibility {
         /**
           * Column visibility options
          */
         "columnsVisibility"?: ModusTableColumnsVisibilityOptions;
-        "menuIconContainerRef"?: HTMLDivElement;
-        "showDropdown"?: boolean;
         /**
           * Table data.
          */
-        "table"?: Table<unknown>;
+        "getColumnsFn"?: () => Column<unknown, unknown>[];
+        "menuIconContainerRef"?: HTMLDivElement;
+        "showDropdown"?: boolean;
         "toggleDropdown"?: (show: boolean) => void;
     }
     interface ModusTableDropdownMenu {
-        /**
-          * dropdown menu options.
-         */
-        "options"?: ModusTableToolbarOptions;
-        /**
-          * Table data.
-         */
-        "table"?: Table<unknown>;
+        "context"?: TableContext;
     }
     /**
      * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
@@ -3176,15 +3196,19 @@ declare namespace LocalJSX {
         "container"?: HTMLElement;
         "summaryRow"?: boolean;
     }
+    interface ModusTableRowActions {
+        "context"?: TableContext;
+        "onOverflowRowActions"?: (event: ModusTableRowActionsCustomEvent<TableRowActionsMenuEvent>) => void;
+        "row"?: Row<unknown>;
+    }
+    interface ModusTableRowActionsMenu {
+        "context"?: TableContext;
+    }
     interface ModusTableToolbar {
-        /**
-          * (Optional) Table Panel options.
-         */
-        "options"?: ModusTableToolbarOptions;
         /**
           * Table data.
          */
-        "table"?: Table<unknown>;
+        "context"?: TableContext;
     }
     interface ModusTabs {
         "ariaLabel"?: string | null;
@@ -3528,6 +3552,8 @@ declare namespace LocalJSX {
         "modus-table-columns-visibility": ModusTableColumnsVisibility;
         "modus-table-dropdown-menu": ModusTableDropdownMenu;
         "modus-table-filler-column": ModusTableFillerColumn;
+        "modus-table-row-actions": ModusTableRowActions;
+        "modus-table-row-actions-menu": ModusTableRowActionsMenu;
         "modus-table-toolbar": ModusTableToolbar;
         "modus-tabs": ModusTabs;
         "modus-text-input": ModusTextInput;
@@ -3588,6 +3614,8 @@ declare module "@stencil/core" {
              * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
              */
             "modus-table-filler-column": LocalJSX.ModusTableFillerColumn & JSXBase.HTMLAttributes<HTMLModusTableFillerColumnElement>;
+            "modus-table-row-actions": LocalJSX.ModusTableRowActions & JSXBase.HTMLAttributes<HTMLModusTableRowActionsElement>;
+            "modus-table-row-actions-menu": LocalJSX.ModusTableRowActionsMenu & JSXBase.HTMLAttributes<HTMLModusTableRowActionsMenuElement>;
             "modus-table-toolbar": LocalJSX.ModusTableToolbar & JSXBase.HTMLAttributes<HTMLModusTableToolbarElement>;
             "modus-tabs": LocalJSX.ModusTabs & JSXBase.HTMLAttributes<HTMLModusTabsElement>;
             "modus-text-input": LocalJSX.ModusTextInput & JSXBase.HTMLAttributes<HTMLModusTextInputElement>;

--- a/stencil-workspace/src/components/icons/icon-shield.tsx
+++ b/stencil-workspace/src/components/icons/icon-shield.tsx
@@ -2,9 +2,7 @@
 import { FunctionalComponent, h } from '@stencil/core';
 import { IconProps } from './IconMap';
 
-export const IconShield: FunctionalComponent<IconProps> = (
-  props: IconProps
-) => (
+export const IconShield: FunctionalComponent<IconProps> = (props: IconProps) => (
   <svg
     class={`icon-shield ${props.pressed ? 'pressed' : ''}`}
     height={props.size ?? 16}

--- a/stencil-workspace/src/components/icons/icon-vertical-ellipsis.tsx
+++ b/stencil-workspace/src/components/icons/icon-vertical-ellipsis.tsx
@@ -11,12 +11,10 @@ export const IconVerticalEllipsis: FunctionalComponent<IconProps> = (props: Icon
   <svg
     width={props.size ?? 16}
     height={props.size ?? 16}
-    fill={props.color ?? '#6A6976'}
+    fill={props.color ?? 'currentColor'}
     onClick={props.onClick ? () => props.onClick() : null}
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg">
-    <circle cx="12" cy="17.5" r="1.5" />
-    <circle cx="12" cy="12" r="1.5" />
-    <circle cx="12" cy="6.5" r="1.5" />
+    <path d="M10.59 10.59c-.78.78-.78 2.05 0 2.83s2.05.78 2.83 0 .78-2.05 0-2.83-2.05-.78-2.83 0Zm0-7c-.78.78-.78 2.05 0 2.83s2.05.78 2.83 0 .78-2.05 0-2.83-2.05-.78-2.83 0Zm0 14c-.78.78-.78 2.05 0 2.83s2.05.78 2.83 0 .78-2.05 0-2.83-2.05-.78-2.83 0Z" />
   </svg>
 );

--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -1,7 +1,6 @@
 @import './modus-button.vars';
 
 :host {
-  cursor: pointer;
   display: inline-block;
   position: relative;
   width: auto;
@@ -66,7 +65,7 @@ button {
     }
 
     &.icon-only {
-      height: 32px;
+      height: 24px;
       padding: 0;
 
       &.has-caret {
@@ -77,8 +76,8 @@ button {
         padding: 0 4px;
 
         svg {
-          height: 24px;
-          width: 24px;
+          height: 18px;
+          width: 18px;
         }
       }
     }

--- a/stencil-workspace/src/components/modus-button/readme.md
+++ b/stencil-workspace/src/components/modus-button/readme.md
@@ -46,12 +46,14 @@ Type: `Promise<void>`
 
  - [modus-modal](../modus-modal)
  - [modus-table-columns-visibility](../modus-table/parts/panel/modus-table-columns-visibility)
+ - [modus-table-row-actions](../modus-table/parts/row/actions/modus-table-row-actions)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-modal --> modus-button
   modus-table-columns-visibility --> modus-button
+  modus-table-row-actions --> modus-button
   style modus-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -40,6 +40,7 @@ li {
 
   &.disabled {
     color: $modus-list-item-disabled-color;
+    cursor: default;
     fill: $modus-list-item-disabled-color;
   }
 

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.spec.ts
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.spec.ts
@@ -10,7 +10,7 @@ describe('modus-list-item', () => {
     expect(root).toEqualHtml(`
       <modus-list-item>
         <mock:shadow-root>
-          <li class='standard'>
+          <li class='standard' tabindex="0">
             <span class='slot'>
               <slot></slot>
             </span>
@@ -28,7 +28,7 @@ describe('modus-list-item', () => {
     expect(root).toEqualHtml(`
       <modus-list-item>
         <mock:shadow-root>
-          <li class='standard'>
+          <li class='standard' tabindex="0">
             <span class='slot'>
               <slot></slot>
             </span>

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
+import { Component, Event, EventEmitter, Method, Prop, h } from '@stencil/core';
 import { IconCheck } from '../icons/icon-check';
 
 @Component({
@@ -23,11 +23,24 @@ export class ModusListItem {
   /** An event that fires on list item click */
   @Event() itemClick: EventEmitter;
 
+  listItemRef: HTMLLIElement;
+
+  @Method()
+  async focusItem(): Promise<void> {
+    this.listItemRef?.focus();
+  }
+
   classBySize: Map<string, string> = new Map([
     ['condensed', 'small'],
     ['standard', 'standard'],
     ['large', 'large'],
   ]);
+
+  handleKeydown(e: KeyboardEvent): void {
+    if (e.key.toLowerCase() === 'enter' && !this.disabled) {
+      this.itemClick.emit();
+    }
+  }
 
   render(): unknown {
     const containerClass = `${this.classBySize.get(this.size)} ${this.disabled ? 'disabled' : ''} ${
@@ -36,7 +49,12 @@ export class ModusListItem {
     const iconSize = this.size === 'condensed' ? '18' : '22';
 
     return (
-      <li class={containerClass} onClick={() => (!this.disabled ? this.itemClick.emit() : null)}>
+      <li
+        ref={(el) => (this.listItemRef = el)}
+        class={containerClass}
+        tabIndex={this.disabled ? -1 : 0}
+        onClick={() => (!this.disabled ? this.itemClick.emit() : null)}
+        onKeyDown={(e) => this.handleKeydown(e)}>
         <span class="slot">
           <slot />
         </span>

--- a/stencil-workspace/src/components/modus-list-item/readme.md
+++ b/stencil-workspace/src/components/modus-list-item/readme.md
@@ -22,6 +22,32 @@
 | `itemClick` | An event that fires on list item click | `CustomEvent<any>` |
 
 
+## Methods
+
+### `focusItem() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Dependencies
+
+### Used by
+
+ - [modus-table-row-actions-menu](../modus-table/parts/row/actions/modus-table-row-actions-menu)
+
+### Graph
+```mermaid
+graph TD;
+  modus-table-row-actions-menu --> modus-list-item
+  style modus-list-item fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 

--- a/stencil-workspace/src/components/modus-list/modus-list.tsx
+++ b/stencil-workspace/src/components/modus-list/modus-list.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-import { Component, h } from '@stencil/core';
+import { Component, h, Element } from '@stencil/core';
 
 @Component({
   tag: 'modus-list',
@@ -7,9 +7,35 @@ import { Component, h } from '@stencil/core';
   shadow: true,
 })
 export class ModusList {
+  @Element() element: HTMLElement;
+
+  handleKeyDown(e: KeyboardEvent): void {
+    const itemsLength = this.element.children.length;
+    if (e.key.toLowerCase() === 'arrowdown') {
+      const index = Array.prototype.indexOf.call(this.element.children, e.target);
+
+      let next = this.element.children.item((index + 1) % itemsLength) as HTMLModusListItemElement;
+      while (next?.disabled) {
+        next = this.element.children.item((index + 2) % itemsLength) as HTMLModusListItemElement;
+      }
+      next?.focusItem();
+      e.preventDefault();
+    }
+    if (e.key.toLowerCase() === 'arrowup') {
+      const index = Array.prototype.indexOf.call(this.element.children, e.target);
+
+      let prev = this.element.children.item((index - 1) % itemsLength) as HTMLModusListItemElement;
+      while (prev?.disabled) {
+        prev = this.element.children.item((index - 2) % itemsLength) as HTMLModusListItemElement;
+      }
+      prev?.focusItem();
+      e.preventDefault();
+    }
+  }
+
   render(): unknown {
     return (
-      <ul part="list-items">
+      <ul part="list-items" onKeyDown={(e) => this.handleKeyDown(e)}>
         <slot />
       </ul>
     );

--- a/stencil-workspace/src/components/modus-list/readme.md
+++ b/stencil-workspace/src/components/modus-list/readme.md
@@ -12,6 +12,19 @@
 | `"list-items"` |             |
 
 
+## Dependencies
+
+### Used by
+
+ - [modus-table-row-actions-menu](../modus-table/parts/row/actions/modus-table-row-actions-menu)
+
+### Graph
+```mermaid
+graph TD;
+  modus-table-row-actions-menu --> modus-list
+  style modus-list fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 

--- a/stencil-workspace/src/components/modus-table/models/modus-table.models.ts
+++ b/stencil-workspace/src/components/modus-table/models/modus-table.models.ts
@@ -42,6 +42,19 @@ export type ModusTableCellEditorArgs = ModusTableCellDropdownEditorArgs | ModusT
 
 export type ModusTableSortingFunction<TData extends RowData> = SortingFnOption<TData> | 'sortForHyperlink';
 
+export interface ModusTableRowAction {
+  id: string;
+  icon?: string;
+  label?: string;
+  index: number;
+  isDisabled?: (row: unknown) => boolean;
+}
+
+export interface ModusTableRowActionClick {
+  actionId: string;
+  row: unknown;
+}
+
 export interface ModusTableColumn<TData extends RowData, TValue = unknown> {
   header: string;
   accessorKey: string;
@@ -75,10 +88,6 @@ export interface ModusTableToolbarOptions {
 export interface ModusTableColumnsVisibilityOptions {
   title: string;
   requiredColumns?: string[];
-}
-
-export interface ModusTableRowActions {
-  expandable: boolean;
 }
 
 export interface ModusTableCellLink {

--- a/stencil-workspace/src/components/modus-table/models/table-context.model.ts
+++ b/stencil-workspace/src/components/modus-table/models/table-context.model.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from '@stencil/core';
+import {
+  ModusTableColumn,
+  ModusTableDisplayOptions,
+  ModusTableRowAction,
+  ModusTableRowSelectionOptions,
+  ModusTableToolbarOptions,
+  ModusTableCellValueChange,
+  ModusTableCellLink,
+  ModusTableColumnOrderState,
+  ModusTableColumnSizingState,
+  ModusTableColumnVisibilityState,
+  ModusTableRowActionClick,
+  ModusTableExpandedState,
+  ModusTableSortingState,
+  ModusTablePaginationState,
+} from './modus-table.models';
+import { Row, Table, Updater } from '@tanstack/table-core';
+import ModusTableCore from '../modus-table.core';
+import Position from './position.model';
+
+export interface TableRowActionsMenuEvent {
+  componentId: string;
+  actions: ModusTableRowAction[];
+  position: Position;
+  row: Row<unknown>;
+  onClose: () => void;
+}
+
+export type TableRowActionWithOverflow = ModusTableRowAction & {
+  isOverflow?: boolean;
+};
+
+export type TableCellEdited = Omit<ModusTableCellValueChange, 'data'>;
+
+export default interface TableContext {
+  element: HTMLElement;
+
+  columns: ModusTableColumn<unknown>[];
+
+  columnResize: boolean;
+
+  columnReorder: boolean;
+
+  data: unknown[];
+
+  displayOptions?: ModusTableDisplayOptions;
+
+  hover: boolean;
+
+  fullWidth: boolean;
+
+  maxHeight: string;
+
+  maxWidth: string;
+
+  pageSizeList: number[];
+
+  pagination: boolean;
+
+  rowActions: TableRowActionWithOverflow[];
+
+  rowsExpandable: boolean;
+
+  rowSelection: boolean;
+
+  rowSelectionOptions: ModusTableRowSelectionOptions;
+
+  showSortIconOnHover: boolean;
+
+  sort: boolean;
+
+  summaryRow: boolean;
+
+  toolbar: boolean;
+
+  toolbarOptions: ModusTableToolbarOptions | null;
+
+  cellValueChange: EventEmitter<ModusTableCellValueChange>;
+
+  cellLinkClick: EventEmitter<ModusTableCellLink>;
+
+  columnOrderChange: EventEmitter<ModusTableColumnOrderState>;
+
+  columnSizingChange: EventEmitter<ModusTableColumnSizingState>;
+
+  columnVisibilityChange: EventEmitter<ModusTableColumnVisibilityState>;
+
+  rowActionClick: EventEmitter<ModusTableRowActionClick>;
+
+  rowExpanded: EventEmitter<ModusTableExpandedState>;
+
+  rowSelectionChange: EventEmitter<unknown>;
+
+  sortChange: EventEmitter<ModusTableSortingState>;
+
+  paginationChange: EventEmitter<ModusTablePaginationState>;
+
+  componentId: string;
+
+  frozenColumns: string[];
+
+  isColumnResizing: boolean;
+
+  tableInstance: Table<unknown>;
+
+  tableCore: ModusTableCore;
+
+  updateData: (updater: Updater<unknown>, context: TableCellEdited) => void;
+  onColumnsChange: (newVal: ModusTableColumn<unknown>[]) => void;
+  onColumnResizeChange: (newVal: boolean) => void;
+  onColumnReorderChange: () => void;
+  onDataChange: (newVal: unknown[]) => void;
+  onRowActionsChange: (newVal: ModusTableRowAction[]) => void;
+  onRowsExpandableChange: (newVal: boolean) => void;
+  onRowSelectionOptionsChange: (newVal: ModusTableRowSelectionOptions, oldVal: ModusTableRowSelectionOptions) => void;
+  onSortChange: (newVal) => void;
+  onToolbarOptionsChange: (newVal: ModusTableToolbarOptions | null) => void;
+}

--- a/stencil-workspace/src/components/modus-table/models/table-state.model.ts
+++ b/stencil-workspace/src/components/modus-table/models/table-state.model.ts
@@ -5,10 +5,12 @@ import {
   PaginationState,
   VisibilityState,
   RowSelectionState,
+  Row,
 } from '@tanstack/table-core';
 import { ModusTableSortingState } from './modus-table.models';
+import Position from './position.model';
 
-type ModusTableState = {
+type TableState = {
   columnSizing?: ColumnSizingState; // ColumnSizing has info about width of the column
   columnSizingInfo?: ColumnSizingInfoState; // ColumnSizingInfo has the detailed info about resizing of the column
   expanded?: ExpandedState;
@@ -17,6 +19,11 @@ type ModusTableState = {
   columnVisibility?: VisibilityState;
   columnOrder?: string[];
   rowSelection?: RowSelectionState;
+  rowActionsOverflow?: {
+    position: Position;
+    row: Row<unknown>;
+    onClose: () => void;
+  };
 };
 
-export default ModusTableState;
+export default TableState;

--- a/stencil-workspace/src/components/modus-table/modus-table.constants.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.constants.ts
@@ -3,6 +3,8 @@ export const SORTED_DESCENDING = 'Sorted Descending';
 export const SORT_ASCENDING = 'Sort Ascending';
 export const SORT_DESCENDING = 'Sort Descending';
 
+export const HTML_ATTR_DATA_ACCESSOR_KEY = 'data-accessor-key';
+
 export const COLUMN_DEF_DATATYPE_KEY = 'dataType';
 export const COLUMN_DEF_SUB_ROWS_KEY = 'subRows';
 export const COLUMN_DEF_CELL_EDITOR_TYPE_KEY = 'cellEditorType';

--- a/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
@@ -609,7 +609,6 @@ describe('modus-table', () => {
         index: 0,
         icon: 'edit',
         label: 'Edit',
-        isDisabled: () => true,
       },
     ];
     const component = await page.find('modus-table');
@@ -633,35 +632,30 @@ describe('modus-table', () => {
         index: 0,
         icon: 'edit',
         label: 'Edit',
-        isDisabled: () => false,
       },
       {
         id: '2',
         index: 1,
         icon: 'edit',
         label: 'Edit',
-        isDisabled: () => false,
       },
       {
         id: '3',
         index: 2,
         icon: 'edit',
         label: 'Edit',
-        isDisabled: () => false,
       },
       {
         id: '4',
         index: 3,
         icon: 'edit',
         label: 'Edit',
-        isDisabled: () => false,
       },
       {
         id: '5',
         index: 4,
         icon: 'edit',
         label: 'Edit',
-        isDisabled: () => false,
       },
     ];
     const component = await page.find('modus-table');
@@ -671,9 +665,7 @@ describe('modus-table', () => {
     await page.waitForChanges();
     const rowActionsMenuButton = await page.findAll('modus-table >>> modus-table-row-actions > .row-actions-menu-button');
     expect(rowActionsMenuButton).toHaveLength(MockData.length);
-    const rowActionsMenuButtonClick = await page.spyOnEvent('overflowRowActions');
     await rowActionsMenuButton[0].click();
-    expect(rowActionsMenuButtonClick).toHaveReceivedEvent();
     await page.waitForChanges();
     const rowActionsMenuItem = await page.findAll('modus-table >>> .row-actions-menu-item');
     expect(rowActionsMenuItem).toHaveLength(2);

--- a/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
@@ -1,4 +1,5 @@
 import { E2EPage, newE2EPage } from '@stencil/core/testing';
+import { ModusTableRowAction } from '../../interfaces';
 
 const MockColumns = [
   {
@@ -597,5 +598,87 @@ describe('modus-table', () => {
     await page.waitForChanges();
 
     expect(rowSelectionChange).toHaveReceivedEvent();
+  });
+
+  it('Displays row actions', async () => {
+    page = await newE2EPage();
+    await page.setContent('<modus-table />');
+    const rowActionsMock: ModusTableRowAction[] = [
+      {
+        id: '1',
+        index: 0,
+        icon: 'edit',
+        label: 'Edit',
+        isDisabled: () => true,
+      },
+    ];
+    const component = await page.find('modus-table');
+    component.setProperty('rowActions', rowActionsMock);
+    component.setProperty('columns', MockColumns);
+    component.setProperty('data', MockData);
+    await page.waitForChanges();
+    const rowActions = await page.findAll('modus-table >>> modus-table-row-actions >>> .row-actions');
+    expect(rowActions).toHaveLength(MockData.length);
+    const rowActionClick = await page.spyOnEvent('rowActionClick');
+    await rowActions[0].click();
+    expect(rowActionClick).toHaveReceivedEvent();
+  });
+
+  it('Displays row actions menu', async () => {
+    page = await newE2EPage();
+    await page.setContent('<modus-table />');
+    const rowActionsMock = [
+      {
+        id: '1',
+        index: 0,
+        icon: 'edit',
+        label: 'Edit',
+        isDisabled: () => false,
+      },
+      {
+        id: '2',
+        index: 1,
+        icon: 'edit',
+        label: 'Edit',
+        isDisabled: () => false,
+      },
+      {
+        id: '3',
+        index: 2,
+        icon: 'edit',
+        label: 'Edit',
+        isDisabled: () => false,
+      },
+      {
+        id: '4',
+        index: 3,
+        icon: 'edit',
+        label: 'Edit',
+        isDisabled: () => false,
+      },
+      {
+        id: '5',
+        index: 4,
+        icon: 'edit',
+        label: 'Edit',
+        isDisabled: () => false,
+      },
+    ];
+    const component = await page.find('modus-table');
+    component.setProperty('columns', MockColumns);
+    component.setProperty('data', MockData);
+    component.setProperty('rowActions', rowActionsMock);
+    await page.waitForChanges();
+    const rowActionsMenuButton = await page.findAll('modus-table >>> modus-table-row-actions > .row-actions-menu-button');
+    expect(rowActionsMenuButton).toHaveLength(MockData.length);
+    const rowActionsMenuButtonClick = await page.spyOnEvent('overflowRowActions');
+    await rowActionsMenuButton[0].click();
+    expect(rowActionsMenuButtonClick).toHaveReceivedEvent();
+    await page.waitForChanges();
+    const rowActionsMenuItem = await page.findAll('modus-table >>> .row-actions-menu-item');
+    expect(rowActionsMenuItem).toHaveLength(2);
+    const rowActionsMenuItemClick = await page.spyOnEvent('rowActionClick');
+    await rowActionsMenuItem[0].click();
+    expect(rowActionsMenuItemClick).toHaveReceivedEvent();
   });
 });

--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -252,11 +252,12 @@ table {
             justify-content: flex-end;
           }
 
-          .expand {
-            display: flex;
+          .expand-icon-container {
+            width: 24px;
 
-            span {
+            .expand-icon {
               cursor: pointer;
+              display: flex;
             }
           }
         }

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -20,9 +20,7 @@ import {
   ColumnSizingInfoState,
   ColumnSizingState,
   ExpandedState,
-  HeaderGroup,
   PaginationState,
-  Table,
   RowSelectionState,
   Updater,
   VisibilityState,
@@ -46,6 +44,8 @@ import {
   ModusTableColumnVisibilityState,
   ModusTableExpandedState,
   ModusTablePaginationState,
+  ModusTableRowAction,
+  ModusTableRowActionClick,
   ModusTableSortingState,
 } from './models/modus-table.models';
 import ColumnDragState from './models/column-drag-state.model';
@@ -61,9 +61,10 @@ import { ModusTablePagination } from './parts/modus-table-pagination';
 import { ModusTableFooter } from './parts/modus-table-footer';
 import { TableHeaderDragDrop } from './utilities/table-header-drag-drop.utility';
 import ModusTableCore from './modus-table.core';
-import ModusTableState from './models/modus-table-state.model';
+import TableState from './models/table-state.model';
 import { ModusTableHeader } from './parts/modus-table-header';
-import { ModusTableBody, ModusTableCellEdited } from './parts/modus-table-body';
+import { ModusTableBody } from './parts/modus-table-body';
+import ModusTableContext, { TableCellEdited, TableRowActionWithOverflow } from './models/table-context.model';
 import { createGuid } from '../../utils/utils';
 
 /**
@@ -127,17 +128,19 @@ export class ModusTable {
   /* (optional) To enable pagination for the table. */
   @Prop() pagination: boolean;
 
+  /** (Optional) Actions that can be performed on each row. A maximum of 4 icons will be shown, including overflow menu and expand icons. */
+  @Prop() rowActions: ModusTableRowAction[] = [];
+  @Watch('rowActions') onRowActionsChange(newVal: ModusTableRowAction[]) {
+    if (newVal?.length > 0) {
+      this.freezeColumn(this.tableState.columnOrder[0]);
+    }
+  }
+
   /** (Optional) To display expanded rows. */
   @Prop() rowsExpandable = false;
-  @Watch('rowsExpandable') onRowsExpandableChange() {
-    if (this.rowsExpandable) {
-      this.frozenColumns.push(this.tableState.columnOrder[0]);
-    }
-    if (this.toolbarOptions?.columnsVisibility) {
-      this.toolbarOptions.columnsVisibility.requiredColumns = [
-        ...this.toolbarOptions.columnsVisibility.requiredColumns,
-        ...this.frozenColumns,
-      ];
+  @Watch('rowsExpandable') onRowsExpandableChange(newVal: boolean) {
+    if (newVal) {
+      this.freezeColumn(this.tableState.columnOrder[0]);
     }
   }
 
@@ -178,7 +181,8 @@ export class ModusTable {
   @Prop() toolbarOptions: ModusTableToolbarOptions | null = null;
   @Watch('toolbarOptions') onToolbarOptionsChange(newVal: ModusTableToolbarOptions | null) {
     this.tableCore?.setOptions('enableHiding', !!newVal?.columnsVisibility);
-    this.onRowsExpandableChange();
+    this.onRowsExpandableChange(this.rowsExpandable);
+    this.onRowActionsChange(this.rowActions);
   }
 
   /** Emits the cell value that was edited */
@@ -196,6 +200,9 @@ export class ModusTable {
   /** Emits visibility state of each column */
   @Event() columnVisibilityChange: EventEmitter<ModusTableColumnVisibilityState>;
 
+  /** An event that fires when a row action is clicked. */
+  @Event() rowActionClick: EventEmitter<ModusTableRowActionClick>;
+
   /** Emits expanded state of the columns */
   @Event() rowExpanded: EventEmitter<ModusTableExpandedState>;
 
@@ -208,7 +215,24 @@ export class ModusTable {
   /** Emits selected page index and size */
   @Event() paginationChange: EventEmitter<ModusTablePaginationState>;
 
-  @State() tableState: ModusTableState = {
+  @State() itemDragState: ColumnDragState;
+  @Watch('itemDragState')
+  handleItemDragState(newValue: string, oldValue: string) {
+    if (oldValue && newValue && oldValue === newValue && this.columnReorder) return;
+    if (newValue) {
+      document.addEventListener('mousemove', this.onMouseMove);
+      document.addEventListener('mouseup', this.onMouseUp);
+      document.addEventListener('keydown', this.onKeyDown);
+    } else {
+      document.removeEventListener('mousemove', this.onMouseMove);
+      document.removeEventListener('mouseup', this.onMouseUp);
+      document.removeEventListener('keydown', this.onKeyDown);
+    }
+  }
+
+  @State() dragAndDropObj: TableHeaderDragDrop = new TableHeaderDragDrop();
+
+  @State() tableState: TableState = {
     columnSizing: {},
     columnSizingInfo: {} as ColumnSizingInfoState,
     expanded: null,
@@ -223,12 +247,11 @@ export class ModusTable {
   };
 
   @State() tableCore: ModusTableCore;
-  @State() itemDragState: ColumnDragState;
-  @State() dragAndDropObj: TableHeaderDragDrop = new TableHeaderDragDrop();
 
-  private _id: string;
-  private frozenColumns: string[] = []; // Columns will remain on the left and be unable to reorder, or modify their visibility.
+  private frozenColumns: string[] = [];
   private isColumnResizing = false;
+  private _id: string;
+  private _context: ModusTableContext;
 
   private onMouseMove = (event: MouseEvent) => this.handleDragOver(event);
   private onKeyDown = (event: KeyboardEvent) => this.handleKeyDown(event);
@@ -237,8 +260,13 @@ export class ModusTable {
   componentWillLoad(): void {
     this._id = this.element.id || `modus-table-${createGuid()}`;
     this.setTableState({ columnOrder: this.columns?.map((column) => column.id as string) });
-    this.onRowsExpandableChange();
+    this.onRowsExpandableChange(this.rowsExpandable);
+    this.onRowActionsChange(this.rowActions);
     this.initializeTable();
+  }
+
+  componentWillRender(): void {
+    this._context = this.getTableContext();
   }
 
   /**
@@ -293,18 +321,78 @@ export class ModusTable {
     });
   }
 
-  @Watch('itemDragState')
-  handleItemDragState(newValue: string, oldValue: string) {
-    if (oldValue && newValue && oldValue === newValue && this.columnReorder) return;
-    if (newValue) {
-      document.addEventListener('mousemove', this.onMouseMove);
-      document.addEventListener('mouseup', this.onMouseUp);
-      document.addEventListener('keydown', this.onKeyDown);
-    } else {
-      document.removeEventListener('mousemove', this.onMouseMove);
-      document.removeEventListener('mouseup', this.onMouseUp);
-      document.removeEventListener('keydown', this.onKeyDown);
+  freezeColumn(columnId: string): void {
+    this.frozenColumns.push(columnId);
+    if (this.toolbarOptions?.columnsVisibility) {
+      this.toolbarOptions.columnsVisibility.requiredColumns = [
+        ...this.toolbarOptions.columnsVisibility.requiredColumns,
+        ...this.frozenColumns,
+      ];
     }
+  }
+
+  getRowActionsWithOverflow(): TableRowActionWithOverflow[] {
+    if (this.rowActions) {
+      const sortedActions = this.rowActions.sort((a, b) => a.index - b.index);
+      const visibleLimit = this.rowsExpandable ? 2 : 3;
+      const actionButtons = sortedActions.slice(0, visibleLimit);
+      const overflowMenu = sortedActions.slice(visibleLimit).map((action) => ({ ...action, isOverflow: true }));
+
+      return [...actionButtons, ...overflowMenu];
+    }
+
+    return null;
+  }
+
+  getTableContext(): ModusTableContext {
+    return {
+      element: this.element,
+      data: this.data,
+      sort: this.sort,
+      componentId: this._id,
+      hover: this.hover,
+      pagination: this.pagination,
+      pageSizeList: this.pageSizeList,
+      rowActions: this.getRowActionsWithOverflow(),
+      rowSelection: this.rowSelection,
+      rowSelectionOptions: this.rowSelectionOptions,
+      rowsExpandable: this.rowsExpandable,
+      columns: this.columns,
+      columnReorder: this.columnReorder,
+      columnResize: this.columnResize,
+      rowSelectionChange: this.rowSelectionChange,
+      rowExpanded: this.rowExpanded,
+      rowActionClick: this.rowActionClick,
+      sortChange: this.sortChange,
+      paginationChange: this.paginationChange,
+      columnSizingChange: this.columnSizingChange,
+      columnVisibilityChange: this.columnVisibilityChange,
+      columnOrderChange: this.columnOrderChange,
+      cellValueChange: this.cellValueChange,
+      cellLinkClick: this.cellLinkClick,
+      showSortIconOnHover: this.showSortIconOnHover,
+      displayOptions: this.displayOptions,
+      toolbarOptions: this.toolbarOptions,
+      toolbar: this.toolbar,
+      summaryRow: this.summaryRow,
+      fullWidth: this.fullWidth,
+      maxHeight: this.maxHeight,
+      maxWidth: this.maxWidth,
+      frozenColumns: this.frozenColumns,
+      isColumnResizing: this.isColumnResizing,
+      tableCore: this.tableCore,
+      tableInstance: this.tableCore.getTableInstance(),
+      onColumnsChange: this.onColumnsChange,
+      onColumnResizeChange: this.onColumnResizeChange,
+      onColumnReorderChange: this.onColumnReorderChange,
+      onDataChange: this.onDataChange,
+      onRowActionsChange: this.onRowActionsChange,
+      onRowsExpandableChange: this.onRowsExpandableChange,
+      onRowSelectionOptionsChange: this.onRowSelectionOptionsChange,
+      onSortChange: this.onSortChange,
+      onToolbarOptionsChange: this.onToolbarOptionsChange,
+      updateData: this.updateData.bind(this),
+    };
   }
 
   handleDragStart(
@@ -395,7 +483,7 @@ export class ModusTable {
     });
   }
 
-  setTableState(state: ModusTableState): void {
+  setTableState(state: TableState): void {
     this.tableState = { ...this.tableState, ...state };
   }
 
@@ -411,7 +499,7 @@ export class ModusTable {
     if (event) event.emit(this.tableState[key]);
   }
 
-  updateData(updater: Updater<unknown>, context: ModusTableCellEdited): void {
+  updateData(updater: Updater<unknown>, context: TableCellEdited): void {
     this.data = this.tableCore.getState(updater, this.data) as unknown[];
     this.tableCore.setState('data', this.data);
     this.cellValueChange.emit({ ...context, data: this.data });
@@ -432,11 +520,11 @@ export class ModusTable {
     this.isColumnResizing = !this.tableState.columnSizingInfo.isResizingColumn ? false : true;
   }
 
-  renderToolBar(table: Table<unknown>): JSX.Element | null {
+  renderToolBar(): JSX.Element | null {
     return (
       this.toolbar &&
       this.toolbarOptions && (
-        <modus-table-toolbar table={table} options={this.toolbarOptions}>
+        <modus-table-toolbar context={this._context}>
           <div slot="group-left">
             <slot name="groupLeft"></slot>
           </div>
@@ -448,8 +536,10 @@ export class ModusTable {
     );
   }
 
-  renderMain(table: Table<unknown>): JSX.Element | null {
-    const { borderless, cellBorderless } = this.displayOptions || {};
+  renderMain(): JSX.Element | null {
+    const {
+      displayOptions: { borderless, cellBorderless },
+    } = this._context;
     const tableContainerClass = {
       'table-container': true,
       borderless: borderless,
@@ -458,7 +548,7 @@ export class ModusTable {
     return (
       <Fragment>
         <div class={tableContainerClass} style={{ maxHeight: this.maxHeight }}>
-          {this.renderTable(table)}
+          {this.renderTable()}
 
           {!this.fullWidth && (
             <modus-table-filler-column
@@ -472,9 +562,11 @@ export class ModusTable {
     );
   }
 
-  renderTable(table: Table<unknown>): JSX.Element | null {
-    const { multiple } = this.rowSelectionOptions;
-    const totalSize = table.getTotalSize();
+  renderTable(): JSX.Element | null {
+    const {
+      tableInstance: { getTotalSize },
+    } = this._context;
+    const totalSize = getTotalSize();
 
     const tableMainClass = {
       borderless: this.displayOptions?.borderless,
@@ -489,14 +581,14 @@ export class ModusTable {
 
     return (
       <table data-test-id="main-table" class={tableMainClass} style={tableStyle}>
-        {this.renderTableHeader(table, multiple)}
-        {this.renderTableBody(table, multiple)}
-        {this.renderTableFooter(table)}
+        {this.renderTableHeader()}
+        {this.renderTableBody()}
+        {this.renderTableFooter()}
       </table>
     );
   }
 
-  renderTableHeader(table: Table<unknown>, multipleRowSelection: boolean): JSX.Element | null {
+  renderTableHeader(): JSX.Element | null {
     const setColumnResizing = (val: boolean) => (this.isColumnResizing = val);
 
     const getColumnResizing = () => this.isColumnResizing;
@@ -510,64 +602,35 @@ export class ModusTable {
 
     return (
       <ModusTableHeader
-        componentId={this._id}
-        columnReorder={this.columnReorder}
-        frozenColumns={this.frozenColumns}
-        rowSelection={this.rowSelection}
-        showSortIconOnHover={this.showSortIconOnHover}
-        table={table}
-        multipleRowSelection={multipleRowSelection}
+        context={this._context}
         setColumnResizing={setColumnResizing}
         getColumnResizing={getColumnResizing}
         onDragStart={onDragStart}></ModusTableHeader>
     );
   }
 
-  renderTableBody(table: Table<unknown>, multipleRowSelection: boolean): JSX.Element | null {
-    // Needed in the future to include overflow menu action
-    const rowActions = this.rowsExpandable && { expandable: this.rowsExpandable };
-    return (
-      <ModusTableBody
-        table={table}
-        hover={this.hover}
-        rowSelection={this.rowSelection}
-        multipleRowSelection={multipleRowSelection}
-        rowActions={rowActions}
-        dataUpdater={this.updateData.bind(this)}
-        cellLinkClick={(link: ModusTableCellLink) => this.cellLinkClick.emit(link)}></ModusTableBody>
-    );
+  renderTableBody(): JSX.Element | null {
+    return <ModusTableBody context={this._context}></ModusTableBody>;
   }
 
-  renderTableFooter(table: Table<unknown>): JSX.Element | null {
-    const footerGroups: HeaderGroup<unknown>[] = table.getFooterGroups();
-    return this.summaryRow ? (
-      <ModusTableFooter
-        footerGroups={[footerGroups[0]]}
-        tableData={this.data}
-        frozenColumns={this.frozenColumns}
-        rowSelection={this.rowSelection}
-      />
-    ) : null;
+  renderTableFooter(): JSX.Element | null {
+    return this.summaryRow ? <ModusTableFooter context={this._context} /> : null;
   }
 
-  renderPagination(table: Table<unknown>): JSX.Element | null {
-    return (
-      this.pagination && (
-        <ModusTablePagination table={table} totalCount={this.data.length} pageSizeList={this.pageSizeList} />
-      )
-    );
+  renderPagination(): JSX.Element | null {
+    return this.pagination && <ModusTablePagination context={this._context} />;
   }
 
   render(): void {
-    const table = this.tableCore.getTableInstance();
     return (
       <Host id={this._id}>
         <div style={{ maxWidth: this.maxWidth }}>
-          {this.renderToolBar(table)}
-          {this.renderMain(table)}
-          {this.renderPagination(table)}
+          {this.renderToolBar()}
+          {this.renderMain()}
+          {this.renderPagination()}
           <ModusTableColumnDragItem draggingState={this.itemDragState} />
           <ModusTableColumnDropIndicator position={this.itemDragState?.dropIndicator} />
+          <modus-table-row-actions-menu context={this._context}></modus-table-row-actions-menu>
         </div>
       </Host>
     );

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-expand-icons.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-expand-icons.tsx
@@ -15,6 +15,7 @@ const ModusTableCellExpandIcons: FunctionalComponent<ModusTableCellExpandIconsPr
   let expandEl: HTMLElement;
   return (
     <span
+      class="expand-icon-container"
       ref={(ref) => (expandEl = ref)}
       style={{ paddingLeft: `${row.depth * 2}rem` }}
       onClick={(e) => {
@@ -23,7 +24,7 @@ const ModusTableCellExpandIcons: FunctionalComponent<ModusTableCellExpandIconsPr
       }}>
       {row.getCanExpand() && (
         <span
-          class="expand"
+          class="expand-icon"
           tabIndex={0}
           onKeyDown={(event) => {
             if (event.key.toLowerCase() === KEYBOARD_ENTER || event.key.toLowerCase() === KEYBOARD_SPACE) {

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -8,8 +8,8 @@ import {
   Prop,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Cell, Row } from '@tanstack/table-core';
-import { ModusTableCellEditorArgs, ModusTableCellLink, ModusTableRowActions } from '../../../models/modus-table.models';
+import { Cell } from '@tanstack/table-core';
+import { ModusTableCellEditorArgs, ModusTableCellLink } from '../../../models/modus-table.models';
 import {
   COLUMN_DEF_DATATYPE_KEY,
   COLUMN_DEF_DATATYPE_INTEGER,
@@ -21,11 +21,10 @@ import {
   KEYBOARD_ENTER,
   KEYBOARD_ESCAPE,
 } from '../../../modus-table.constants';
-import ModusTableCellExpandIcons from '../modus-table-cell-expand-icons';
 import NavigateTableCells from '../../../utilities/table-cell-navigation.utility';
 import { CellFormatter } from '../../../utilities/table-cell-formatter.utility';
 import { ModusTableCellLinkElement } from '../modus-table-cell-link-element';
-import { ModusTableCellEdited } from '../../modus-table-body';
+import TableContext, { TableCellEdited } from '../../../models/table-context.model';
 
 @Component({
   tag: 'modus-table-cell-main',
@@ -33,9 +32,9 @@ import { ModusTableCellEdited } from '../../modus-table-body';
 export class ModusTableCellMain {
   @Element() el: HTMLElement;
   @Prop() cell: Cell<unknown, unknown>;
-  @Prop() rowActions: ModusTableRowActions;
-  @Prop() valueChange: (props: ModusTableCellEdited) => void;
-  @Prop() linkClick: (link: ModusTableCellLink) => void;
+  @Prop() context: TableContext;
+  @Prop() hasRowActions: boolean;
+  @Prop() valueChange: (props: TableCellEdited) => void;
 
   @State() editMode: boolean;
   @Watch('editMode') onEditModeChange(newValue: boolean) {
@@ -44,7 +43,7 @@ export class ModusTableCellMain {
   }
 
   private cellEl: HTMLElement;
-  private onCellClick: () => void = () => this.handleCellClick();
+  private onCellClick: (e: MouseEvent) => void = (e) => this.handleCellClick(e);
   private onCellKeyDown: (e: KeyboardEvent) => void = (e: KeyboardEvent) => this.handleCellKeydown(e);
   private onCellBlur: (e: FocusEvent) => void = (e) => this.handleCellBlur(e);
 
@@ -85,7 +84,9 @@ export class ModusTableCellMain {
     return this.cell.column.columnDef[COLUMN_DEF_CELL_EDITOR_ARGS_KEY];
   }
 
-  handleCellClick = () => {
+  handleCellClick = (event: MouseEvent) => {
+    if (event.defaultPrevented) return;
+
     if (this.cell.column.columnDef[this.cellEditableKey]) {
       this.editMode = true;
     }
@@ -98,6 +99,8 @@ export class ModusTableCellMain {
   };
 
   handleCellKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return;
+
     const key = event.key?.toLowerCase();
     const isCellEditable = this.cell.column.columnDef[this.cellEditableKey];
 
@@ -141,24 +144,30 @@ export class ModusTableCellMain {
     event.stopPropagation();
   };
 
-  renderCellValue(cellValue: unknown, row: Row<unknown>): JSX.Element[] {
+  renderCellValue(): JSX.Element[] {
+    const { row, getValue } = this.cell;
+    const cellValue = getValue();
+
     if (!cellValue) return null;
 
+    const { cellLinkClick } = this.context;
     const cellDataType = cellValue['_type'] ?? this.cell.column.columnDef[COLUMN_DEF_DATATYPE_KEY];
     const classes = {
       'cell-content': true,
+      'wrap-text': true,
       'text-align-right': cellDataType === COLUMN_DEF_DATATYPE_INTEGER,
     };
 
     return (
       <div class={classes}>
-        {this.rowActions?.expandable && <ModusTableCellExpandIcons row={row} />}
+        {this.hasRowActions && <modus-table-row-actions context={this.context} row={row}></modus-table-row-actions>}
+
         <span class="wrap-text">
           {cellDataType === COLUMN_DEF_DATATYPE_LINK ? (
             <ModusTableCellLinkElement
               link={cellValue as ModusTableCellLink}
               onLinkClick={(link: ModusTableCellLink) => {
-                this.linkClick(link);
+                cellLinkClick.emit(link);
               }}
             />
           ) : (
@@ -170,9 +179,7 @@ export class ModusTableCellMain {
   }
 
   render(): void {
-    const cellValue = this.cell.getValue();
-    const valueString = cellValue?.toString();
-    const row = this.cell.row;
+    const valueString = this.cell.getValue()?.toString();
 
     return (
       <Host>
@@ -185,7 +192,7 @@ export class ModusTableCellMain {
             keyDown={(event: KeyboardEvent, newVal: string) => this.handleCellEditorKeyDown(event, newVal, valueString)}
           />
         ) : (
-          this.renderCellValue(cellValue, row)
+          this.renderCellValue()
         )}
       </Host>
     );

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property      | Attribute | Description | Type                                    | Default     |
-| ------------- | --------- | ----------- | --------------------------------------- | ----------- |
-| `cell`        | --        |             | `Cell<unknown, unknown>`                | `undefined` |
-| `linkClick`   | --        |             | `(link: ModusTableCellLink) => void`    | `undefined` |
-| `rowActions`  | --        |             | `ModusTableRowActions`                  | `undefined` |
-| `valueChange` | --        |             | `(props: ModusTableCellEdited) => void` | `undefined` |
+| Property        | Attribute         | Description | Type                               | Default     |
+| --------------- | ----------------- | ----------- | ---------------------------------- | ----------- |
+| `cell`          | --                |             | `Cell<unknown, unknown>`           | `undefined` |
+| `cellIndex`     | `cell-index`      |             | `number`                           | `undefined` |
+| `context`       | --                |             | `TableContext`                     | `undefined` |
+| `hasRowActions` | `has-row-actions` |             | `boolean`                          | `undefined` |
+| `valueChange`   | --                |             | `(props: TableCellEdited) => void` | `undefined` |
 
 
 ## Dependencies
@@ -23,12 +24,15 @@
 
 ### Depends on
 
+- [modus-table-row-actions](../../row/actions/modus-table-row-actions)
 - [modus-table-cell-editor](../modus-table-cell-editor)
 
 ### Graph
 ```mermaid
 graph TD;
+  modus-table-cell-main --> modus-table-row-actions
   modus-table-cell-main --> modus-table-cell-editor
+  modus-table-row-actions --> modus-button
   modus-table-cell-editor --> modus-number-input
   modus-table-cell-editor --> modus-text-input
   modus-table-cell-editor --> modus-select

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
@@ -3,32 +3,33 @@ import {
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
 import { Cell } from '@tanstack/table-core';
-import { ModusTableCellLink, ModusTableRowActions } from '../../models/modus-table.models';
-import { ModusTableCellEdited } from '../modus-table-body';
+import TableContext, { TableCellEdited } from '../../models/table-context.model';
 
 interface ModusTableCellProps {
   cell: Cell<unknown, unknown>;
-  rowActions: ModusTableRowActions;
-  linkClick: (link: ModusTableCellLink) => void;
-  valueChange: (props: ModusTableCellEdited) => void;
+  cellIndex: number;
+  context: TableContext;
+  valueChange: (props: TableCellEdited) => void;
 }
 
-export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({ cell, rowActions, valueChange, linkClick }) => {
+export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({ cell, cellIndex, context, valueChange }) => {
+  const { rowsExpandable, rowActions } = context;
+  const hasRowActions = cellIndex === 0 && (rowsExpandable || rowActions?.length > 0);
   const { id } = cell;
   return (
     <td
       key={id}
       tabindex={0}
       class={`
-      ${rowActions ? 'sticky-left' : ''}
+      ${hasRowActions ? 'sticky-left' : ''}
       ${cell.column.getIsResizing() ? 'active-resize' : ''}
   `}
       style={{ width: `${cell.column.getSize()}px` }}>
       <modus-table-cell-main
         cell={cell}
-        rowActions={rowActions}
-        valueChange={valueChange}
-        linkClick={linkClick}></modus-table-cell-main>
+        hasRowActions={hasRowActions}
+        context={context}
+        valueChange={valueChange}></modus-table-cell-main>
     </td>
   );
 };

--- a/stencil-workspace/src/components/modus-table/parts/columnHeader/modus-table-column-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/columnHeader/modus-table-column-header.tsx
@@ -2,20 +2,17 @@ import {
   FunctionalComponent,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Header, Table } from '@tanstack/table-core';
+import { Header } from '@tanstack/table-core';
 import { KEYBOARD_ENTER } from '../../modus-table.constants';
 import { ModusTableColumnResizingHandler } from './modus-table-column-resizing-handler';
 import { ModusTableColumnSortIcon } from './modus-table-column-sort-icon';
+import TableContext from '../../models/table-context.model';
 
 interface ModusTableColumnHeaderProps {
-  id: string;
-  table: Table<unknown>;
+  context: TableContext;
   header: Header<unknown, unknown>;
+  id: string;
   isNestedParentHeader: boolean;
-  showSortIconOnHover: boolean;
-  columnReorder: boolean;
-  isColumnResizing: boolean;
-  frozenColumns: string[];
   onDragStart: (
     event: MouseEvent | KeyboardEvent,
     id: string,
@@ -31,22 +28,20 @@ interface ModusTableColumnHeaderProps {
  */
 export const ModusTableColumnHeader: FunctionalComponent<ModusTableColumnHeaderProps> = ({
   id,
-  table,
+  context,
   header,
   isNestedParentHeader,
-  showSortIconOnHover,
-  columnReorder,
-  isColumnResizing,
-  frozenColumns,
   onDragStart,
   onMouseEnterResize,
   onMouseLeaveResize,
 }) => {
   let elementRef: HTMLTableCellElement;
+  const { tableInstance: table, isColumnResizing, columnReorder, frozenColumns, showSortIconOnHover } = context;
   const { column, id: headerId, colSpan, isPlaceholder, getSize } = header;
 
   return (
     <th
+      data-accessor-key={headerId}
       tabindex={`${!isColumnResizing && columnReorder ? '0' : ''}`}
       key={id}
       colSpan={colSpan}

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
@@ -2,37 +2,24 @@ import {
   FunctionalComponent,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Table, Updater } from '@tanstack/table-core';
-import { ModusTableCellLink, ModusTableCellValueChange, ModusTableRowActions } from '../models/modus-table.models';
+import { ModusTableCellValueChange } from '../models/modus-table.models';
 import { ModusTableCell } from './cell/modus-table-cell';
 import { ModusTableCellCheckbox } from './row/selection/modus-table-cell-checkbox';
 import { COLUMN_DEF_SUB_ROWS_KEY } from '../modus-table.constants';
+import TableContext from '../models/table-context.model';
 
 interface ModusTableBodyProps {
-  table: Table<unknown>;
-  hover: boolean;
-  multipleRowSelection: boolean;
-  rowSelection: boolean;
-  rowActions: ModusTableRowActions;
-  dataUpdater: (updater: Updater<unknown>, context: ModusTableCellEdited) => void;
-  cellLinkClick: (link: ModusTableCellLink) => void;
+  context: TableContext;
 }
 
-export type ModusTableCellEdited = Omit<ModusTableCellValueChange, 'data'>;
+export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({ context }) => {
+  const { hover, rowSelection, rowSelectionOptions, tableInstance: table, updateData } = context;
+  const multipleRowSelection = rowSelectionOptions?.multiple;
 
-export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({
-  table,
-  hover,
-  rowSelection,
-  multipleRowSelection,
-  rowActions,
-  dataUpdater,
-  cellLinkClick,
-}) => {
   // Note: This function supports only 3 levels of nested rows.
   function handleCellValueChange(props: ModusTableCellValueChange) {
     const { row, accessorKey, newValue } = props;
-    dataUpdater(
+    updateData(
       (old: unknown[]) => {
         const newData = [...old];
 
@@ -68,14 +55,9 @@ export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({
                 row={row}
                 isChecked={isChecked}></ModusTableCellCheckbox>
             )}
-            {getVisibleCells()?.map((cell, index) => {
+            {getVisibleCells()?.map((cell, cellIndex) => {
               return (
-                <ModusTableCell
-                  cell={cell}
-                  rowActions={index === 0 && rowActions ? rowActions : null}
-                  valueChange={handleCellValueChange}
-                  linkClick={cellLinkClick}
-                />
+                <ModusTableCell cell={cell} cellIndex={cellIndex} context={context} valueChange={handleCellValueChange} />
               );
             })}
           </tr>

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-footer.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-footer.tsx
@@ -2,7 +2,6 @@ import {
   FunctionalComponent,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { HeaderGroup } from '@tanstack/table-core';
 import {
   COLUMN_DEF_DATATYPE_KEY,
   COLUMN_DEF_SHOWTOTAL,
@@ -10,12 +9,10 @@ import {
   COLUMN_DEF_ROW_SELECTION_CSS,
   COLUMN_DEF_DATATYPE_INTEGER,
 } from '../modus-table.constants';
+import TableContext from '../models/table-context.model';
 
 interface ModusTableSummaryRowProps {
-  footerGroups: HeaderGroup<unknown>[];
-  tableData: unknown[];
-  frozenColumns: string[];
-  rowSelection: boolean;
+  context: TableContext;
 }
 
 function calculateTotal(tableData: unknown[], header): number | string {
@@ -25,14 +22,16 @@ function calculateTotal(tableData: unknown[], header): number | string {
 }
 
 export const ModusTableFooter: FunctionalComponent<ModusTableSummaryRowProps> = ({
-  footerGroups,
-  tableData,
-  frozenColumns,
-  rowSelection,
+  context: {
+    tableInstance: { getFooterGroups },
+    data,
+    rowSelection,
+    frozenColumns,
+  },
 }) => {
   return (
     <tfoot>
-      {footerGroups.map((group) => (
+      {getFooterGroups().map((group) => (
         <tr class="summary-row">
           {rowSelection && (
             <td id={COLUMN_DEF_ROW_SELECTION_ID} key={COLUMN_DEF_ROW_SELECTION_ID} class={COLUMN_DEF_ROW_SELECTION_CSS}></td>
@@ -45,9 +44,7 @@ export const ModusTableFooter: FunctionalComponent<ModusTableSummaryRowProps> = 
                 ${frozenColumns.includes(header.id) ? 'sticky-left' : ''}
                 ${header.column.columnDef[COLUMN_DEF_DATATYPE_KEY] === COLUMN_DEF_DATATYPE_INTEGER ? 'text-align-right' : ''}
               `}>
-              {header.column.columnDef[COLUMN_DEF_SHOWTOTAL]
-                ? calculateTotal(tableData, header)
-                : header.column.columnDef.footer}
+              {header.column.columnDef[COLUMN_DEF_SHOWTOTAL] ? calculateTotal(data, header) : header.column.columnDef.footer}
             </td>
           ))}
         </tr>

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-header.tsx
@@ -2,18 +2,13 @@ import {
   FunctionalComponent,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { HeaderGroup, Table } from '@tanstack/table-core';
+import { HeaderGroup } from '@tanstack/table-core';
 import { ModusTableColumnHeader } from './columnHeader/modus-table-column-header';
 import { ModusTableHeaderCheckbox } from './row/selection/modus-table-header-checkbox';
+import TableContext from '../models/table-context.model';
 
 interface ModusTableHeaderProps {
-  componentId: string;
-  columnReorder: boolean;
-  frozenColumns: string[];
-  multipleRowSelection: boolean;
-  rowSelection: boolean;
-  showSortIconOnHover: boolean;
-  table: Table<unknown>;
+  context: TableContext;
   onDragStart: (
     event: MouseEvent | KeyboardEvent,
     id: string,
@@ -25,18 +20,18 @@ interface ModusTableHeaderProps {
 }
 
 export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
-  componentId,
-  columnReorder,
-  frozenColumns,
-  multipleRowSelection,
-  rowSelection,
-  showSortIconOnHover,
-  table,
+  context,
   onDragStart,
   getColumnResizing,
   setColumnResizing,
 }) => {
-  const { getHeaderGroups } = table;
+  const {
+    tableInstance: { getHeaderGroups },
+    columnReorder,
+    rowSelection,
+    componentId,
+  } = context;
+
   const tableHeadClass = { 'show-resize-cursor': getColumnResizing(), 'show-column-reorder-cursor': columnReorder };
   const headerGroups: HeaderGroup<unknown>[] = getHeaderGroups();
 
@@ -44,21 +39,15 @@ export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
     <thead class={tableHeadClass}>
       {headerGroups?.map((headerGroup, index) => (
         <tr key={headerGroup.id}>
-          {rowSelection && (
-            <ModusTableHeaderCheckbox table={table} multipleRowSelection={multipleRowSelection}></ModusTableHeaderCheckbox>
-          )}
+          {rowSelection && <ModusTableHeaderCheckbox context={context}></ModusTableHeaderCheckbox>}
           {headerGroup.headers?.map((header) => {
             const id = `${componentId}-${header.id}`;
             return (
               <ModusTableColumnHeader
                 id={id}
-                table={table}
+                context={context}
                 header={header}
                 isNestedParentHeader={index < headerGroups.length - 1}
-                showSortIconOnHover={showSortIconOnHover}
-                columnReorder={columnReorder}
-                isColumnResizing={getColumnResizing()}
-                frozenColumns={frozenColumns}
                 onDragStart={onDragStart}
                 onMouseEnterResize={() => setColumnResizing(true)}
                 onMouseLeaveResize={() => setColumnResizing(false)}

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-pagination.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-pagination.tsx
@@ -2,20 +2,17 @@ import {
   FunctionalComponent,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Table } from '@tanstack/table-core';
 import { PAGINATION_PAGEVIEW_TEXT, PAGINATION_SUMMARY_TEXT } from '../modus-table.constants';
+import TableContext from '../models/table-context.model';
 
 interface ModusTablePaginationProps {
-  table: Table<unknown>;
-  totalCount: number;
-  pageSizeList: number[];
+  context: TableContext;
 }
 
 export const ModusTablePagination: FunctionalComponent<ModusTablePaginationProps> = ({
-  table,
-  totalCount,
-  pageSizeList,
+  context: { tableInstance: table, pageSizeList, data },
 }) => {
+  const totalCount = data.length;
   const optionsList = pageSizeList.map((option) => ({ display: option }));
   const { options, getState, getPageCount, getExpandedRowModel, setPageIndex, setPageSize } = table;
   const { pageIndex, pageSize } = getState().pagination;

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/modus-table-columns-visibility.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/modus-table-columns-visibility.tsx
@@ -4,7 +4,7 @@ import {
   State,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Table } from '@tanstack/table-core';
+import { Column } from '@tanstack/table-core';
 import { KEYBOARD_DOWN, KEYBOARD_UP, KEYBOARD_ENTER, KEYBOARD_SPACE, KEYBOARD_TAB } from '../../../modus-table.constants';
 import { JSX } from '@stencil/core/internal';
 import { ModusTableColumnsVisibilityOptions } from '../../../models/modus-table.models';
@@ -16,7 +16,7 @@ import { ModusTableColumnsVisibilityOptions } from '../../../models/modus-table.
 })
 export class ModusTableColumnsVisibility {
   /** Table data. */
-  @Prop() table: Table<unknown>;
+  @Prop() getColumnsFn: () => Column<unknown, unknown>[];
 
   /** Column visibility options */
   @Prop() columnsVisibility: ModusTableColumnsVisibilityOptions;
@@ -32,7 +32,7 @@ export class ModusTableColumnsVisibility {
   private refItemContent: HTMLElement[] = [];
 
   applyColumnsVisibility() {
-    this.table.getAllLeafColumns().forEach((column) => {
+    this.getColumnsFn().forEach((column) => {
       if (this.columnsVisibilityState.has(column.id)) {
         column.toggleVisibility(this.columnsVisibilityState.get(column.id));
       }
@@ -117,7 +117,7 @@ export class ModusTableColumnsVisibility {
       };
     };
 
-    return this.table.getAllLeafColumns().map((column, index) => {
+    return this.getColumnsFn().map((column, index) => {
       return (
         <div {...columnVisibilityItemControls(column.id, index)} class="column-visibility-item">
           <modus-checkbox

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/readme.md
@@ -10,9 +10,9 @@
 | Property               | Attribute       | Description               | Type                                 | Default     |
 | ---------------------- | --------------- | ------------------------- | ------------------------------------ | ----------- |
 | `columnsVisibility`    | --              | Column visibility options | `ModusTableColumnsVisibilityOptions` | `undefined` |
+| `getColumnsFn`         | --              | Table data.               | `() => Column<unknown, unknown>[]`   | `undefined` |
 | `menuIconContainerRef` | --              |                           | `HTMLDivElement`                     | `undefined` |
 | `showDropdown`         | `show-dropdown` |                           | `boolean`                            | `undefined` |
-| `table`                | --              | Table data.               | `Table<unknown>`                     | `undefined` |
 | `toggleDropdown`       | --              |                           | `(show: boolean) => void`            | `undefined` |
 
 

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-dropdown-menu/modus-table-dropdown-menu.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-dropdown-menu/modus-table-dropdown-menu.tsx
@@ -1,15 +1,7 @@
-import {
-  Component,
-  Prop,
-  Listen,
-  State,
-  h, // eslint-disable-line @typescript-eslint/no-unused-vars
-  Element,
-} from '@stencil/core';
+import { Component, Prop, Listen, State, h } from '@stencil/core';
 import { IconHorizontalEllipsis } from '../../../../icons/icon-horizontal-ellipsis';
 import { KEYBOARD_ENTER, KEYBOARD_ESCAPE, KEYBOARD_SPACE } from '../../../modus-table.constants';
-import { Table } from '@tanstack/table-core';
-import { ModusTableToolbarOptions } from '../../../models/modus-table.models';
+import TableContext from '../../../models/table-context.model';
 
 @Component({
   tag: 'modus-table-dropdown-menu',
@@ -17,16 +9,12 @@ import { ModusTableToolbarOptions } from '../../../models/modus-table.models';
   shadow: true,
 })
 export class ModusTableDropdownMenu {
-  @Element() element: HTMLElement; // Remove if not utilized
-
-  /** Table data. */
-  @Prop() table: Table<unknown>;
-
-  /** dropdown menu options. */
-  @Prop() options: ModusTableToolbarOptions;
+  @Prop() context: TableContext;
 
   /** Dropdown visibility state */
   @State() show = false;
+
+  private menuIconContainerRef: HTMLDivElement;
 
   @Listen('click', { target: 'document' })
   handleClickOutside(event: MouseEvent): void {
@@ -36,8 +24,6 @@ export class ModusTableDropdownMenu {
       this.show = false;
     }
   }
-
-  menuIconContainerRef: HTMLDivElement;
 
   handleIconKeyDown(event: KeyboardEvent) {
     const eventKey = event.key.toLowerCase();
@@ -59,6 +45,10 @@ export class ModusTableDropdownMenu {
   }
 
   render(): void {
+    const {
+      tableInstance: { getAllLeafColumns },
+      toolbarOptions: options,
+    } = this.context;
     return (
       <div class="dropdown-menu-container">
         <div
@@ -69,15 +59,19 @@ export class ModusTableDropdownMenu {
           ref={(el) => (this.menuIconContainerRef = el as HTMLDivElement)}>
           <IconHorizontalEllipsis size="20" />
         </div>
-        <div onKeyDown={(event) => this.handleDropdownKeyDown(event)} class={`dropdown-menu ${this.show ? 'visible' : ''}`}>
-          <modus-table-columns-visibility
-            table={this.table}
-            columnsVisibility={this.options?.columnsVisibility}
-            showDropdown={this.show}
-            menuIconContainerRef={this.menuIconContainerRef}
-            toggleDropdown={(show: boolean) => (this.show = show)}
-          />
-        </div>
+        {options?.columnsVisibility && (
+          <div
+            onKeyDown={(event) => this.handleDropdownKeyDown(event)}
+            class={`dropdown-menu ${this.show ? 'visible' : ''}`}>
+            <modus-table-columns-visibility
+              getColumnsFn={getAllLeafColumns}
+              columnsVisibility={options?.columnsVisibility}
+              showDropdown={this.show}
+              menuIconContainerRef={this.menuIconContainerRef}
+              toggleDropdown={(show: boolean) => (this.show = show)}
+            />
+          </div>
+        )}
       </div>
     );
   }

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-dropdown-menu/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-dropdown-menu/readme.md
@@ -7,10 +7,9 @@
 
 ## Properties
 
-| Property  | Attribute | Description            | Type                       | Default     |
-| --------- | --------- | ---------------------- | -------------------------- | ----------- |
-| `options` | --        | dropdown menu options. | `ModusTableToolbarOptions` | `undefined` |
-| `table`   | --        | Table data.            | `Table<unknown>`           | `undefined` |
+| Property  | Attribute | Description | Type           | Default     |
+| --------- | --------- | ----------- | -------------- | ----------- |
+| `context` | --        |             | `TableContext` | `undefined` |
 
 
 ## Dependencies

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-toolbar/modus-table-toolbar.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-toolbar/modus-table-toolbar.tsx
@@ -4,8 +4,7 @@ import {
   Prop,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Table } from '@tanstack/table-core';
-import { ModusTableToolbarOptions } from '../../../models/modus-table.models';
+import TableContext from '../../../models/table-context.model';
 @Component({
   tag: 'modus-table-toolbar',
   styleUrl: './modus-table-toolbar.scss',
@@ -13,12 +12,10 @@ import { ModusTableToolbarOptions } from '../../../models/modus-table.models';
 })
 export class ModusTablePanel {
   /** Table data. */
-  @Prop() table: Table<unknown>;
-
-  /** (Optional) Table Panel options. */
-  @Prop() options: ModusTableToolbarOptions;
+  @Prop() context: TableContext;
 
   render(): void {
+    // const { tableInstance: table, toolbarOptions: options } = this.context;
     return (
       <Host>
         <div class="table-toolbar">
@@ -27,7 +24,7 @@ export class ModusTablePanel {
           </div>
           <div class="section">
             <slot name="group-right" />
-            {<modus-table-dropdown-menu table={this.table} options={this.options} />}
+            {<modus-table-dropdown-menu context={this.context} />}
           </div>
         </div>
       </Host>

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-toolbar/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-toolbar/readme.md
@@ -7,10 +7,9 @@
 
 ## Properties
 
-| Property  | Attribute | Description                     | Type                       | Default     |
-| --------- | --------- | ------------------------------- | -------------------------- | ----------- |
-| `options` | --        | (Optional) Table Panel options. | `ModusTableToolbarOptions` | `undefined` |
-| `table`   | --        | Table data.                     | `Table<unknown>`           | `undefined` |
+| Property  | Attribute | Description | Type           | Default     |
+| --------- | --------- | ----------- | -------------- | ----------- |
+| `context` | --        | Table data. | `TableContext` | `undefined` |
 
 
 ## Dependencies

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.scss
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.scss
@@ -1,0 +1,17 @@
+@import '../../../../modus-table.vars';
+
+modus-table-row-actions-menu {
+  .row-actions-menu {
+    background-color: $modus-table-body-bg;
+    box-shadow: 0 0 2px rgba(37, 42, 46, 0.3);
+    color: $modus-table-body-color;
+    display: flex;
+    position: fixed;
+    top: -1px;
+    z-index: 9;
+  }
+
+  modus-list-item {
+    cursor: pointer;
+  }
+}

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.tsx
@@ -79,7 +79,7 @@ export class ModusTableRowActionsMenu {
   }
 
   handleRowActionButtonClick({ detail: { actionId } }: CustomEvent<ModusTableRowActionClick>): void {
-    const rowActionButtonClicked = this.overFlowMenu.find((action) => action.id !== actionId);
+    const rowActionButtonClicked = this.overFlowMenu && this.overFlowMenu.find((action) => action.id !== actionId);
     if (rowActionButtonClicked) this.isMenuOpen = false;
   }
 

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.tsx
@@ -1,0 +1,147 @@
+import {
+  Component,
+  h,
+  State,
+  Listen,
+  Host,
+  Watch,
+  Prop, // eslint-disable-line @typescript-eslint/no-unused-vars
+} from '@stencil/core';
+import { ModusTableRowAction, ModusTableRowActionClick } from '../../../../models/modus-table.models';
+import TableContext, { TableRowActionsMenuEvent } from '../../../../models/table-context.model';
+import Position from '../../../../models/position.model';
+import { Element } from '@stencil/core';
+import { Row } from '@tanstack/table-core';
+
+@Component({
+  tag: 'modus-table-row-actions-menu',
+  styleUrl: './modus-table-row-actions-menu.scss',
+})
+export class ModusTableRowActionsMenu {
+  @Element() element: HTMLElement;
+
+  @Prop() context: TableContext;
+
+  @State() isMenuOpen = false;
+  @Watch('isMenuOpen') onMenuOpenChange(newValue: boolean) {
+    if (!newValue) {
+      this.overFlowMenu = null;
+      this.position = null;
+      this.tableRow = null;
+    }
+  }
+
+  @State() overFlowMenu: ModusTableRowAction[];
+
+  @State() position: Position;
+
+  private tableRow: Row<unknown>;
+
+  // a local state to keep track of the overflow icon click to prevent `handleClickOutside` from closing the menu
+  // event.preventDefault would not solve the problem when multiple tables are present on the page
+  private isOverflowIconClicked = false;
+
+  private onCloseMenu: () => void;
+  private onOverflowRowActions: (event: CustomEvent<TableRowActionsMenuEvent>) => void = (e) =>
+    this.handleOverflowRowActions(e);
+  private onRowActionClick: (event: CustomEvent<ModusTableRowActionClick>) => void = (e) =>
+    this.handleRowActionButtonClick(e);
+  private onRowExpanded: (event: CustomEvent) => void = () => (this.isMenuOpen = false);
+
+  connectedCallback(): void {
+    const { element } = this.context;
+    element.addEventListener('overflowRowActions', this.onOverflowRowActions);
+    element.addEventListener('rowActionClick', this.onRowActionClick);
+    element.addEventListener('rowExpanded', this.onRowExpanded);
+  }
+
+  disconnectedCallback(): void {
+    const { element } = this.context;
+    element.removeEventListener('overflowRowActions', this.onOverflowRowActions);
+    element.removeEventListener('rowActionClick', this.onRowActionClick);
+    element.removeEventListener('rowExpanded', this.onRowExpanded);
+  }
+
+  handleOverflowRowActions(event: CustomEvent<TableRowActionsMenuEvent>): void {
+    const { componentId, actions, position, row, onClose } = event.detail;
+    if (componentId !== this.context.componentId) return;
+
+    this.isMenuOpen = this.tableRow?.id === row.id ? false : true;
+    if (this.isMenuOpen) {
+      this.overFlowMenu = actions;
+      this.position = position;
+      this.tableRow = row;
+      this.onCloseMenu = onClose;
+    }
+    this.isOverflowIconClicked = this.isMenuOpen;
+
+    event.stopPropagation();
+  }
+
+  handleRowActionButtonClick({ detail: { actionId } }: CustomEvent<ModusTableRowActionClick>): void {
+    const rowActionButtonClicked = this.overFlowMenu.find((action) => action.id !== actionId);
+    if (rowActionButtonClicked) this.isMenuOpen = false;
+  }
+
+  @Listen('click', { target: 'document' })
+  handleClickOutside(event: MouseEvent): void {
+    console.log(event.target);
+    if (!(this.element.contains(event.target as HTMLElement) || this.isOverflowIconClicked)) {
+      this.isMenuOpen = false;
+    }
+
+    this.isOverflowIconClicked = false;
+  }
+
+  handleListItemClick(id: string): void {
+    const { rowActionClick } = this.context;
+    rowActionClick.emit({ actionId: id, row: this.tableRow.original });
+  }
+
+  handleListItemKeydown(e: KeyboardEvent): void {
+    if (e.key.toLowerCase() === 'escape' || e.key.toLowerCase() === 'enter') {
+      this.isMenuOpen = false;
+      this.onCloseMenu?.();
+      e.preventDefault();
+    }
+  }
+
+  render(): void {
+    if (!(this.overFlowMenu?.length && this.position)) return null;
+
+    const { x, y } = this.position;
+    const style = {
+      transform: `translate(calc(${x}px - 8px), calc(${y}px))`,
+    };
+
+    return (
+      <Host>
+        {this.isMenuOpen && (
+          <div style={{ ...style }} class="row-actions-menu">
+            <modus-list class="hydrated">
+              {this.overFlowMenu.map(({ label, id, isDisabled = () => false }) => {
+                const disabled = isDisabled(this.tableRow?.original);
+                return (
+                  <modus-list-item
+                    disabled={disabled}
+                    onItemClick={() => this.handleListItemClick(id)}
+                    class="hydrated row-actions-menu-item"
+                    onKeyDown={(e) => this.handleListItemKeydown(e)}
+                    tabindex={disabled ? -1 : 0}>
+                    {label}
+                  </modus-list-item>
+                );
+              })}
+            </modus-list>
+          </div>
+        )}
+      </Host>
+    );
+  }
+
+  componentDidRender(): void {
+    if (this.isMenuOpen) {
+      (this.element.children.item(0)?.children.item(0)?.children.item(0) as HTMLElement)?.focus();
+    }
+  }
+}

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/readme.md
@@ -1,0 +1,37 @@
+# modus-table-filler-column
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type           | Default     |
+| --------- | --------- | ----------- | -------------- | ----------- |
+| `context` | --        |             | `TableContext` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [modus-table](../../../..)
+
+### Depends on
+
+- [modus-list](../../../../../modus-list)
+- [modus-list-item](../../../../../modus-list-item)
+
+### Graph
+```mermaid
+graph TD;
+  modus-table-row-actions-menu --> modus-list
+  modus-table-row-actions-menu --> modus-list-item
+  modus-table --> modus-table-row-actions-menu
+  style modus-table-row-actions-menu fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.scss
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.scss
@@ -1,0 +1,6 @@
+modus-table-row-actions {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-right: 8px;
+}

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.tsx
@@ -81,7 +81,7 @@ export class ModusTableRowActions {
               size="small"
               disabled={disabled}
               onKeyDown={(e) => this.handleActionButtonKeydown(e, id)}
-              onClick={(e) => (!disabled ? this.handleActionButtonClick(e, id) : e.preventDefault())}></modus-button>
+              onButtonClick={(e) => (!disabled ? this.handleActionButtonClick(e, id) : e.preventDefault())}></modus-button>
           );
         })}
 
@@ -95,7 +95,7 @@ export class ModusTableRowActions {
               icon-only="vertical-ellipsis"
               size="small"
               onKeyDown={(e) => this.handleMoreButtonKeydown(e, overflowMenu)}
-              onClick={(e) => this.handleMoreButtonClick(e, overflowMenu)}></modus-button>
+              onButtonClick={(e) => this.handleMoreButtonClick(e, overflowMenu)}></modus-button>
           </Fragment>
         )}
       </Host>

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.tsx
@@ -1,0 +1,104 @@
+import {
+  Host,
+  Component,
+  Prop,
+  h, // eslint-disable-line @typescript-eslint/no-unused-vars
+  Fragment,
+  Event,
+  EventEmitter,
+} from '@stencil/core';
+import { Row } from '@tanstack/table-core';
+import { ModusTableRowAction } from '../../../../models/modus-table.models';
+import TableContext, { TableRowActionsMenuEvent } from '../../../../models/table-context.model';
+import ModusTableCellExpandIcons from '../../../cell/modus-table-cell-expand-icons';
+
+@Component({
+  tag: 'modus-table-row-actions',
+  styleUrl: './modus-table-row-actions.scss',
+})
+export class ModusTableRowActions {
+  @Prop() row: Row<unknown>;
+  @Prop() context: TableContext;
+
+  @Event() overflowRowActions: EventEmitter<TableRowActionsMenuEvent>;
+
+  private overflowButtonRef: HTMLModusButtonElement;
+
+  handleMoreButtonClick(e: Event, menu: ModusTableRowAction[]): void {
+    const { left, top, height } = this.overflowButtonRef.getBoundingClientRect();
+
+    this.overflowRowActions.emit({
+      componentId: this.context.componentId,
+      actions: menu,
+      position: { x: left, y: top + height },
+      row: this.row,
+      onClose: () => this.overflowButtonRef.focusButton(),
+    });
+    e.preventDefault();
+  }
+
+  handleMoreButtonKeydown(e: KeyboardEvent, menu: ModusTableRowAction[]): void {
+    if (e.key.toLowerCase() === 'enter') {
+      this.handleMoreButtonClick(e, menu);
+      e.preventDefault();
+    }
+  }
+
+  handleActionButtonClick(e: Event, actionId: string): void {
+    const { rowActionClick } = this.context;
+    rowActionClick.emit({ actionId, row: this.row.original });
+    e.preventDefault();
+  }
+
+  handleActionButtonKeydown(e: KeyboardEvent, actionId: string): void {
+    if (e.key.toLowerCase() === 'enter') {
+      this.handleActionButtonClick(e, actionId);
+      e.preventDefault();
+    }
+  }
+
+  render(): void {
+    const { rowActions, rowsExpandable } = this.context;
+    let actionButtons: ModusTableRowAction[];
+    let overflowMenu: ModusTableRowAction[];
+
+    if (rowActions) {
+      actionButtons = rowActions.filter((action) => !action.isOverflow);
+      overflowMenu = rowActions.filter((action) => action.isOverflow);
+    }
+    return (
+      <Host>
+        {rowsExpandable && <ModusTableCellExpandIcons row={this.row} />}
+
+        {actionButtons?.map(({ icon, id, isDisabled = () => false }) => {
+          const disabled = isDisabled(this.row.original);
+          return (
+            <modus-button
+              class="row-actions"
+              button-style="borderless"
+              color="secondary"
+              icon-only={icon}
+              size="small"
+              disabled={disabled}
+              onKeyDown={(e) => this.handleActionButtonKeydown(e, id)}
+              onClick={(e) => (!disabled ? this.handleActionButtonClick(e, id) : e.preventDefault())}></modus-button>
+          );
+        })}
+
+        {overflowMenu?.length > 0 && (
+          <Fragment>
+            <modus-button
+              ref={(el) => (this.overflowButtonRef = el)}
+              class="row-actions-menu-button"
+              button-style="borderless"
+              color="secondary"
+              icon-only="vertical-ellipsis"
+              size="small"
+              onKeyDown={(e) => this.handleMoreButtonKeydown(e, overflowMenu)}
+              onClick={(e) => this.handleMoreButtonClick(e, overflowMenu)}></modus-button>
+          </Fragment>
+        )}
+      </Host>
+    );
+  }
+}

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/readme.md
@@ -1,0 +1,43 @@
+# modus-table-filler-column
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property  | Attribute | Description | Type           | Default     |
+| --------- | --------- | ----------- | -------------- | ----------- |
+| `context` | --        |             | `TableContext` | `undefined` |
+| `row`     | --        |             | `Row<unknown>` | `undefined` |
+
+
+## Events
+
+| Event                | Description | Type                                    |
+| -------------------- | ----------- | --------------------------------------- |
+| `overflowRowActions` |             | `CustomEvent<TableRowActionsMenuEvent>` |
+
+
+## Dependencies
+
+### Used by
+
+ - [modus-table-cell-main](../../../cell/modus-table-cell-main)
+
+### Depends on
+
+- [modus-button](../../../../../modus-button)
+
+### Graph
+```mermaid
+graph TD;
+  modus-table-row-actions --> modus-button
+  modus-table-cell-main --> modus-table-row-actions
+  style modus-table-row-actions fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/stencil-workspace/src/components/modus-table/parts/row/selection/modus-table-header-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/selection/modus-table-header-checkbox.tsx
@@ -2,21 +2,20 @@ import {
   FunctionalComponent,
   h, // eslint-disable-line @typescript-eslint/no-unused-vars
 } from '@stencil/core';
-import { Table } from '@tanstack/table-core';
+import TableContext from '../../../models/table-context.model';
 
 interface ModusTableHeaderCheckboxProps {
-  multipleRowSelection: boolean;
-  table: Table<unknown>;
+  context: TableContext;
 }
 
-export const ModusTableHeaderCheckbox: FunctionalComponent<ModusTableHeaderCheckboxProps> = ({
-  multipleRowSelection,
-  table,
-}) => {
-  const { getIsAllRowsSelected, getIsSomeRowsSelected, getToggleAllRowsSelectedHandler } = table;
+export const ModusTableHeaderCheckbox: FunctionalComponent<ModusTableHeaderCheckboxProps> = ({ context }) => {
+  const {
+    tableInstance: { getIsAllRowsSelected, getIsSomeRowsSelected, getToggleAllRowsSelectedHandler },
+    rowSelectionOptions,
+  } = context;
   return (
     <th class="row-checkbox sticky-left">
-      {multipleRowSelection && (
+      {rowSelectionOptions?.multiple && (
         <modus-checkbox
           ariaLabel="Select all rows"
           checked={getIsAllRowsSelected()}

--- a/stencil-workspace/src/components/modus-table/readme.md
+++ b/stencil-workspace/src/components/modus-table/readme.md
@@ -7,42 +7,44 @@
 
 ## Properties
 
-| Property               | Attribute                 | Description                                                                                   | Type                                   | Default                                                   |
-| ---------------------- | ------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------- | --------------------------------------------------------- |
-| `columnReorder`        | `column-reorder`          | (Optional) To allow column reordering.                                                        | `boolean`                              | `false`                                                   |
-| `columnResize`         | `column-resize`           |                                                                                               | `boolean`                              | `false`                                                   |
-| `columns` _(required)_ | --                        | (Required) To display headers in the table.                                                   | `ModusTableColumn<unknown, unknown>[]` | `undefined`                                               |
-| `data` _(required)_    | --                        | (Required) To display data in the table.                                                      | `unknown[]`                            | `undefined`                                               |
-| `displayOptions`       | --                        | (Optional) To control display options of table.                                               | `ModusTableDisplayOptions`             | `{     borderless: false,     cellBorderless: false,   }` |
-| `fullWidth`            | `full-width`              |                                                                                               | `boolean`                              | `false`                                                   |
-| `hover`                | `hover`                   | (Optional) To enable row hover in table.                                                      | `boolean`                              | `false`                                                   |
-| `maxHeight`            | `max-height`              | (Optional) To display a vertical scrollbar when the height is exceeded.                       | `string`                               | `undefined`                                               |
-| `maxWidth`             | `max-width`               | (Optional) To display a horizontal scrollbar when the width is exceeded.                      | `string`                               | `undefined`                                               |
-| `pageSizeList`         | --                        |                                                                                               | `number[]`                             | `PAGINATION_DEFAULT_SIZES`                                |
-| `pagination`           | `pagination`              |                                                                                               | `boolean`                              | `undefined`                                               |
-| `rowSelection`         | `row-selection`           | (Optional) To display checkbox.                                                               | `boolean`                              | `false`                                                   |
-| `rowSelectionOptions`  | --                        | (Optional) To control multiple row selection.                                                 | `ModusTableRowSelectionOptions`        | `{     multiple: false,     subRowSelection: false,   }`  |
-| `rowsExpandable`       | `rows-expandable`         | (Optional) To display expanded rows.                                                          | `boolean`                              | `false`                                                   |
-| `showSortIconOnHover`  | `show-sort-icon-on-hover` | (Optional) To display sort icon on hover.                                                     | `boolean`                              | `false`                                                   |
-| `sort`                 | `sort`                    | (Optional) To sort data in table.                                                             | `boolean`                              | `false`                                                   |
-| `summaryRow`           | `summary-row`             | (Optional) To display summary row.                                                            | `boolean`                              | `false`                                                   |
-| `toolbar`              | `toolbar`                 | (Optional) To display a toolbar for the table.                                                | `boolean`                              | `false`                                                   |
-| `toolbarOptions`       | --                        | (Optional) To display a toolbar, which allows access to table operations like hiding columns. | `ModusTableToolbarOptions`             | `null`                                                    |
+| Property               | Attribute                 | Description                                                                                                                         | Type                                   | Default                                                   |
+| ---------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- | --------------------------------------------------------- |
+| `columnReorder`        | `column-reorder`          | (Optional) To allow column reordering.                                                                                              | `boolean`                              | `false`                                                   |
+| `columnResize`         | `column-resize`           |                                                                                                                                     | `boolean`                              | `false`                                                   |
+| `columns` _(required)_ | --                        | (Required) To display headers in the table.                                                                                         | `ModusTableColumn<unknown, unknown>[]` | `undefined`                                               |
+| `data` _(required)_    | --                        | (Required) To display data in the table.                                                                                            | `unknown[]`                            | `undefined`                                               |
+| `displayOptions`       | --                        | (Optional) To control display options of table.                                                                                     | `ModusTableDisplayOptions`             | `{     borderless: false,     cellBorderless: false,   }` |
+| `fullWidth`            | `full-width`              |                                                                                                                                     | `boolean`                              | `false`                                                   |
+| `hover`                | `hover`                   | (Optional) To enable row hover in table.                                                                                            | `boolean`                              | `false`                                                   |
+| `maxHeight`            | `max-height`              | (Optional) To display a vertical scrollbar when the height is exceeded.                                                             | `string`                               | `undefined`                                               |
+| `maxWidth`             | `max-width`               | (Optional) To display a horizontal scrollbar when the width is exceeded.                                                            | `string`                               | `undefined`                                               |
+| `pageSizeList`         | --                        |                                                                                                                                     | `number[]`                             | `PAGINATION_DEFAULT_SIZES`                                |
+| `pagination`           | `pagination`              |                                                                                                                                     | `boolean`                              | `undefined`                                               |
+| `rowActions`           | --                        | (Optional) Actions that can be performed on each row. A maximum of 4 icons will be shown, including overflow menu and expand icons. | `ModusTableRowAction[]`                | `[]`                                                      |
+| `rowSelection`         | `row-selection`           | (Optional) To display checkbox.                                                                                                     | `boolean`                              | `false`                                                   |
+| `rowSelectionOptions`  | --                        | (Optional) To control multiple row selection.                                                                                       | `ModusTableRowSelectionOptions`        | `{     multiple: false,     subRowSelection: false,   }`  |
+| `rowsExpandable`       | `rows-expandable`         | (Optional) To display expanded rows.                                                                                                | `boolean`                              | `false`                                                   |
+| `showSortIconOnHover`  | `show-sort-icon-on-hover` | (Optional) To display sort icon on hover.                                                                                           | `boolean`                              | `false`                                                   |
+| `sort`                 | `sort`                    | (Optional) To sort data in table.                                                                                                   | `boolean`                              | `false`                                                   |
+| `summaryRow`           | `summary-row`             | (Optional) To display summary row.                                                                                                  | `boolean`                              | `false`                                                   |
+| `toolbar`              | `toolbar`                 | (Optional) To display a toolbar for the table.                                                                                      | `boolean`                              | `false`                                                   |
+| `toolbarOptions`       | --                        | (Optional) To display a toolbar, which allows access to table operations like hiding columns.                                       | `ModusTableToolbarOptions`             | `null`                                                    |
 
 
 ## Events
 
-| Event                    | Description                           | Type                                                |
-| ------------------------ | ------------------------------------- | --------------------------------------------------- |
-| `cellLinkClick`          | Emits the link that was clicked       | `CustomEvent<ModusTableCellLink>`                   |
-| `cellValueChange`        | Emits the cell value that was edited  | `CustomEvent<ModusTableCellValueChange>`            |
-| `columnOrderChange`      | Emits columns in the updated order    | `CustomEvent<string[]>`                             |
-| `columnSizingChange`     | Emits latest column size              | `CustomEvent<{ [x: string]: number; }>`             |
-| `columnVisibilityChange` | Emits visibility state of each column | `CustomEvent<{ [x: string]: boolean; }>`            |
-| `paginationChange`       | Emits selected page index and size    | `CustomEvent<PaginationState>`                      |
-| `rowExpanded`            | Emits expanded state of the columns   | `CustomEvent<boolean \| { [x: string]: boolean; }>` |
-| `rowSelectionChange`     | Emits rows selected                   | `CustomEvent<unknown>`                              |
-| `sortChange`             | Emits column sort order               | `CustomEvent<ColumnSort[]>`                         |
+| Event                    | Description                                       | Type                                                |
+| ------------------------ | ------------------------------------------------- | --------------------------------------------------- |
+| `cellLinkClick`          | Emits the link that was clicked                   | `CustomEvent<ModusTableCellLink>`                   |
+| `cellValueChange`        | Emits the cell value that was edited              | `CustomEvent<ModusTableCellValueChange>`            |
+| `columnOrderChange`      | Emits columns in the updated order                | `CustomEvent<string[]>`                             |
+| `columnSizingChange`     | Emits latest column size                          | `CustomEvent<{ [x: string]: number; }>`             |
+| `columnVisibilityChange` | Emits visibility state of each column             | `CustomEvent<{ [x: string]: boolean; }>`            |
+| `paginationChange`       | Emits selected page index and size                | `CustomEvent<PaginationState>`                      |
+| `rowActionClick`         | An event that fires when a row action is clicked. | `CustomEvent<ModusTableRowActionClick>`             |
+| `rowExpanded`            | Emits expanded state of the columns               | `CustomEvent<boolean \| { [x: string]: boolean; }>` |
+| `rowSelectionChange`     | Emits rows selected                               | `CustomEvent<unknown>`                              |
+| `sortChange`             | Emits column sort order                           | `CustomEvent<ColumnSort[]>`                         |
 
 
 ## Methods
@@ -83,6 +85,7 @@ Type: `Promise<void>`
 
 - [modus-table-toolbar](./parts/panel/modus-table-toolbar)
 - [modus-table-filler-column](./parts/fillerColumn)
+- [modus-table-row-actions-menu](./parts/row/actions/modus-table-row-actions-menu)
 - [modus-select](../modus-select)
 - [modus-pagination](../modus-pagination)
 - [modus-tooltip](../modus-tooltip)
@@ -94,6 +97,7 @@ Type: `Promise<void>`
 graph TD;
   modus-table --> modus-table-toolbar
   modus-table --> modus-table-filler-column
+  modus-table --> modus-table-row-actions-menu
   modus-table --> modus-select
   modus-table --> modus-pagination
   modus-table --> modus-tooltip
@@ -103,7 +107,11 @@ graph TD;
   modus-table-dropdown-menu --> modus-table-columns-visibility
   modus-table-columns-visibility --> modus-checkbox
   modus-table-columns-visibility --> modus-button
+  modus-table-row-actions-menu --> modus-list
+  modus-table-row-actions-menu --> modus-list-item
+  modus-table-cell-main --> modus-table-row-actions
   modus-table-cell-main --> modus-table-cell-editor
+  modus-table-row-actions --> modus-button
   modus-table-cell-editor --> modus-number-input
   modus-table-cell-editor --> modus-text-input
   modus-table-cell-editor --> modus-select

--- a/stencil-workspace/src/components/modus-table/utilities/table-header-drag-drop.utility.tsx
+++ b/stencil-workspace/src/components/modus-table/utilities/table-header-drag-drop.utility.tsx
@@ -1,5 +1,12 @@
 import { Table } from '@tanstack/table-core';
-import { KEYBOARD_LEFT, KEYBOARD_RIGHT, KEYBOARD_ENTER, KEYBOARD_ESCAPE, KEYBOARD_TAB } from '../modus-table.constants';
+import {
+  KEYBOARD_LEFT,
+  KEYBOARD_RIGHT,
+  KEYBOARD_ENTER,
+  KEYBOARD_ESCAPE,
+  KEYBOARD_TAB,
+  HTML_ATTR_DATA_ACCESSOR_KEY,
+} from '../modus-table.constants';
 import ColumnDragState from '../models/column-drag-state.model';
 
 export class TableHeaderDragDrop {
@@ -125,8 +132,9 @@ export class TableHeaderDragDrop {
       translation,
     };
 
-    if (node?.id && node.id !== newDragState.draggedColumnId) {
-      newDragState = { ...newDragState, dropColumnId: node.id, dropIndicator: node.getBoundingClientRect() };
+    const dropColumnId = node && node.getAttribute(HTML_ATTR_DATA_ACCESSOR_KEY);
+    if (dropColumnId && dropColumnId !== newDragState.draggedColumnId) {
+      newDragState = { ...newDragState, dropColumnId: dropColumnId, dropIndicator: node.getBoundingClientRect() };
     } else {
       newDragState = { ...newDragState, dropIndicator: null };
     }

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -926,6 +926,7 @@ modus-data-table {
 
 modus-table {
   @include modus-checkbox;
+  @include modus-list-item;
 }
 
 modus-file-dropzone {

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
@@ -21,6 +21,7 @@ import { Story } from '@storybook/addon-docs';
 - [Column Visibility](#column-visibility)
 - [Expandable Rows](#Expandable-rows)
 - [Checkbox Row Selection](#checkbox-row-selection)
+- [Row Actions](#row-actions)
 - [Inline Editing](#inline-editing)
 - [Types](#types)
 - [Accessibility](#accessibility)
@@ -125,6 +126,7 @@ This displays the highlighted row where the cursor is currently located.
 
 - Hover is disable by default, set `hover` to `true` to enable hover.
 
+<Story id="components-table--hover" height={'350px'} />
 
 ### Borderless
 
@@ -134,6 +136,7 @@ Table has two views one with border and another is borderless.
 - To eliminate the outer table border, set `borderless` to `true`.
 - Set `cellborderless` to `true` remove the innter table border i.e. for the border for cells.
 
+<Story id="components-table--borderless" height={'350px'} />
 
 ### Sorting
 
@@ -144,6 +147,7 @@ Users can arrange data in a table by sorting it in either ascending or descendin
 - When enabled, the sort icon's initial click will sort in ascending order, while its second click will sort in descending order.
 - Set `showSortIconOnHover` to `true` to enable sort on hover as well.
 
+<Story id="components-table--sorting" height={'350px'} />
 
 ### Value Formatter
 
@@ -182,6 +186,7 @@ User can take the data of a cell and apply any string-based formatting logic.
   // NOTE: One can use their own custom functions to format data as per their requirements.
 ```
 
+<Story id="components-table--value-formatter" height={'350px'} />
 
 ### Hyperlink
 
@@ -191,6 +196,7 @@ User can display hyperlink in a table column.
 - `_type: ModusTableColumnDataType.Link` is used to override the column data type in order to display a hyperlink only in a specific cell and not on the entire column.
 - As a link is an object, the default sorting is ineffective. We must pass `sortingFn:'sortForHyperlink'` along with the column information in order to sort a column with the `ModusTableCellLink` datatype or if '\_type' is used to override the datatype.
 
+<Story id="components-table--hyperlink" height={'350px'} />
 
 ### Column Resize
 
@@ -200,6 +206,7 @@ The column sizing feature allows users to dynamically change the width of all co
 - By setting `fullWidth` to true, a column can be resized with table responsiveness and other columns will be adjusted to fit within the confines of the table.
 - Optionally you can specify the width of each column using `size`, `minSize` and `maxSize` to limit the resizing of a column to a specific value.
 
+<Story id="components-table--column-resize" height={'350px'} />
 
 ```html
 <div style="width: 950px">
@@ -285,12 +292,16 @@ Users can rearrange the column headers.
 
 - Column reorder is disabled by default. The way to activate it is to set `columnReorder` to `true`.
 
+<Story id="components-table--column-reorder" height={'350px'} />
+
 ### Pagination
 
 Pagination allows users to navigate between pages
 
 - Modus Table uses `modus-pagination` component to navigate between pages.
 - Pagination can be enabled using the `pagination` prop. The `pageSizeList` takes an array for page size options.
+
+<Story id="components-table--pagination" height={'380px'} />
 
 ### Summary Row
 
@@ -300,9 +311,13 @@ User can opt for this summary row, which can be used as footer or a row to view 
 - Pass any text in `footer` property of `columns` to be display in the summary row.
 - Set `showTotal` as `true` in the `columns` array for the specific column to display the total value that column.
 
+<Story id="components-table--summary-row" height={'480px'} />
+
 ### Column Visibility
 
 A toolbar is used to perform operations like hiding/showing the columns. It is enabled by `toolbar` and is shown above the table. By setting `toolbarOptions.columnsVisibility` a meatball icon appears at the right corner, and clicking on it shows a dropdown menu with columns for selection. Additionally, users can use `slot='groupLeft'` and `slot='groupRight'` to add custom content to the toolbar.
+
+<Story id="components-table--column-visibility" height={'480px'} />
 
 ```html
 <div style="width: 950px">
@@ -355,12 +370,24 @@ User can expand rows to display as child/sub row data.
 - Expandable row is disabled by default. Set `rowsExpandable` to `true` to enable it.
 - Pass data to `subRows` property in `columns`.
 
+<Story id="components-table--expandable-rows" height={'480px'} />
+
 ### Checkbox Row Selection
 
 To select rows, users can use the checkbox provided on each row. Normally, the Modus Table permits selecting only one row at a time, but this can be modified to allow multiple selections by using `rowSelectionOptions` option.
 
   - To enable multiple row selection, set `multiple` to `true`.
   - Sub-rows will also be selected if the parent is selected by setting `subRowSelection` to `true`.
+
+<Story id="components-table--checkbox-row-selection" height={'480px'} />
+
+### Row Actions
+
+Users can add actions to rows. These actions will be shown in the first column as icons. A maximum of 4 icons will be shown, including the expand icon for expandable rows, if there more actions are provided, an overflow menu will be shown with a list of the remaining actions displayed as their label.
+
+  - To disable actions for specific rows, use the isDisabled(row) method.
+
+<Story id="components-table--row-actions" height={'480px'} />
 
 ### Inline Editing
 
@@ -386,6 +413,8 @@ Refer to the [Accessibility](#accessibility) section for how to use keyboard for
     },
   },
 ```
+
+<Story id="components-table--large-dataset" height={'480px'} />
 
 ### Types
 
@@ -467,6 +496,14 @@ interface ModusTableRowSelectionOptions {
   multiple?: boolean;
   subRowSelection?: boolean;
 }
+
+interface ModusTableRowAction {
+  id: string;
+  icon?: string;
+  label?: string;
+  index: number;
+  isDisabled?: (row: unknown) => boolean;
+}
 ```
 
 ### Accessibility
@@ -498,6 +535,7 @@ Users can use keyboard navigation to perform different actions.
 | `maxWidth`             | `max-width`               | (Optional) To display a horizontal scrollbar when the width is exceeded.                      | `string`                               | `undefined`                                               |
 | `pageSizeList`         | --                        |                                                                                               | `number[]`                             | `PAGINATION_DEFAULT_SIZES`                                |
 | `pagination`           | `pagination`              |                                                                                               | `boolean`                              | `undefined`                                               |
+| `rowSelection`         | `row-actions`             | (Optional) To display row actions.                                                            | `ModusTableRowAction[]`                | `[]`                                                      |
 | `rowSelection`         | `row-selection`           | (Optional) To display checkbox.                                                               | `boolean`                              | `false`                                                   |
 | `rowSelectionOptions`  | --                        | (Optional) To control multiple row selection.                                                 | `ModusTableRowSelectionOptions`        | `{     multiple: false,     subRowSelection: false,   }`  |
 | `rowsExpandable`       | `rows-expandable`         | (Optional) To display expanded rows.                                                          | `boolean`                              | `false`                                                   |
@@ -517,10 +555,10 @@ Users can use keyboard navigation to perform different actions.
 | `columnSizingChange`     | Emits latest column size              | `CustomEvent<{ [x: string]: number; }>`             |
 | `columnVisibilityChange` | Emits visibility state of each column | `CustomEvent<{ [x: string]: boolean; }>`            |
 | `paginationChange`       | Emits selected page index and size    | `CustomEvent<PaginationState>`                      |
+| `rowActionClick`         | Emits the clicked action id and row   | `CustomEvent<{ actionId: string; row: unknown; }>`  |
 | `rowExpanded`            | Emits expanded state of the columns   | `CustomEvent<boolean \| { [x: string]: boolean; }>` |
 | `rowSelectionChange`     | Emits rows selected                   | `CustomEvent<unknown>`                              |
 | `sortChange`             | Emits column sort order               | `CustomEvent<ColumnSort[]>`                         |
-
 
 ### Slot
 
@@ -543,7 +581,6 @@ Users can use this to provide custom elements.
 
 There are still additional features that we plan to implement. Some of them:
 
-- Row Actions
 - Column Filtering
 - Save Filter Preferences
 

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
@@ -47,7 +47,7 @@ function makeData(...lens): object[] {
   return makeDataLevel();
 }
 
-function initializeTable(columns, data, pageSizeList, toolbarOptions, displayOptions, rowSelectionOptions) {
+function initializeTable(columns, data, pageSizeList, toolbarOptions, displayOptions, rowSelectionOptions, rowActions) {
   const tag = document.createElement('script');
   tag.innerHTML = `
   document.querySelector('modus-table').columns = ${JSON.stringify(columns)};
@@ -56,6 +56,7 @@ function initializeTable(columns, data, pageSizeList, toolbarOptions, displayOpt
   document.querySelector('modus-table').toolbarOptions = ${JSON.stringify(toolbarOptions)};
   document.querySelector('modus-table').displayOptions = ${JSON.stringify(displayOptions)};
   document.querySelector('modus-table').rowSelectionOptions = ${JSON.stringify(rowSelectionOptions)};
+  document.querySelector('modus-table').rowActions = ${JSON.stringify(rowActions)};
   `;
 
   return tag;
@@ -168,6 +169,7 @@ const DefaultArgs = {
   rowsExpandable: false,
   maxHeight: '',
   maxWidth: '',
+  rowActions: [],
   rowSelection: false,
   rowSelectionOptions: {},
 };
@@ -309,6 +311,14 @@ export default {
       },
       type: { required: false },
     },
+    rowActions: {
+      name: 'rowActions',
+      description: 'Control row actions.',
+      table: {
+        type: { summary: 'ModusTableRowAction[]' },
+      },
+      type: { required: false },
+    },
     maxHeight: {
       name: 'maxHeight',
       description: 'To display a vertical scrollbar when the height is exceeded.',
@@ -349,7 +359,7 @@ export default {
 
   parameters: {
     actions: {
-      handles: ['cellValueChange','cellLinkClick', 'columnOrderChange', 'columnSizingChange', 'columnVisibilityChange', 'paginationChange', 'rowExpanded', 'rowSelectionChange', 'rowUpdated', 'sortChange'],
+      handles: ['cellValueChange','cellLinkClick', 'columnOrderChange', 'columnSizingChange', 'columnVisibilityChange', 'paginationChange', 'rowExpanded', 'rowSelectionChange', 'rowUpdated', 'sortChange', 'rowActionClick'],
     },
     controls: { expanded: true, sort: 'requiredFirst' },
     docs: {
@@ -381,6 +391,7 @@ const Template = ({
   rowsExpandable,
   maxHeight,
   maxWidth,
+  rowActions,
   rowSelection,
   rowSelectionOptions
 }) => html`
@@ -400,7 +411,7 @@ const Template = ({
       max-width="${maxWidth}"
       row-selection="${rowSelection}" />
   </div>
-  ${initializeTable(columns, data, pageSizeList, toolbarOptions, displayOptions, rowSelectionOptions)}
+  ${initializeTable(columns, data, pageSizeList, toolbarOptions, displayOptions, rowSelectionOptions, rowActions)}
 `;
 
 export const Default = Template.bind({});
@@ -526,9 +537,8 @@ CheckboxRowSelection.args = {
   }, data: makeData(7)
 };
 
-const editableColumns =DefaultColumns.map(col =>{
+const EditableColumns =DefaultColumns.map(col =>{
   if(col.dataType === 'link') return col;
-
   if(col.accessorKey === 'status'){
     return {...col,  cellEditable:true,
       cellEditorType: 'dropdown',
@@ -542,13 +552,12 @@ const editableColumns =DefaultColumns.map(col =>{
   }
   else return {...col, cellEditable: true};
 });
-
 export const InlineEditing = Template.bind({});
-InlineEditing.args = { ...DefaultArgs, columns: editableColumns, data: makeData(7) };
+InlineEditing.args = { ...DefaultArgs, columns: EditableColumns, data: makeData(7) };
 
 export const LargeDataset = Template.bind({});
 
-LargeDataset.args = { ...DefaultArgs, columns: editableColumns, data: makeData(10000, 1,1 ),pagination: true, pageSizeList: [5, 10, 50], sort: true , hover: true, rowsExpandable: true, summaryRow: true , columnReorder:true, columnResize: true, toolbar:true,  toolbarOptions: {
+LargeDataset.args = { ...DefaultArgs, columns: EditableColumns, data: makeData(10000, 1,1 ),pagination: true, pageSizeList: [5, 10, 50], sort: true , hover: true, rowsExpandable: true, summaryRow: true , columnReorder:true, columnResize: true, toolbar:true,  toolbarOptions: {
   columnsVisibility: {
     title: '',
     requiredColumns: ['age', 'visits'],
@@ -558,4 +567,37 @@ rowSelection: true, rowSelectionOptions: {
   multiple: true,
   subRowSelection: true
 }
+};
+
+export const RowActions = Template.bind({});
+RowActions.args = {
+  ...DefaultArgs, rowActions:[
+    {
+      id: '1',
+      icon: 'add',
+      label: 'Add',
+      index: 0,
+    },
+
+    {
+      id: '2',
+      icon: 'calendar',
+      label: 'calendar',
+      index: 1,
+    },
+
+    {
+      id: '3',
+      icon: 'cancel',
+      label: 'Cancel',
+      index: 2,
+    },
+
+    {
+      id: '4',
+      index: 3,
+      icon: 'delete',
+      label: 'Delete',
+    }
+  ], data: makeData(7), fullWidth: true
 };


### PR DESCRIPTION
## Description

- Added custom row actions to the Modus Table configuration with keyboard navigation.
- Up to four icons (including expandable and overflow icons) can be displayed for unlimited row actions.
- Enabled Keyboard navigation on Modus List component
- Refactored code to allow all child components to obtain details from a single context object.

References https://github.com/trimble-oss/modus-web-components/issues/1729

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Storybook page

Go to preview and edit the rowActions control to add/remove row actions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
