### PR TITLE
[Issue 1865] Modus Table - Add default hidden columns in the Column visibility panel

### DIFF
--- a/stencil-workspace/src/components/modus-table/models/modus-table.models.ts
+++ b/stencil-workspace/src/components/modus-table/models/modus-table.models.ts
@@ -81,6 +81,7 @@ export interface ModusTableToolbarOptions {
 export interface ModusTableColumnsVisibilityOptions {
   title: string;
   requiredColumns?: string[];
+  hiddenColumns?: string[];
 }
 
 export interface ModusTableRowActions {

--- a/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
@@ -18,11 +18,11 @@ const MockColumns = [
 ];
 
 const MockManualPagination = {
-  currentPageIndex: 2, 
-  currentPageSize: 10, 
+  currentPageIndex: 2,
+  currentPageSize: 10,
   pageCount: 10,
-  totalRecords: 100
-}
+  totalRecords: 100,
+};
 
 const MockData = [
   {
@@ -288,18 +288,17 @@ describe('modus-table', () => {
     component.setProperty('pageSizeList', [5, 10, 50]);
     await page.waitForChanges();
 
-    const pagination = await page.find(`modus-table >>> modus-pagination`)
+    const pagination = await page.find(`modus-table >>> modus-pagination`);
     const paginationContainer = await page.find('modus-table >>> .pagination-and-count > .total-count');
     await page.waitForChanges();
- 
+
     expect(await pagination.getAttribute('active-page')).toBeTruthy();
     expect(await pagination.getAttribute('max-page')).toBeTruthy();
     expect(await pagination.getAttribute('active-page')).toBe(`${MockManualPagination.currentPageIndex}`);
     expect(await pagination.getAttribute('max-page')).toBe(`${MockManualPagination.pageCount}`);
-    
+
     expect(paginationContainer).not.toBeNull();
     expect(paginationContainer.textContent).toContain('Showing result11-20of100');
- 
   });
   it('Display page view when pagination is enabled', async () => {
     page = await newE2EPage();
@@ -473,6 +472,33 @@ describe('modus-table', () => {
     expect(resizeContainer).not.toBeNull();
   });
 
+  it('Renders column resizing when columnVisibility is enabled', async () => {
+    page = await newE2EPage();
+
+    await page.setContent('<modus-table />');
+    const component = await page.find('modus-table');
+    component.setProperty('columns', MockColumns);
+    component.setProperty('data', MockData);
+    component.setProperty('toolbar', true);
+    component.setProperty('toolbarOptions', {
+      columnsVisibility: {
+        title: '',
+        requiredColumns: ['mock-column-one'],
+        hiddenColumns: ['mock-column-two'],
+      },
+    });
+
+    await page.waitForChanges();
+
+    // Check for the required column; it should be present.
+    const requiredColumn = await page.find(`modus-table >>> th[aria-label="Mock Column One"]`);
+    expect(requiredColumn).not.toBeNull();
+
+    // Check for the hidden column; it should NOT be present.
+    const hiddenColumn = await page.find(`modus-table >>> th[aria-label="Mock Column Two"]`);
+    expect(hiddenColumn).toBeNull();
+  });
+
   it('Renders Hyperlinks in cell and emits cellLinkEvent', async () => {
     page = await newE2EPage();
 
@@ -503,7 +529,7 @@ describe('modus-table', () => {
     linkElement.focus();
     await page.keyboard.press('Enter');
     await page.waitForChanges();
-    
+
     expect(cellLinkClickEvent).toHaveReceivedEventDetail(emailData);
   });
 

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/modus-table-columns-visibility.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/modus-table-columns-visibility.tsx
@@ -97,7 +97,10 @@ export class ModusTableColumnsVisibility {
   private initializeVisibilityState() {
     // Set the visibility state based on hiddenColumns prop
     this.table.getAllLeafColumns().forEach((column) => {
-      if (this.columnsVisibility.hiddenColumns?.includes(column.id)) {
+      const isRequired = this.columnsVisibility?.requiredColumns?.includes(column.id);
+      const isHidden = this.columnsVisibility?.hiddenColumns?.includes(column.id);
+
+      if (!isRequired && isHidden) {
         column.toggleVisibility(false);
       }
     });

--- a/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/modus-table-columns-visibility.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/panel/modus-table-columns-visibility/modus-table-columns-visibility.tsx
@@ -31,6 +31,11 @@ export class ModusTableColumnsVisibility {
 
   private refItemContent: HTMLElement[] = [];
 
+  componentWillLoad() {
+    // Initialize columns visibility state based on hiddenColumns
+    this.initializeVisibilityState();
+  }
+
   applyColumnsVisibility() {
     this.table.getAllLeafColumns().forEach((column) => {
       if (this.columnsVisibilityState.has(column.id)) {
@@ -87,6 +92,15 @@ export class ModusTableColumnsVisibility {
     if (!requiredColumn) {
       this.refItemContent[i] = el;
     }
+  }
+
+  private initializeVisibilityState() {
+    // Set the visibility state based on hiddenColumns prop
+    this.table.getAllLeafColumns().forEach((column) => {
+      if (this.columnsVisibility.hiddenColumns?.includes(column.id)) {
+        column.toggleVisibility(false);
+      }
+    });
   }
 
   private toggleColumnVisibility(columnIndex: number) {

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table-storybook-docs.mdx
@@ -332,7 +332,8 @@ A toolbar is used to perform operations like hiding/showing the columns. It is e
     document.querySelector('modus-table').toolbarOptions = {
         columnsVisibility: {
           title: '',
-          requiredColumns: ['first-name']
+          requiredColumns: ['first-name'],
+          hiddenColumns: ['last-name']
         }
       };
     document.querySelector('modus-table').columns = [
@@ -340,6 +341,14 @@ A toolbar is used to perform operations like hiding/showing the columns. It is e
         header: 'First Name',
         accessorKey: 'firstName',
         id: 'first-name',
+        dataType: 'text',
+        size: 150,
+        minSize: 80
+      },
+      {
+        header: 'Last Name',
+        accessorKey: 'lastName',
+        id: 'last-name',
         dataType: 'text',
         size: 150,
         minSize: 80

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
@@ -72,7 +72,7 @@ function initializeTable(
     "paginationChange", (ev)=> {
       if(!!modusTable.manualPaginationOptions){
         const manualPaginationData = ${JSON.stringify([
-          ...data, 
+          ...data,
           ...makeData(manualPaginationOptions?.totalRecords).slice(data.length)
         ])};
         modusTable.data = manualPaginationData.slice(ev.detail.pageIndex * ev.detail.pageSize,
@@ -541,7 +541,7 @@ const valueFormatterTable = (pageSizeList, toolbarOptions, displayOptions, rowSe
    document.querySelector('modus-table').toolbarOptions = ${JSON.stringify(toolbarOptions)};
    document.querySelector('modus-table').displayOptions = ${JSON.stringify(displayOptions)};
    document.querySelector('modus-table').rowSelectionOptions = ${JSON.stringify(rowSelectionOptions)};
-   
+
   `;
   return tag;
 };
@@ -580,6 +580,7 @@ ColumnVisibility.args = {
     columnsVisibility: {
       title: '',
       requiredColumns: ['age', 'visits'],
+      hiddenColumns: ['progress', 'createdAt'],
     },
   },
   toolbar: true,


### PR DESCRIPTION
## Description


References #1865 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Run storybook in `stencil-workspace` and go to the path `/?path=/story/components-table--column-visibility` to see modus table with column visibility.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
