### PR TITLE
Fix for Failed Avatar navbar example is not using a valid URL

### DIFF
--- a/angular-workspace/test-ng14/src/examples/modus-navbar-examples/modus-navbar-examples.component.ts
+++ b/angular-workspace/test-ng14/src/examples/modus-navbar-examples/modus-navbar-examples.component.ts
@@ -30,7 +30,7 @@ export class ModusNavbarExamplesComponent implements OnInit {
   };
 
   profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',

--- a/angular-workspace/test-ng15/src/examples/modus-navbar-examples/modus-navbar-examples.component.ts
+++ b/angular-workspace/test-ng15/src/examples/modus-navbar-examples/modus-navbar-examples.component.ts
@@ -30,7 +30,7 @@ export class ModusNavbarExamplesComponent implements OnInit {
   };
 
   profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -133,7 +133,10 @@ nav {
         img.avatar {
           background-color: $modus-navbar-icon-color;
           border-radius: 50%;
+          display: flex;
           height: 32px;
+          max-height: 32px;
+          max-width: 32px;
           width: 32px;
         }
 
@@ -147,6 +150,8 @@ nav {
           font-weight: $font-weight-semi-bold;
           height: 32px;
           justify-content: center;
+          max-height: 32px;
+          max-width: 32px;
           user-select: none;
           width: 32px;
         }

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -108,7 +108,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
     secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
   };
   element.profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',
@@ -152,7 +152,7 @@ Use the `variant` prop to choose a blue background navbar.
     secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
   };
   element.profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -174,7 +174,7 @@ const setNavbar = (
   const tag = document.createElement('script');
   profileMenuOptions.avatarUrl = workingAvatar
     ? 'https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/0e738c17-7f3c-422e-8225-f8c782b08626/d9pordj-43d4aa59-54b0-46a1-a568-e36dd691cf27.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzBlNzM4YzE3LTdmM2MtNDIyZS04MjI1LWY4Yzc4MmIwODYyNlwvZDlwb3Jkai00M2Q0YWE1OS01NGIwLTQ2YTEtYTU2OC1lMzZkZDY5MWNmMjcucG5nIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.xvDk9KFIUAx0yAG3BPamDfRqmWUX6zwR4WVW40GjsoY'
-    : 'broken-link';
+    : 'https://avatar.example.com/broken-image-link.png';
 
   tag.innerHTML = `
 document.querySelectorAll('modus-list-item').forEach(i => i.style.setProperty('--modus-list-item-border-color', 'transparent'));

--- a/stencil-workspace/storybook/stories/components/modus-side-navigation/modus-side-navigation-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-side-navigation/modus-side-navigation-storybook-docs.mdx
@@ -129,7 +129,7 @@ A basic Modus Side Navigation with only item selection and keyboard navigation f
     },
   };
   document.querySelector('#navbar').profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',
@@ -233,7 +233,7 @@ Modus side navigation uses CSS variables for theming ex:`--modus-side-navigation
     },
   };
   document.querySelector('#navbar').profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',

--- a/stencil-workspace/storybook/stories/components/modus-side-navigation/modus-side-navigation.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-side-navigation/modus-side-navigation.stories.tsx
@@ -283,7 +283,7 @@ const helpers = (containerId) => {
     },
   };
   getRoot().querySelector('#navbar').profileMenuOptions = {
-    avatarUrl: 'broken-link',
+    avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
     initials: 'MU',
     username: 'Modus User',


### PR DESCRIPTION
## Description

- Use a valid URL which doesn't load an image: https://avatar.example.com/broken-image-link.png
- Set `max-height:32px` and `max-width:32px` to prevent failed image to appear much larger.
- Add `display: flex` to set it to display correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Locally, works every time.

![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/c44a8e30-7f09-475e-93ce-68951cf20ce7)


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
