### PR TITLE
Modus Table - Add row actions

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1317,6 +1317,28 @@ export declare interface ModusTableRowActions extends Components.ModusTableRowAc
 
 
 @ProxyCmp({
+  inputs: ['context', 'row']
+})
+@Component({
+  selector: 'modus-table-row-actions-cell',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['context', 'row'],
+})
+export class ModusTableRowActionsCell {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface ModusTableRowActionsCell extends Components.ModusTableRowActionsCell {}
+
+
+@ProxyCmp({
   inputs: ['context']
 })
 @Component({

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1201,14 +1201,14 @@ export declare interface ModusTableCellEditor extends Components.ModusTableCellE
 
 
 @ProxyCmp({
-  inputs: ['cell', 'context', 'hasRowActions', 'valueChange']
+  inputs: ['cell', 'context', 'hasRowsExpandable', 'valueChange']
 })
 @Component({
   selector: 'modus-table-cell-main',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['cell', 'context', 'hasRowActions', 'valueChange'],
+  inputs: ['cell', 'context', 'hasRowsExpandable', 'valueChange'],
 })
 export class ModusTableCellMain {
   protected el: HTMLElement;

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
@@ -46,6 +46,7 @@ export const DIRECTIVES = [
   d.ModusTableDropdownMenu,
   d.ModusTableFillerColumn,
   d.ModusTableRowActions,
+  d.ModusTableRowActionsCell,
   d.ModusTableRowActionsMenu,
   d.ModusTableToolbar,
   d.ModusTabs,

--- a/react-workspace/react-17/src/components/stencil-generated/index.ts
+++ b/react-workspace/react-17/src/components/stencil-generated/index.ts
@@ -52,6 +52,7 @@ export const ModusTableColumnsVisibility = /*@__PURE__*/createReactComponent<JSX
 export const ModusTableDropdownMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableDropdownMenu, HTMLModusTableDropdownMenuElement>('modus-table-dropdown-menu');
 export const ModusTableFillerColumn = /*@__PURE__*/createReactComponent<JSX.ModusTableFillerColumn, HTMLModusTableFillerColumnElement>('modus-table-filler-column');
 export const ModusTableRowActions = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActions, HTMLModusTableRowActionsElement>('modus-table-row-actions');
+export const ModusTableRowActionsCell = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsCell, HTMLModusTableRowActionsCellElement>('modus-table-row-actions-cell');
 export const ModusTableRowActionsMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsMenu, HTMLModusTableRowActionsMenuElement>('modus-table-row-actions-menu');
 export const ModusTableToolbar = /*@__PURE__*/createReactComponent<JSX.ModusTableToolbar, HTMLModusTableToolbarElement>('modus-table-toolbar');
 export const ModusTabs = /*@__PURE__*/createReactComponent<JSX.ModusTabs, HTMLModusTabsElement>('modus-tabs');

--- a/react-workspace/react-18/src/components/stencil-generated/index.ts
+++ b/react-workspace/react-18/src/components/stencil-generated/index.ts
@@ -52,6 +52,7 @@ export const ModusTableColumnsVisibility = /*@__PURE__*/createReactComponent<JSX
 export const ModusTableDropdownMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableDropdownMenu, HTMLModusTableDropdownMenuElement>('modus-table-dropdown-menu');
 export const ModusTableFillerColumn = /*@__PURE__*/createReactComponent<JSX.ModusTableFillerColumn, HTMLModusTableFillerColumnElement>('modus-table-filler-column');
 export const ModusTableRowActions = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActions, HTMLModusTableRowActionsElement>('modus-table-row-actions');
+export const ModusTableRowActionsCell = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsCell, HTMLModusTableRowActionsCellElement>('modus-table-row-actions-cell');
 export const ModusTableRowActionsMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsMenu, HTMLModusTableRowActionsMenuElement>('modus-table-row-actions-menu');
 export const ModusTableToolbar = /*@__PURE__*/createReactComponent<JSX.ModusTableToolbar, HTMLModusTableToolbarElement>('modus-table-toolbar');
 export const ModusTabs = /*@__PURE__*/createReactComponent<JSX.ModusTabs, HTMLModusTabsElement>('modus-tabs');

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1092,7 +1092,7 @@ export namespace Components {
     interface ModusTableCellMain {
         "cell": Cell<unknown, unknown>;
         "context": TableContext;
-        "hasRowActions": boolean;
+        "hasRowsExpandable": boolean;
         "valueChange": (props: TableCellEdited) => void;
     }
     interface ModusTableColumnsVisibility {
@@ -3169,7 +3169,7 @@ declare namespace LocalJSX {
     interface ModusTableCellMain {
         "cell"?: Cell<unknown, unknown>;
         "context"?: TableContext;
-        "hasRowActions"?: boolean;
+        "hasRowsExpandable"?: boolean;
         "valueChange"?: (props: TableCellEdited) => void;
     }
     interface ModusTableColumnsVisibility {

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1123,6 +1123,10 @@ export namespace Components {
         "context": TableContext;
         "row": Row<unknown>;
     }
+    interface ModusTableRowActionsCell {
+        "context": TableContext;
+        "row": Row<unknown>;
+    }
     interface ModusTableRowActionsMenu {
         "context": TableContext;
     }
@@ -1816,6 +1820,12 @@ declare global {
         prototype: HTMLModusTableRowActionsElement;
         new (): HTMLModusTableRowActionsElement;
     };
+    interface HTMLModusTableRowActionsCellElement extends Components.ModusTableRowActionsCell, HTMLStencilElement {
+    }
+    var HTMLModusTableRowActionsCellElement: {
+        prototype: HTMLModusTableRowActionsCellElement;
+        new (): HTMLModusTableRowActionsCellElement;
+    };
     interface HTMLModusTableRowActionsMenuElement extends Components.ModusTableRowActionsMenu, HTMLStencilElement {
     }
     var HTMLModusTableRowActionsMenuElement: {
@@ -1915,6 +1925,7 @@ declare global {
         "modus-table-dropdown-menu": HTMLModusTableDropdownMenuElement;
         "modus-table-filler-column": HTMLModusTableFillerColumnElement;
         "modus-table-row-actions": HTMLModusTableRowActionsElement;
+        "modus-table-row-actions-cell": HTMLModusTableRowActionsCellElement;
         "modus-table-row-actions-menu": HTMLModusTableRowActionsMenuElement;
         "modus-table-toolbar": HTMLModusTableToolbarElement;
         "modus-tabs": HTMLModusTabsElement;
@@ -3201,6 +3212,10 @@ declare namespace LocalJSX {
         "onOverflowRowActions"?: (event: ModusTableRowActionsCustomEvent<TableRowActionsMenuEvent>) => void;
         "row"?: Row<unknown>;
     }
+    interface ModusTableRowActionsCell {
+        "context"?: TableContext;
+        "row"?: Row<unknown>;
+    }
     interface ModusTableRowActionsMenu {
         "context"?: TableContext;
     }
@@ -3553,6 +3568,7 @@ declare namespace LocalJSX {
         "modus-table-dropdown-menu": ModusTableDropdownMenu;
         "modus-table-filler-column": ModusTableFillerColumn;
         "modus-table-row-actions": ModusTableRowActions;
+        "modus-table-row-actions-cell": ModusTableRowActionsCell;
         "modus-table-row-actions-menu": ModusTableRowActionsMenu;
         "modus-table-toolbar": ModusTableToolbar;
         "modus-tabs": ModusTabs;
@@ -3615,6 +3631,7 @@ declare module "@stencil/core" {
              */
             "modus-table-filler-column": LocalJSX.ModusTableFillerColumn & JSXBase.HTMLAttributes<HTMLModusTableFillerColumnElement>;
             "modus-table-row-actions": LocalJSX.ModusTableRowActions & JSXBase.HTMLAttributes<HTMLModusTableRowActionsElement>;
+            "modus-table-row-actions-cell": LocalJSX.ModusTableRowActionsCell & JSXBase.HTMLAttributes<HTMLModusTableRowActionsCellElement>;
             "modus-table-row-actions-menu": LocalJSX.ModusTableRowActionsMenu & JSXBase.HTMLAttributes<HTMLModusTableRowActionsMenuElement>;
             "modus-table-toolbar": LocalJSX.ModusTableToolbar & JSXBase.HTMLAttributes<HTMLModusTableToolbarElement>;
             "modus-tabs": LocalJSX.ModusTabs & JSXBase.HTMLAttributes<HTMLModusTabsElement>;

--- a/stencil-workspace/src/components/modus-table/models/table-context.model.ts
+++ b/stencil-workspace/src/components/modus-table/models/table-context.model.ts
@@ -111,7 +111,6 @@ export default interface TableContext {
   onColumnResizeChange: (newVal: boolean) => void;
   onColumnReorderChange: () => void;
   onDataChange: (newVal: unknown[]) => void;
-  onRowActionsChange: (newVal: ModusTableRowAction[]) => void;
   onRowsExpandableChange: (newVal: boolean) => void;
   onRowSelectionOptionsChange: (newVal: ModusTableRowSelectionOptions, oldVal: ModusTableRowSelectionOptions) => void;
   onSortChange: (newVal) => void;

--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -335,6 +335,13 @@ table {
       }
     }
   }
+
+  .sticky-right {
+    border-left: $rem-2px $modus-table-border-color solid;
+    position: sticky;
+    right: 0;
+    z-index: 1;
+  }
 }
 
 modus-table-filler-column {

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -130,11 +130,6 @@ export class ModusTable {
 
   /** (Optional) Actions that can be performed on each row. A maximum of 4 icons will be shown, including overflow menu and expand icons. */
   @Prop() rowActions: ModusTableRowAction[] = [];
-  @Watch('rowActions') onRowActionsChange(newVal: ModusTableRowAction[]) {
-    if (newVal?.length > 0) {
-      this.freezeColumn(this.tableState.columnOrder[0]);
-    }
-  }
 
   /** (Optional) To display expanded rows. */
   @Prop() rowsExpandable = false;
@@ -182,7 +177,6 @@ export class ModusTable {
   @Watch('toolbarOptions') onToolbarOptionsChange(newVal: ModusTableToolbarOptions | null) {
     this.tableCore?.setOptions('enableHiding', !!newVal?.columnsVisibility);
     this.onRowsExpandableChange(this.rowsExpandable);
-    this.onRowActionsChange(this.rowActions);
   }
 
   /** Emits the cell value that was edited */
@@ -261,7 +255,6 @@ export class ModusTable {
     this._id = this.element.id || `modus-table-${createGuid()}`;
     this.setTableState({ columnOrder: this.columns?.map((column) => column.id as string) });
     this.onRowsExpandableChange(this.rowsExpandable);
-    this.onRowActionsChange(this.rowActions);
     this.initializeTable();
   }
 
@@ -386,7 +379,6 @@ export class ModusTable {
       onColumnResizeChange: this.onColumnResizeChange,
       onColumnReorderChange: this.onColumnReorderChange,
       onDataChange: this.onDataChange,
-      onRowActionsChange: this.onRowActionsChange,
       onRowsExpandableChange: this.onRowsExpandableChange,
       onRowSelectionOptionsChange: this.onRowSelectionOptionsChange,
       onSortChange: this.onSortChange,

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -334,7 +334,7 @@ export class ModusTable {
   getRowActionsWithOverflow(): TableRowActionWithOverflow[] {
     if (this.rowActions) {
       const sortedActions = this.rowActions.sort((a, b) => a.index - b.index);
-      const visibleLimit = this.rowsExpandable ? 2 : 3;
+      const visibleLimit = sortedActions.length < 5 ? 4 : 3;
       const actionButtons = sortedActions.slice(0, visibleLimit);
       const overflowMenu = sortedActions.slice(visibleLimit).map((action) => ({ ...action, isOverflow: true }));
 

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -25,6 +25,7 @@ import NavigateTableCells from '../../../utilities/table-cell-navigation.utility
 import { CellFormatter } from '../../../utilities/table-cell-formatter.utility';
 import { ModusTableCellLinkElement } from '../modus-table-cell-link-element';
 import TableContext, { TableCellEdited } from '../../../models/table-context.model';
+import ModusTableCellExpandIcons from '../modus-table-cell-expand-icons';
 
 @Component({
   tag: 'modus-table-cell-main',
@@ -33,7 +34,7 @@ export class ModusTableCellMain {
   @Element() el: HTMLElement;
   @Prop() cell: Cell<unknown, unknown>;
   @Prop() context: TableContext;
-  @Prop() hasRowActions: boolean;
+  @Prop() hasRowsExpandable: boolean;
   @Prop() valueChange: (props: TableCellEdited) => void;
 
   @State() editMode: boolean;
@@ -160,7 +161,7 @@ export class ModusTableCellMain {
 
     return (
       <div class={classes}>
-        {this.hasRowActions && <modus-table-row-actions context={this.context} row={row}></modus-table-row-actions>}
+        {this.hasRowsExpandable && <ModusTableCellExpandIcons row={row} />}
 
         <span class="wrap-text">
           {cellDataType === COLUMN_DEF_DATATYPE_LINK ? (

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property        | Attribute         | Description | Type                               | Default     |
-| --------------- | ----------------- | ----------- | ---------------------------------- | ----------- |
-| `cell`          | --                |             | `Cell<unknown, unknown>`           | `undefined` |
-| `context`       | --                |             | `TableContext`                     | `undefined` |
-| `hasRowActions` | `has-row-actions` |             | `boolean`                          | `undefined` |
-| `valueChange`   | --                |             | `(props: TableCellEdited) => void` | `undefined` |
+| Property            | Attribute             | Description | Type                               | Default     |
+| ------------------- | --------------------- | ----------- | ---------------------------------- | ----------- |
+| `cell`              | --                    |             | `Cell<unknown, unknown>`           | `undefined` |
+| `context`           | --                    |             | `TableContext`                     | `undefined` |
+| `hasRowsExpandable` | `has-rows-expandable` |             | `boolean`                          | `undefined` |
+| `valueChange`       | --                    |             | `(props: TableCellEdited) => void` | `undefined` |
 
 
 ## Dependencies
@@ -23,15 +23,12 @@
 
 ### Depends on
 
-- [modus-table-row-actions](../../row/actions/modus-table-row-actions)
 - [modus-table-cell-editor](../modus-table-cell-editor)
 
 ### Graph
 ```mermaid
 graph TD;
-  modus-table-cell-main --> modus-table-row-actions
   modus-table-cell-main --> modus-table-cell-editor
-  modus-table-row-actions --> modus-button
   modus-table-cell-editor --> modus-number-input
   modus-table-cell-editor --> modus-text-input
   modus-table-cell-editor --> modus-select

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell.tsx
@@ -13,21 +13,21 @@ interface ModusTableCellProps {
 }
 
 export const ModusTableCell: FunctionalComponent<ModusTableCellProps> = ({ cell, cellIndex, context, valueChange }) => {
-  const { rowsExpandable, rowActions } = context;
-  const hasRowActions = cellIndex === 0 && (rowsExpandable || rowActions?.length > 0);
+  const { rowsExpandable, frozenColumns } = context;
+  const hasRowsExpandable = cellIndex === 0 && rowsExpandable;
   const { id } = cell;
   return (
     <td
       key={id}
       tabindex={0}
       class={`
-      ${hasRowActions ? 'sticky-left' : ''}
+      ${hasRowsExpandable || frozenColumns.includes(cell.column.id) ? 'sticky-left' : ''}
       ${cell.column.getIsResizing() ? 'active-resize' : ''}
   `}
       style={{ width: `${cell.column.getSize()}px` }}>
       <modus-table-cell-main
         cell={cell}
-        hasRowActions={hasRowActions}
+        hasRowsExpandable={hasRowsExpandable}
         context={context}
         valueChange={valueChange}></modus-table-cell-main>
     </td>

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
@@ -13,7 +13,8 @@ interface ModusTableBodyProps {
 }
 
 export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({ context }) => {
-  const { hover, rowSelection, rowSelectionOptions, tableInstance: table, updateData } = context;
+  const { hover, rowSelection, rowSelectionOptions, rowActions, tableInstance: table, updateData } = context;
+  const hasRowActions = rowActions?.length > 0;
   const multipleRowSelection = rowSelectionOptions?.multiple;
 
   // Note: This function supports only 3 levels of nested rows.
@@ -60,6 +61,11 @@ export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({ conte
                 <ModusTableCell cell={cell} cellIndex={cellIndex} context={context} valueChange={handleCellValueChange} />
               );
             })}
+            {hasRowActions && (
+              <td class="sticky-right">
+                <modus-table-row-actions row={row} context={context} />
+              </td>
+            )}
           </tr>
         );
       })}

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-body.tsx
@@ -62,8 +62,9 @@ export const ModusTableBody: FunctionalComponent<ModusTableBodyProps> = ({ conte
               );
             })}
             {hasRowActions && (
-              <td class="sticky-right">
-                <modus-table-row-actions row={row} context={context} />
+              <td class="sticky-right" tabindex="0">
+                {/* <modus-table-row-actions row={row} context={context} /> */}
+                <modus-table-row-actions-cell row={row} context={context} />
               </td>
             )}
           </tr>

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-footer.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-footer.tsx
@@ -27,6 +27,7 @@ export const ModusTableFooter: FunctionalComponent<ModusTableSummaryRowProps> = 
     data,
     rowSelection,
     frozenColumns,
+    rowActions,
   },
 }) => {
   return (
@@ -47,6 +48,7 @@ export const ModusTableFooter: FunctionalComponent<ModusTableSummaryRowProps> = 
               {header.column.columnDef[COLUMN_DEF_SHOWTOTAL] ? calculateTotal(data, header) : header.column.columnDef.footer}
             </td>
           ))}
+          {rowActions.length > 0 && <td></td>}
         </tr>
       ))}
     </tfoot>

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-header.tsx
@@ -30,10 +30,12 @@ export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
     columnReorder,
     rowSelection,
     componentId,
+    rowActions,
   } = context;
 
   const tableHeadClass = { 'show-resize-cursor': getColumnResizing(), 'show-column-reorder-cursor': columnReorder };
   const headerGroups: HeaderGroup<unknown>[] = getHeaderGroups();
+  const rowActionsLength = Math.min(Math.max(rowActions.length * 40, 90), 160);
 
   return (
     <thead class={tableHeadClass}>
@@ -54,6 +56,11 @@ export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
               />
             );
           })}
+          {rowActions.length > 0 && (
+            <th class="sticky-right" style={{ width: `${rowActionsLength}px` }}>
+              Actions
+            </th>
+          )}
         </tr>
       ))}
     </thead>

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions-menu/modus-table-row-actions-menu.tsx
@@ -47,7 +47,7 @@ export class ModusTableRowActionsMenu {
   private onRowActionClick: (event: CustomEvent<ModusTableRowActionClick>) => void = (e) =>
     this.handleRowActionButtonClick(e);
   private onRowExpanded: (event: CustomEvent) => void = () => (this.isMenuOpen = false);
-  
+
   componentDidRender(): void {
     if (this.isMenuOpen) {
       const firstItem = Array.from(this.element.querySelectorAll('modus-list-item'))?.find(

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions-cell.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions-cell.tsx
@@ -1,0 +1,51 @@
+import { Component, Element, Host, Prop, h } from '@stencil/core';
+import { Row } from '@tanstack/table-core';
+import NavigateTableCells from '../../../../utilities/table-cell-navigation.utility';
+import { KEYBOARD_ENTER } from '../../../../modus-table.constants';
+import TableContext from '../../../../models/table-context.model';
+
+@Component({
+  tag: 'modus-table-row-actions-cell',
+})
+export class ModusTableRowActionsCell {
+  @Element() el: HTMLElement;
+  @Prop() row: Row<unknown>;
+  @Prop() context: TableContext;
+
+  private cellEl: HTMLElement;
+
+  private onCellKeyDown: (e: KeyboardEvent) => void = (e: KeyboardEvent) => this.handleCellKeydown(e);
+  connectedCallback() {
+    this.cellEl = this.el.parentElement;
+    this.cellEl.addEventListener('keydown', this.onCellKeyDown);
+  }
+
+  disconnectedCallback() {
+    if (this.cellEl) {
+      this.cellEl.removeEventListener('keydown', this.onCellKeyDown);
+    }
+  }
+  handleCellKeydown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return;
+
+    const key = event.key?.toLowerCase();
+
+    if (key === KEYBOARD_ENTER) {
+      (this.el.firstChild?.firstChild as HTMLModusButtonElement)?.focusButton();
+      event.stopPropagation();
+    } else {
+      NavigateTableCells({
+        eventKey: event.key,
+        cellElement: this.cellEl,
+      });
+    }
+  };
+
+  render(): void {
+    return (
+      <Host>
+        <modus-table-row-actions row={this.row} context={this.context} />
+      </Host>
+    );
+  }
+}

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.scss
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.scss
@@ -2,5 +2,5 @@ modus-table-row-actions {
   align-items: center;
   display: flex;
   gap: 8px;
-  margin-right: 8px;
+  justify-content: center;
 }

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/modus-table-row-actions.tsx
@@ -10,7 +10,6 @@ import {
 import { Row } from '@tanstack/table-core';
 import { ModusTableRowAction } from '../../../../models/modus-table.models';
 import TableContext, { TableRowActionsMenuEvent } from '../../../../models/table-context.model';
-import ModusTableCellExpandIcons from '../../../cell/modus-table-cell-expand-icons';
 
 @Component({
   tag: 'modus-table-row-actions',
@@ -58,7 +57,7 @@ export class ModusTableRowActions {
   }
 
   render(): void {
-    const { rowActions, rowsExpandable } = this.context;
+    const { rowActions } = this.context;
     let actionButtons: ModusTableRowAction[];
     let overflowMenu: ModusTableRowAction[];
 
@@ -68,8 +67,6 @@ export class ModusTableRowActions {
     }
     return (
       <Host>
-        {rowsExpandable && <ModusTableCellExpandIcons row={this.row} />}
-
         {actionButtons?.map(({ label, icon, id, isDisabled = () => false }) => {
           const disabled = isDisabled(this.row.original);
           return (

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/readme.md
@@ -13,13 +13,6 @@
 | `row`     | --        |             | `Row<unknown>` | `undefined` |
 
 
-## Events
-
-| Event                | Description | Type                                    |
-| -------------------- | ----------- | --------------------------------------- |
-| `overflowRowActions` |             | `CustomEvent<TableRowActionsMenuEvent>` |
-
-
 ## Dependencies
 
 ### Used by
@@ -28,14 +21,15 @@
 
 ### Depends on
 
-- [modus-button](../../../../../modus-button)
+- [modus-table-row-actions](.)
 
 ### Graph
 ```mermaid
 graph TD;
+  modus-table-row-actions-cell --> modus-table-row-actions
   modus-table-row-actions --> modus-button
-  modus-table --> modus-table-row-actions
-  style modus-table-row-actions fill:#f9f,stroke:#333,stroke-width:4px
+  modus-table --> modus-table-row-actions-cell
+  style modus-table-row-actions-cell fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/row/actions/modus-table-row-actions/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [modus-table-cell-main](../../../cell/modus-table-cell-main)
+ - [modus-table](../../../..)
 
 ### Depends on
 
@@ -34,7 +34,7 @@
 ```mermaid
 graph TD;
   modus-table-row-actions --> modus-button
-  modus-table-cell-main --> modus-table-row-actions
+  modus-table --> modus-table-row-actions
   style modus-table-row-actions fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/stencil-workspace/src/components/modus-table/readme.md
+++ b/stencil-workspace/src/components/modus-table/readme.md
@@ -90,6 +90,7 @@ Type: `Promise<void>`
 - [modus-pagination](../modus-pagination)
 - [modus-tooltip](../modus-tooltip)
 - [modus-checkbox](../modus-checkbox)
+- [modus-table-row-actions](./parts/row/actions/modus-table-row-actions)
 - [modus-table-cell-main](./parts/cell/modus-table-cell-main)
 
 ### Graph
@@ -102,6 +103,7 @@ graph TD;
   modus-table --> modus-pagination
   modus-table --> modus-tooltip
   modus-table --> modus-checkbox
+  modus-table --> modus-table-row-actions
   modus-table --> modus-table-cell-main
   modus-table-toolbar --> modus-table-dropdown-menu
   modus-table-dropdown-menu --> modus-table-columns-visibility
@@ -109,9 +111,8 @@ graph TD;
   modus-table-columns-visibility --> modus-button
   modus-table-row-actions-menu --> modus-list
   modus-table-row-actions-menu --> modus-list-item
-  modus-table-cell-main --> modus-table-row-actions
-  modus-table-cell-main --> modus-table-cell-editor
   modus-table-row-actions --> modus-button
+  modus-table-cell-main --> modus-table-cell-editor
   modus-table-cell-editor --> modus-number-input
   modus-table-cell-editor --> modus-text-input
   modus-table-cell-editor --> modus-select

--- a/stencil-workspace/src/components/modus-table/readme.md
+++ b/stencil-workspace/src/components/modus-table/readme.md
@@ -90,7 +90,7 @@ Type: `Promise<void>`
 - [modus-pagination](../modus-pagination)
 - [modus-tooltip](../modus-tooltip)
 - [modus-checkbox](../modus-checkbox)
-- [modus-table-row-actions](./parts/row/actions/modus-table-row-actions)
+- [modus-table-row-actions-cell](./parts/row/actions/modus-table-row-actions)
 - [modus-table-cell-main](./parts/cell/modus-table-cell-main)
 
 ### Graph
@@ -103,7 +103,7 @@ graph TD;
   modus-table --> modus-pagination
   modus-table --> modus-tooltip
   modus-table --> modus-checkbox
-  modus-table --> modus-table-row-actions
+  modus-table --> modus-table-row-actions-cell
   modus-table --> modus-table-cell-main
   modus-table-toolbar --> modus-table-dropdown-menu
   modus-table-dropdown-menu --> modus-table-columns-visibility
@@ -111,6 +111,7 @@ graph TD;
   modus-table-columns-visibility --> modus-button
   modus-table-row-actions-menu --> modus-list
   modus-table-row-actions-menu --> modus-list-item
+  modus-table-row-actions-cell --> modus-table-row-actions
   modus-table-row-actions --> modus-button
   modus-table-cell-main --> modus-table-cell-editor
   modus-table-cell-editor --> modus-number-input

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -16,6 +16,231 @@
   </head>
 
   <body>
-    <!-- Test components -->
+    <modus-table>
+    </modus-table>
+
+    <script>
+
+function range(len) {
+  const arr = [];
+  for (let i = 0; i < len; i++) {
+    arr.push(i);
+  }
+  return arr;
+}
+
+function randomNumber(min, max) {
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+function newPerson() {
+  const namesIndex = randomNumber(0, 17);
+  const firstName = Names[namesIndex].split(' ')[0];
+  const lastName = Names[namesIndex].split(' ')[1];
+  const email= `${firstName}${lastName}@example.com`.toLowerCase();
+  return {
+    firstName,
+    lastName,
+    age: randomNumber(20, 80) * 30,
+    visits: randomNumber(1, 100) * 100,
+    email:{ display: email, url: email },
+    progress: randomNumber(1, 100) * 100,
+    status: randomNumber(1, 100) > 66 ? 'Verified' : randomNumber(0, 100) > 33 ? 'Pending' : 'Rejected',
+    createdAt: new Date(randomNumber(1990, 2020), randomNumber(0, 11), randomNumber(1, 30)).toDateString(),
+  };
+}
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+function makeData(...lens) {
+  const makeDataLevel = (depth = 0) => {
+    const len = lens[depth];
+    return range(len).map(() => {
+      return {
+        ...newPerson(),
+        subRows: lens[depth + 1] ? makeDataLevel(depth + 1) : undefined,
+      };
+    });
+  };
+
+  return makeDataLevel();
+}
+
+const Names = [
+  'Mickey Mouse',
+  'Bugs Bunny',
+  'Homer Simpson',
+  'Fred Flintstone',
+  'Sponge Bob',
+  'Daffy Duck',
+  'Charlie Brown',
+  'Scooby Doo',
+  'Tom Cat',
+  'Jerry Mouse',
+  'Mighty Mouse',
+  'Wile E Coyote',
+  'Tweety Bird',
+  'Pink Panther',
+  'Road Runner',
+  'Patrick Star',
+  'Roger Rabbit',
+  'Papa Smurf',
+  'Buzz Lightyear',
+];
+const DefaultColumns = [
+  {
+    header: 'First Name',
+    accessorKey: 'firstName',
+    id: 'first-name',
+    dataType: 'text',
+    size: 250,
+    // minSize: 150,
+    footer: 'Total',
+    cellEditable:true,
+  },
+  {
+    header: 'Last Name',
+    accessorKey: 'lastName',
+    id: 'last-name',
+    dataType: 'text',
+    size: 150,
+    minSize: 80,
+    cellEditable:true,
+  },
+  {
+    header: 'Age',
+    accessorKey: 'age',
+    id: 'age',
+    dataType: 'integer',
+    size: 80,
+    minSize: 60,
+    cellEditable:true,
+  },
+  {
+    header: 'Visits',
+    accessorKey: 'visits',
+    id: 'visits',
+    dataType: 'integer',
+    maxSize: 80,
+    showTotal: true,
+    minSize: 80,
+    cellEditable:true,
+  },
+  {
+    header: 'Email',
+    accessorKey: 'email',
+    id: 'email',
+    dataType: 'link',
+    size: 230,
+    minSize: 80,
+    sortingFn: 'sortForHyperlink'},
+  {
+    header: 'Status',
+    accessorKey: 'status',
+    id: 'status',
+    dataType: 'text',
+    minSize: 80,
+    cellEditable:true,
+    cellEditorType: 'dropdown',
+    cellEditorArgs: {
+      options:[
+      { display: 'Verified' },
+      { display: 'Pending' },
+      { display: 'Rejected' },
+      ]
+    },
+  },
+  {
+    header: 'Profile Progress',
+    accessorKey: 'progress',
+    id: 'progress',
+    dataType: 'integer',
+    minSize: 100,
+    cellEditable:true,
+  },
+  {
+    header: 'Created At',
+    accessorKey: 'createdAt',
+    id: 'createdAt',
+    dataType: 'string',
+    size: 150,
+    minSize: 150,
+  },
+];
+
+
+const DefaultArgs = {
+  hover: false,
+  sort: false,
+  columnResize: false,
+  columnReorder: false,
+  pagination: true,
+  showSortIconOnHover: false,
+  summaryRow: false,
+  fullWidth: false,
+  pageSizeList: [7, 10, 20],
+  toolbar: false,
+  columns: DefaultColumns,
+  data: makeData(5),
+  toolbarOptions: {},
+  displayOptions: {},
+  rowsExpandable: false,
+  maxHeight: '',
+  maxWidth: '800px',
+  rowSelection: false,
+  rowSelectionOptions: {},
+};
+
+const LargeDataSetArgs = { ...DefaultArgs, columns: DefaultColumns, data: makeData(10000, 1,1 ),pagination: true, pageSizeList: [5, 10, 50], sort: true , hover: true, rowsExpandable: false, summaryRow: true , columnReorder:true, columnResize: true, toolbar:true,  toolbarOptions: {
+  columnsVisibility: {
+    title: '',
+    requiredColumns: ['age', 'visits'],
+  }
+},
+rowActions:[
+  {
+    id: '1',
+    icon: 'notifications',
+    label: 'Notification',
+    index: 0,
+  },
+
+  {
+    id: '2',
+    icon: 'delete',
+    label: 'Delete',
+    index: 1,
+  },
+
+  {
+    id: '3',
+    icon: 'cancel',
+    label: 'Cancel',
+    index: 2,
+    isDisabled: () => true
+  },
+
+  {
+    id: '4',
+    index: 3,
+    icon: 'calendar',
+    label: 'Calendar',
+  },
+
+{
+  id: '5',
+  index: 4,
+  icon: 'delete',
+  label: 'Delete menu',
+}
+]
+};
+
+
+Object.keys(LargeDataSetArgs).forEach((key) => {
+  const value = LargeDataSetArgs[key];
+  document.querySelector('modus-table')[key] = value;
+});
+
+document.querySelector('modus-table').addEventListener('rowActionClick', (e)=> console.log(e.detail) );
+     </script>
  </body>
 </html>


### PR DESCRIPTION
## Description

- Added custom row actions to the Modus Table configuration with keyboard navigation.
- Up to four icons (including expandable and overflow icons) can be displayed for unlimited row actions.
- Enabled Keyboard navigation on Modus List component
- Refactored code to allow all child components to obtain details from a single context object.

References https://github.com/trimble-oss/modus-web-components/issues/1729

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Storybook page

Go to [preview](https://deploy-preview-1857--modus-webcomponents.netlify.app/?path=/story/components-table--row-actions) and edit the rowActions control to add/remove row actions. Users should be able to use keyboard to select the row actions and press escape key to escape the overflow menu dropdown.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings