### PR TITLE
Added PopperJs for Modus Tooltips

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -254,14 +254,14 @@ export declare interface ModusCheckbox extends Components.ModusCheckbox {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value']
+  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'maxWidth', 'showCheckmark', 'showClose', 'size', 'value']
 })
 @Component({
   selector: 'modus-chip',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'showCheckmark', 'showClose', 'size', 'value'],
+  inputs: ['ariaLabel', 'chipStyle', 'disabled', 'hasError', 'imageUrl', 'maxWidth', 'showCheckmark', 'showClose', 'size', 'value'],
 })
 export class ModusChip {
   protected el: HTMLElement;

--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
+        "@popperjs/core": "^2.11.8",
         "@stencil/core": "^3.3.0",
         "@tanstack/table-core": "^8.8.5"
       },
@@ -1304,6 +1305,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@puppeteer/browsers": {

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -39,6 +39,7 @@
     "start-storybook": "npm run build && cd storybook && npm run storybook"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.8",
     "@stencil/core": "^3.3.0",
     "@tanstack/table-core": "^8.8.5"
   },

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -300,6 +300,10 @@ export namespace Components {
          */
         "imageUrl": string;
         /**
+          * (optional) Maximum width for the Chip's text and shows ellipsis when truncated
+         */
+        "maxWidth": string;
+        /**
           * (optional) Whether to show the checkmark.
          */
         "showCheckmark": boolean;
@@ -1342,7 +1346,7 @@ export namespace Components {
         /**
           * (optional) The tooltip's position relative to its content.
          */
-        "position": 'bottom' | 'left' | 'right' | 'top';
+        "position": ToolTipPlacement;
         /**
           * The tooltip's text.
          */
@@ -2203,6 +2207,10 @@ declare namespace LocalJSX {
           * (optional) The image's url.
          */
         "imageUrl"?: string;
+        /**
+          * (optional) Maximum width for the Chip's text and shows ellipsis when truncated
+         */
+        "maxWidth"?: string;
         /**
           * An event that fires on chip click.
          */
@@ -3417,7 +3425,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The tooltip's position relative to its content.
          */
-        "position"?: 'bottom' | 'left' | 'right' | 'top';
+        "position"?: ToolTipPlacement;
         /**
           * The tooltip's text.
          */

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.e2e.ts
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.e2e.ts
@@ -184,15 +184,17 @@ describe('modus-navbar', () => {
     navbar.setProperty('searchTooltip', { text: 'Search' });
     await page.waitForChanges();
 
-    const tooltip = await page.find('modus-navbar >>> :first-child');
-    const tooltipText = await tooltip.find('modus-tooltip >>> .text');
-    expect(await tooltipText.isVisible()).toBe(false);
+    const tooltip = await searchIcon.find('modus-tooltip >>> .tooltip');
+    expect(tooltip.getAttribute('data-show')).toBeNull();
 
-    await searchIcon.find('modus-tooltip >>> .modus-tooltip').then((e) => e.hover());
+    await searchIcon.hover();
     await page.waitForChanges();
 
-    expect(await tooltipText.isVisible()).toBe(true);
-    expect(tooltipText.innerText).toBe('Search');
+    await new Promise((r) => setTimeout(r, 500));
+    expect(tooltip.getAttribute('data-show')).not.toBeNull();
+
+    const tooltipText = await page.$eval('modus-navbar >>> modus-tooltip >>> .tooltip', (tooltip) => tooltip.textContent);
+    expect(tooltipText).toBe('Search');
   });
 
   it('should show searchoverlay on search button click', async () => {
@@ -301,7 +303,7 @@ describe('modus-navbar', () => {
     expect(await productLogo.isVisible()).toBe(true);
   });
 
-  it('should show tooltip on hover of profile menu', async () => {
+  it('should show tooltip on hover of profile menu and hide it when menu is open', async () => {
     const page = await newE2EPage();
     await page.setContent('<modus-navbar></modus-navbar>');
 
@@ -312,66 +314,22 @@ describe('modus-navbar', () => {
     await page.waitForChanges();
 
     const profileMenuButton = await page.find('modus-navbar >>> .profile-menu');
-    const tooltipText = await profileMenuButton.find('modus-tooltip >>> .text');
 
-    expect(await tooltipText.isVisible()).toBe(false);
+    const tooltip = await profileMenuButton.find('modus-tooltip >>> .tooltip');
+    expect(tooltip.getAttribute('data-show')).toBeNull();
 
-    await profileMenuButton.find('modus-tooltip >>> .modus-tooltip').then((e) => e.hover());
-
+    await profileMenuButton.hover();
     await page.waitForChanges();
 
-    expect(await tooltipText.isVisible()).toBe(true);
-    expect(tooltipText.innerText).toBe('Modus User');
-  });
+    await new Promise((r) => setTimeout(r, 500));
+    expect(tooltip.getAttribute('data-show')).not.toBeNull();
 
-  it('should hide tooltip on hovering over of profile menu', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<modus-navbar profile-menu-tooltip-text="Modus User"></modus-navbar>');
-
-    await page.waitForChanges();
-
-    const navbar = await page.find('modus-navbar');
-    navbar.setProperty('profileMenuOptions', { tooltip: { text: 'Modus User' } });
-    await page.waitForChanges();
-
-    const profileMenuButton = await page.find('modus-navbar >>> .profile-menu');
-    const tooltipText = await profileMenuButton.find('modus-tooltip >>> .text');
-
-    await profileMenuButton.find('modus-tooltip >>> .modus-tooltip').then((e) => e.hover());
-
-    await page.waitForChanges();
-
-    page.mouse.move(0, 0);
-
-    await page.waitForChanges();
-    expect(await tooltipText.isVisible()).toBe(false);
-  });
-
-  it('should hide tooltip while profile menu open', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<modus-navbar profile-menu-tooltip-text="Modus User"></modus-navbar>');
-
-    await page.waitForChanges();
-
-    const navbar = await page.find('modus-navbar');
-    navbar.setProperty('profileMenuOptions', { tooltip: { text: 'Modus User' } });
-    await page.waitForChanges();
-
-    const profileMenuButton = await page.find('modus-navbar >>> .profile-menu');
-    const tooltipText = await profileMenuButton.find('modus-tooltip >>> .text');
-
-    await profileMenuButton.find('modus-tooltip >>> .modus-tooltip').then((e) => e.hover());
-
-    await page.waitForChanges();
+    const tooltipText = await page.$eval('modus-navbar >>> modus-tooltip >>> .tooltip', (tooltip) => tooltip.textContent);
+    expect(tooltipText).toBe('Modus User');
 
     await profileMenuButton.click();
-
-    await page.waitForChanges();
-
-    const profileMenu = await page.find('modus-navbar >>> modus-navbar-profile-menu');
-
-    expect(await profileMenu.isVisible()).toBe(true);
-    expect(await tooltipText.isVisible()).toBe(false);
+    await new Promise((r) => setTimeout(r, 500));
+    expect(tooltip.getAttribute('data-show')).toBeNull();
   });
 
   it('should render primary logo in all screen when secondary logo not provided', async () => {

--- a/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation-item/modus-side-navigation-item.tsx
+++ b/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation-item/modus-side-navigation-item.tsx
@@ -93,31 +93,31 @@ export class ModusSideNavigationItem {
     const classes = `side-nav-item${this.expanded ? ' expanded' : ''}${this.selected ? ' selected' : ''}${
       this.disabled ? ' disabled' : ''
     }`;
-    const menuIconTooltip = this.expanded || this.disabled ? null : this.label;
+    const menuIconTooltip = this.label;
 
     return (
-      <li
-        role="treeitem"
-        ref={(el) => (this._itemRef = el)}
-        tabIndex={this.disabled ? -1 : 0}
-        class={classes}
-        onClick={() => this.handleClick()}
-        onKeyDown={(e) => this.handleKeyDown(e)}
-        aria-disabled={this.disabled ? 'true' : null}
-        aria-label={this.label}
-        aria-current={this.selected ? 'true' : null}
-        onFocus={() => this.sideNavItemFocus.emit({ id: this.element.id })}>
-        <div class="menu-icon" onClick={() => this.sideNavItemFocus.emit({ id: this.element.id })}>
-          <modus-tooltip text={menuIconTooltip} position="right">
+      <modus-tooltip text={menuIconTooltip} disabled={this.disabled} position="right">
+        <li
+          role="treeitem"
+          ref={(el) => (this._itemRef = el)}
+          tabIndex={this.disabled ? -1 : 0}
+          class={classes}
+          onClick={() => this.handleClick()}
+          onKeyDown={(e) => this.handleKeyDown(e)}
+          aria-disabled={this.disabled ? 'true' : null}
+          aria-label={this.label}
+          aria-current={this.selected ? 'true' : null}
+          onFocus={() => this.sideNavItemFocus.emit({ id: this.element.id })}>
+          <div class="menu-icon" onClick={() => this.sideNavItemFocus.emit({ id: this.element.id })}>
             <slot name="menu-icon"></slot>
             {this.menuIcon && <IconMap icon={this.menuIcon} aria-label={this.label} size="24"></IconMap>}
-          </modus-tooltip>
-        </div>
+          </div>
 
-        {this.expanded && <div class="menu-text">{this.label}</div>}
+          {this.expanded && <div class="menu-text">{this.label}</div>}
 
-        <div class="level-icon">{this.showExpandIcon && <IconMap icon="chevron-right-thick" />}</div>
-      </li>
+          <div class="level-icon">{this.showExpandIcon && <IconMap icon="chevron-right-thick" />}</div>
+        </li>
+      </modus-tooltip>
     );
   }
 }

--- a/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.spec.tsx
+++ b/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.spec.tsx
@@ -71,15 +71,15 @@ describe('modus-side-navigation-item', () => {
     expect(page.root).toEqualHtml(`
       <modus-side-navigation-item label="Test">
         <mock:shadow-root>
+        <modus-tooltip position="right" text="Test">
         <li class="side-nav-item" role="treeitem" aria-label="Test"  tabindex="0">
           <div class="menu-icon">
-            <modus-tooltip position="right" text="Test">
               <slot name="menu-icon"></slot>
-            </modus-tooltip>
           </div>
           <div class="level-icon">
           </div>
         </li>
+        </modus-tooltip>
         </mock:shadow-root>
       </modus-side-navigation-item>
     `);

--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.e2e.ts
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.e2e.ts
@@ -12,29 +12,35 @@ describe('modus-tooltip', () => {
   it('renders changes to text', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<modus-tooltip text="Hello"></modus-tooltip>');
+    await page.setContent('<modus-tooltip></modus-tooltip>');
 
-    let text = await page.find('modus-tooltip >>> .text');
-    expect(text.textContent).toEqual('Hello');
+    let text = await page.find('modus-tooltip >>> .tooltip');
+    expect(text).toHaveClass('hide');
 
     const tooltip = await page.find('modus-tooltip');
-    tooltip.setProperty('text', 'Something else');
+    tooltip.setProperty('text', 'Something');
     await page.waitForChanges();
-    text = await page.find('modus-tooltip >>> .text');
-    expect(text.textContent).toEqual('Something else');
+
+    text = await page.find('modus-tooltip >>> .tooltip');
+    expect(text.textContent).toEqual('Something');
   });
 
   it('renders changes to the position', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<modus-tooltip></modus-tooltip>');
+    await page.setContent(`
+    <modus-tooltip text="Tooltip text...">
+          <modus-button>Button</modus-button>
+        </modus-tooltip>
+    `);
     const component = await page.find('modus-tooltip');
-    const element = await page.find('modus-tooltip >>> .modus-tooltip');
-    expect(element).toHaveClass('top');
+    let element = await page.find('modus-tooltip >>> .tooltip');
+    expect(element.getAttribute('data-popper-placement')).toEqual('top');
 
     component.setProperty('position', 'bottom');
     await page.waitForChanges();
-    expect(element).toHaveClass('bottom');
+    element = await page.find('modus-tooltip >>> .tooltip');
+    expect(element.getAttribute('data-popper-placement')).toEqual('bottom');
   });
 
   it('tooltip should show or hide if disabled prop set', async () => {
@@ -44,12 +50,32 @@ describe('modus-tooltip', () => {
 
     tooltip.setProperty('disabled', false);
     await page.waitForChanges();
-    let text = await page.find('modus-tooltip >>> .text');
-    expect(text.textContent).toEqual('Hello');
+    let text = await page.find('modus-tooltip >>> .tooltip');
+    expect(text).not.toHaveClass('hide');
 
     tooltip.setProperty('disabled', true);
     await page.waitForChanges();
-    text = await page.find('modus-tooltip >>> .text');
-    expect(text).toEqual(null);
+    text = await page.find('modus-tooltip >>> .tooltip');
+    expect(text).toHaveClass('hide');
+  });
+
+  it('should display tooltip on hover', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-tooltip text="Tooltip text">
+            <modus-button>Button</modus-button>
+          </modus-tooltip>
+      `);
+    await page.hover('modus-button'); // Hover over the element that triggers the tooltip
+    await new Promise((r) => setTimeout(r, 500));
+
+    const tooltip = await page.find('modus-tooltip >>> .tooltip');
+    expect(tooltip.getAttribute('data-show')).not.toBeNull();
+
+    const button = await page.find('modus-button >>> button');
+    await button.click();
+    await new Promise((r) => setTimeout(r, 500));
+    expect(tooltip.getAttribute('data-show')).toBeNull();
   });
 });

--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
@@ -1,88 +1,52 @@
 @import './modus-tooltip.vars';
 
-.modus-tooltip {
-  align-items: center;
-  display: inline-flex;
+.tooltip {
+  background: $modus-tooltip-bg;
+  border-radius: $rem-2px;
+  color: $modus-tooltip-color;
+  display: none;
   font-family: $primary-font;
-  justify-content: center;
-  position: relative;
+  font-size: $rem-12px;
+  max-width: none;
+  padding: $rem-4px $rem-8px;
+  white-space: nowrap;
+  z-index: 1;
+}
 
-  .text {
-    background-color: $modus-tooltip-bg;
-    border-radius: $rem-2px;
-    color: $modus-tooltip-color;
-    display: none;
-    font-size: $rem-12px;
-    opacity: 0;
-    padding: $rem-4px $rem-8px;
-    position: absolute;
-    text-align: center;
-    transition: opacity 0.3s ease-in-out;
-    width: max-content;
-    z-index: 1;
-  }
+.tooltip[data-show]:not(.hide) {
+  display: block;
+}
 
-  .text::after {
-    border-style: solid;
-    border-width: $rem-5px;
-    content: '';
-    position: absolute;
-  }
+#arrow,
+#arrow::before {
+  background: inherit;
+  height: 8px;
+  position: absolute;
+  width: 8px;
+}
 
-  &.top {
-    .text {
-      top: -2.125rem;
-    }
+#arrow {
+  visibility: hidden;
+}
 
-    .text::after {
-      border-color: $modus-tooltip-bg transparent transparent transparent;
-      left: 50%;
-      margin-left: -0.313rem;
-      top: 100%;
-    }
-  }
+#arrow::before {
+  content: '';
+  transform: rotate(45deg);
+  visibility: visible;
+}
 
-  &.bottom {
-    .text {
-      bottom: -2.125rem;
-    }
+.tooltip[data-popper-placement^='top'] > #arrow {
+  bottom: -4px;
+}
 
-    .text::after {
-      border-color: transparent transparent $modus-tooltip-bg transparent;
-      bottom: 100%;
-      left: 50%;
-      margin-left: -0.313rem;
-    }
-  }
+.tooltip[data-popper-placement^='bottom'] > #arrow {
+  top: -4px;
+}
 
-  &.left {
-    .text {
-      right: calc(100% + 0.375rem);
-    }
+.tooltip[data-popper-placement^='left'] > #arrow {
+  right: -4px;
+}
 
-    .text::after {
-      border-color: transparent transparent transparent $modus-tooltip-bg;
-      left: 100%;
-      margin-top: -0.313rem;
-      top: 50%;
-    }
-  }
-
-  &.right {
-    .text {
-      left: calc(100% + 0.375rem);
-    }
-
-    .text::after {
-      border-color: transparent $modus-tooltip-bg transparent transparent;
-      margin-top: -0.313rem;
-      right: 100%;
-      top: 50%;
-    }
-  }
-
-  &:hover .text {
-    display: unset;
-    opacity: 1;
-  }
+.tooltip[data-popper-placement^='right'] > #arrow {
+  left: -4px;
 }

--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.spec.ts
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.spec.ts
@@ -10,10 +10,11 @@ describe('modus-tooltip', () => {
     expect(root).toEqualHtml(`
       <modus-tooltip text="message">
         <mock:shadow-root>
-          <div class="modus-tooltip top">
             <slot></slot>
-            <div class="text" role="tooltip">message</div>
-          </div>
+            <div class="tooltip" role="tooltip" tabindex="-1">
+              message
+              <div data-popper-arrow id="arrow"></div>
+            </div>
         </mock:shadow-root>
       </modus-tooltip>
     `);

--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.tsx
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.tsx
@@ -1,5 +1,8 @@
 // eslint-disable-next-line
-import { Component, h, Prop } from '@stencil/core';
+import { Component, Element, Fragment, h, Prop, Watch } from '@stencil/core';
+import { createPopper, Instance } from '@popperjs/core';
+
+type ToolTipPlacement = 'bottom' | 'left' | 'right' | 'top' | 'auto';
 
 @Component({
   tag: 'modus-tooltip',
@@ -7,30 +10,145 @@ import { Component, h, Prop } from '@stencil/core';
   shadow: true,
 })
 export class ModusTooltip {
+  @Element() element: HTMLElement;
   /** (optional) The tooltip's aria-label. */
   @Prop() ariaLabel: string | null;
 
   /** (optional) The tooltip's position relative to its content. */
-  @Prop() position: 'bottom' | 'left' | 'right' | 'top' = 'top';
+  @Prop() position: ToolTipPlacement = 'top';
+  @Watch('position')
+  handlePositionChange(newValue: ToolTipPlacement) {
+    if (this.popperInstance) {
+      this.popperInstance.setOptions((options) => ({
+        ...options,
+        placement: newValue,
+        modifiers: [...options.modifiers],
+      }));
+    } else this.initializePopper(newValue);
+  }
 
   /** The tooltip's text. */
   @Prop() text: string;
+  @Watch('text') onTextChange(newValue: string) {
+    if (newValue?.length > 1) {
+      this.initializePopper(this.position);
+    } else {
+      this.cleanupPopper();
+    }
+  }
 
   /** Hide the tooltip */
   @Prop() disabled: boolean;
+  @Watch('disabled') onDisabledChange(newValue: boolean) {
+    if (!newValue) {
+      this.initializePopper(this.position);
+    } else {
+      this.cleanupPopper();
+    }
+  }
+
+  private popperInstance: Instance;
+  private tooltipElement: HTMLDivElement;
+  private readonly showEvents = ['mouseenter', 'focus'];
+  private readonly hideEvents = ['mouseleave', 'blur', 'click'];
+  private showEventsListener = () => this.show();
+  private hideEventsListener = () => this.hide();
+
+  componentDidLoad(): void {
+    this.tooltipElement = this.element.shadowRoot.querySelector('.tooltip') as HTMLDivElement;
+    if (!this.disabled && this.text?.length > 1) {
+      this.initializePopper(this.position);
+    }
+  }
+
+  disconnectedCallback(): void {
+    this.cleanupPopper();
+  }
+
+  initializePopper(position: ToolTipPlacement): void {
+    if (this.popperInstance) {
+      this.cleanupPopper();
+    }
+
+    const target = this.element.firstElementChild;
+    if (!target || !this.tooltipElement) return;
+
+    this.popperInstance = createPopper(target, this.tooltipElement, {
+      placement: position,
+      modifiers: [
+        {
+          name: 'offset',
+          options: {
+            offset: [0, 8],
+          },
+        },
+      ],
+    });
+
+    this.showEvents.forEach((event) => {
+      target.addEventListener(event, this.showEventsListener);
+    });
+
+    this.hideEvents.forEach((event) => {
+      target.addEventListener(event, this.hideEventsListener);
+    });
+  }
+
+  cleanupPopper(): void {
+    const target = this.element.firstElementChild;
+    if (target) {
+      this.showEvents.forEach((event) => {
+        target.removeEventListener(event, this.showEventsListener);
+      });
+
+      this.hideEvents.forEach((event) => {
+        target.removeEventListener(event, this.hideEventsListener);
+      });
+    }
+
+    this.popperInstance?.destroy();
+    this.popperInstance = null;
+  }
+
+  show(): void {
+    if (this.popperInstance) {
+      // Make the tooltip visible
+      this.tooltipElement.setAttribute('data-show', '');
+
+      // Enable the event listeners
+      this.popperInstance.setOptions((options) => ({
+        ...options,
+        modifiers: [...options.modifiers, { name: 'eventListeners', enabled: true }],
+      }));
+
+      // Update its position
+      this.popperInstance.update();
+    }
+  }
+
+  hide(): void {
+    if (this.popperInstance) {
+      // Hide the tooltip
+      this.tooltipElement.removeAttribute('data-show');
+
+      // Disable the event listeners
+      this.popperInstance.setOptions((options) => ({
+        ...options,
+        modifiers: [...options.modifiers, { name: 'eventListeners', enabled: false }],
+      }));
+    }
+  }
 
   render(): unknown {
-    const className = `modus-tooltip ${this.position}`;
-    const showTooltip = !this.disabled && this.text;
+    const hidden = this.disabled || !(this.text?.length > 1);
     return (
-      <div class={className}>
+      <Fragment>
         <slot />
-        {showTooltip && (
-          <div aria-label={this.ariaLabel} class={'text'} role="tooltip">
-            {this.text}
-          </div>
-        )}
-      </div>
+        <div tabIndex={-1} class={{ tooltip: true, hide: hidden }} aria-label={this.ariaLabel} role="tooltip">
+          {this.text}
+          <div id="arrow" data-popper-arrow></div>
+        </div>
+      </Fragment>
     );
   }
 }

--- a/stencil-workspace/src/components/modus-tooltip/readme.md
+++ b/stencil-workspace/src/components/modus-tooltip/readme.md
@@ -7,12 +7,12 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                                | Type                                     | Default     |
-| ----------- | ------------ | ---------------------------------------------------------- | ---------------------------------------- | ----------- |
-| `ariaLabel` | `aria-label` | (optional) The tooltip's aria-label.                       | `string`                                 | `undefined` |
-| `disabled`  | `disabled`   | Hide the tooltip                                           | `boolean`                                | `undefined` |
-| `position`  | `position`   | (optional) The tooltip's position relative to its content. | `"bottom" \| "left" \| "right" \| "top"` | `'top'`     |
-| `text`      | `text`       | The tooltip's text.                                        | `string`                                 | `undefined` |
+| Property    | Attribute    | Description                                                | Type                                               | Default     |
+| ----------- | ------------ | ---------------------------------------------------------- | -------------------------------------------------- | ----------- |
+| `ariaLabel` | `aria-label` | (optional) The tooltip's aria-label.                       | `string`                                           | `undefined` |
+| `disabled`  | `disabled`   | Hide the tooltip                                           | `boolean`                                          | `undefined` |
+| `position`  | `position`   | (optional) The tooltip's position relative to its content. | `"auto" \| "bottom" \| "left" \| "right" \| "top"` | `'top'`     |
+| `text`      | `text`       | The tooltip's text.                                        | `string`                                           | `undefined` |
 
 
 ## Dependencies

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -16,6 +16,182 @@
   </head>
 
   <body>
-    <!-- Test components -->
+    <modus-button id="Toggle">Toggle</modus-button>
+    <div style="display: flex; justify-content: end;padding-right: 20%;">
+
+      <modus-tooltip text="Tooltip text Tooltip text...Tooltip text...Tooltip text...Tooltip text...Tooltip text...Tooltip text... Tooltip text...Tooltip text......" position="right">
+        <modus-button>Button</modus-button>
+      </modus-tooltip>
+    </div>
+
+
+    <div id="dataTemplate">
+      <modus-switch id="switch-theme" label="Enable blue theme"></modus-switch>
+      <br />
+      <modus-switch
+        id="switch-mode"
+        label="Enable Push Side Navigation"></modus-switch>
+      <div
+        style="width: 100%;align-items: center;height: 56px;box-shadow: 0 0 2px var(--modus-secondary)!important; margin-top: 10px;">
+        <modus-navbar
+          id="navbar"
+          show-apps-menu
+          show-help
+          show-main-menu
+          show-notifications>
+        </modus-navbar>
+      </div>
+
+      <div
+        id="container"
+        style="display:flex; min-height:500px; overflow-y: auto; position: relative;box-shadow: 0 0 2px var(--modus-secondary)!important;">
+        <modus-side-navigation
+          max-width="300px"
+          id="sideNav"
+          target-content="#dataTemplate #panelcontent"
+          mode="overlay">
+        </modus-side-navigation>
+
+        <div
+          id="panelcontent"
+          style="padding:10px; transition: all 0.25s linear 0s;">
+          <div id="overview">
+            <p>
+              The side navigation of an application provides context through
+              accessible menu options and positions a consistent component to
+              connect to various pages in the application.
+            </p>
+            <p>
+              The side navigation is a collapsible side content of the site’s pages.
+              It is located alongside the page’s primary content. The component is
+              designed to add side content to a fullscreen application. It is
+              activated through the “hamburger” menu in the Navbar.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script>
+      document.querySelector('#navbar').logoOptions = {
+        primary: {
+          url: 'https://modus.trimble.com/img/trimble-logo.svg',
+        },
+      };
+      document.querySelector('#navbar').profileMenuOptions = {
+        avatarUrl: 'broken-link',
+        email: 'modus_user@trimble.com',
+        initials: 'MU',
+        username: 'Modus User',
+      };
+
+      const homeIcon =
+        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' height='24' width='24' viewBox='0 0 32 32'%3E%3Cstyle%3E .st1 %7B stroke: %23000; stroke-miterlimit: 10; %7D %3C/style%3E%3Cpath d='M30.707 15.293 26 10.586V5a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v1.586l-4.293-4.293a1 1 0 0 0-1.414 0l-13 13A1 1 0 0 0 4 17h3v12a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1v-7h6v7a1 1 0 0 0 1 1h5a1 1 0 0 0 1-1V17h3a1 1 0 0 0 .707-1.707z' /%3E%3C/svg%3E";
+
+      const usageIcon =
+        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' height='24' width='24' viewBox='0 0 32 32'%3E%3Cg%3E%3Cpath d='M30 23v6c0 .55-.45 1-1 1h-6c-.55 0-1-.45-1-1v-6c0-.55.45-1 1-1h2v-5h-8v5h2c.55 0 1 .45 1 1v6c0 .55-.45 1-1 1h-6c-.55 0-1-.45-1-1v-6c0-.55.45-1 1-1h2v-5H7v5h2c.55 0 1 .45 1 1v6c0 .55-.45 1-1 1H3c-.55 0-1-.45-1-1v-6c0-.55.45-1 1-1h2v-6c0-.55.45-1 1-1h9v-5h-2c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h6c.55 0 1 .45 1 1v6c0 .55-.45 1-1 1h-2v5h9c.55 0 1 .45 1 1v6h2c.55 0 1 .45 1 1z' /%3E%3C/g%3E%3C/svg%3E";
+
+      const stylesIcon =
+        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' height='24' width='24' viewBox='0 0 32 32'%3E%3Cpath d='M30 25h-1v-9a1 1 0 0 0-1-1h-5a1 1 0 0 0-1 1v9h-2V5a1 1 0 0 0-1-1h-5a1 1 0 0 0-1 1v20h-2V12a1 1 0 0 0-1-1H5a1 1 0 0 0-1 1v13H3a1 1 0 1 0 0 2h27a1 1 0 1 0 0-2zM6 25V13h3v12H6zm9 0V6h3v19h-3zm9 0v-8h3v8h-3z' /%3E%3C/svg%3E";
+
+      const accessibilityIcon =
+        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' height='24' width='24' viewBox='0 0 32 32'%3E%3Cg%3E%3Cpath d='M29 4H3c-.55 0-1 .45-1 1v17c0 .55.45 1 1 1h12v3h-4c-.55 0-1 .45-1 1s.45 1 1 1h10c.55 0 1-.45 1-1s-.45-1-1-1h-4v-3h12c.55 0 1-.45 1-1V5c0-.55-.45-1-1-1zm-1 17H4v-2h24v2z' /%3E%3C/g%3E%3C/svg%3E";
+
+      const selectionHandler = (e) => {
+        if (e.detail) {
+          const panel = document.querySelector('#panelcontent');
+          document.querySelector('#sidenav-content-title')?.remove();
+          const el = document.createElement('h3');
+          el.id = 'sidenav-content-title';
+          el.innerHTML = e.target?.label || 'Home page';
+          panel.insertBefore(el, document.querySelector('#overview'));
+        }
+      };
+
+      const blueTheme = `--modus-side-navigation-bg:#0e416c;--modus-side-navigation-item-color:#ffffff;--modus-side-navigation-item-active-bg:#217cbb;--modus-side-navigation-item-hover-bg:#0063a3;--modus-side-navigation-item-icon-color:#ffffff;--modus-side-navigation-item-chevron-color:#ffffff;--modus-side-navigation-item-icon-filter:invert(100%) sepia(0%) saturate(24%) hue-rotate(114deg) brightness(108%) contrast(108%);`;
+
+      function initialize() {
+        const sidenav = document.querySelector('modus-side-navigation');
+        sidenav.data = [
+          {
+            id: 'home-menu',
+            menuIconUrl: homeIcon,
+            label: 'Home page 1',
+            children: [
+              {
+                id: 'home-menu-2',
+                menuIconUrl: homeIcon,
+                label: 'Home page 2',
+                onSideNavItemClicked: selectionHandler,
+              },
+              {
+                id: 'usage-menu-2',
+                children: [
+                  {
+                    id: 'home-menu-3',
+                    menuIconUrl: homeIcon,
+                    label: 'Home page 3',
+                    onSideNavItemClicked: selectionHandler,
+                  },
+                ],
+                menuIconUrl: usageIcon,
+                label: 'Usage page 2',
+              },
+            ],
+          },
+          {
+            id: 'usage-menu',
+            menuIconUrl: usageIcon,
+            label: 'Usage page 1',
+            onSideNavItemClicked: selectionHandler,
+          },
+          {
+            id: 'styles-menu',
+            menuIconUrl: stylesIcon,
+            label: 'Styles page 1',
+            onSideNavItemClicked: selectionHandler,
+          },
+          {
+            id: 'accessibility-menu',
+            menuIconUrl: accessibilityIcon,
+            label: 'Accessibility page 1',
+            onSideNavItemClicked: selectionHandler,
+          },
+        ];
+      }
+
+      function addEventHandlers() {
+        document.addEventListener('mainMenuClick', (e) => {
+          executeListener(e, () => {
+            const panel = document.querySelector('modus-side-navigation');
+            panel.expanded = !panel.expanded;
+          });
+        });
+
+        document
+          .querySelector('#switch-theme')
+          .addEventListener('switchClick', (e) => {
+            const sidenav = document.querySelector('modus-side-navigation');
+            if (e.detail) {
+              sidenav.style = blueTheme;
+            } else sidenav.style = '';
+          });
+
+        document
+          .querySelector('#switch-mode')
+          .addEventListener('switchClick', (e) => {
+            const sidenav = document.querySelector('modus-side-navigation');
+            sidenav.mode = sidenav.mode === 'push' ? 'overlay' : 'push';
+          });
+      }
+
+      initialize();
+      addEventHandlers();
+
+      document.querySelector('#Toggle').addEventListener('click', () => {
+        debugger;
+        document.querySelector('modus-tooltip').disabled = !document.querySelector('modus-tooltip').disabled;
+      });
+    </script>
  </body>
 </html>

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -1,7 +1,6 @@
 // @ts-ignore: JSX/MDX with Stencil
 import docs from './modus-navbar-storybook-docs.mdx';
 import { html } from 'lit-html';
-import { ModusNavbarButton } from '../../../../src/components/modus-navbar/modus-navbar.models';
 
 export default {
   title: 'Components/Navbar',
@@ -23,17 +22,17 @@ export default {
       },
     },
     profileMenuOptions: {
-      name: 'profileMenuOptions',
+      name: 'profile-menu-options',
       description: 'Set the options for profile menu',
       table: {
-        type: { summary: 'object' },
+        type: { summary: 'ModusProfileMenuOptions' },
       },
     },
     buttons: {
       name: 'buttons',
       description: 'To add icon buttons dynamically to the Navbar, create an array of ModusNavbarButton.',
       table: {
-        type: { summary: 'object' },
+        type: { summary: 'ModusNavbarButton[]' },
       },
     },
   },
@@ -59,7 +58,6 @@ const Template = ({ profileMenuOptions, buttons, showSearch, enableSearchOverlay
     enable-search-overlay=${enableSearchOverlay}
     show-search=${showSearch}
     show-apps-menu
-    show-help
     show-main-menu>
     <div slot="main" style="height:300px;">Render your own main menu.</div>
 
@@ -89,10 +87,17 @@ Default.args = {
         display: "Link 2",
         icon: "sun"
         }
-    ]
+    ],
+    tooltip: {
+      text: 'User Profile Menu',
+    }
   },
   buttons: [
-    { id: 'addMenu', icon: 'add' },
+    { id: 'addMenu', icon: 'add',
+      tooltip: {
+        text: 'Add',
+      }
+    },
     { id: 'notificationMenu', icon: 'notifications' },
   ],
   showSearch: false,
@@ -164,7 +169,7 @@ const setNavbar = (
   profileMenuOptions,
   logoUrl = '',
   iconUrl = '',
-  buttons: ModusNavbarButton[]
+  buttons: []
 ) => {
   const tag = document.createElement('script');
   profileMenuOptions.avatarUrl = workingAvatar

--- a/stencil-workspace/storybook/stories/components/modus-side-navigation/modus-side-navigation.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-side-navigation/modus-side-navigation.stories.tsx
@@ -370,6 +370,7 @@ const setJavascriptDataTemplate = (containerId) => {
         {
           id:'home-menu',
           menuIcon: "${homeIcon}",
+          disabled: true,
           label: 'Home page 1',
           children: [
             {


### PR DESCRIPTION
## Description

Integrated [PopperJs](https://popper.js.org/docs/v2/tutorial/) for the Modus tooltip component.

References #1691 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

To see the tooltip working, go to the Storybook preview page for the Modus tooltip component or any other component that is using Modus Tooltips like Modus Navbar (on the Add button), Modus Side Navigation items when collapsed, Modus Table header sort icons. On the Tooltip Storybook page, use the controls to set the `disabled` to `false` or clear the tooltip text to see no tooltip appearing. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
