### PR TITLE
Set background color for readonly inputs

### DIFF
--- a/stencil-workspace/src/components/modus-date-input/modus-date-input.scss
+++ b/stencil-workspace/src/components/modus-date-input/modus-date-input.scss
@@ -131,6 +131,11 @@
     }
   }
 
+  .input-container:has(input[readonly]) {
+    background-color: $modus-input-readonly-bg;
+    border-bottom-color: $modus-input-disabled-bottom-line-color;
+  }
+
   .sub-text {
     font-size: $rem-11px;
 

--- a/stencil-workspace/src/components/modus-date-input/modus-date-input.vars.scss
+++ b/stencil-workspace/src/components/modus-date-input/modus-date-input.vars.scss
@@ -16,3 +16,6 @@ $modus-input-disabled-bg: var(--modus-input-disabled-bg, #e0e1e9) !default;
 $modus-input-disabled-border-color: var(--modus-input-disabled-border-color, #e0e1e9) !default;
 $modus-input-disabled-bottom-line-color: var(--modus-input-disabled-bottom-line-color, #a3a6b1) !default;
 $modus-input-disabled-color: var(--modus-input-disabled-color, #a3a6b1) !default;
+
+// Readonly
+$modus-input-readonly-bg: var(--modus-input-readonly-bg, #e0e1e9) !default;

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.vars.scss
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.vars.scss
@@ -13,3 +13,6 @@ $modus-date-picker-calendar-day-selected-bg: var(--modus-date-picker-calendar-da
 $modus-date-picker-calendar-day-selected-color: var(--modus-date-picker-calendar-day-selected-color, #fff) !default;
 $modus-date-picker-calendar-day-selected-range-bg: var(--modus-date-picker-calendar-day-selected-range-bg, #dcedf9) !default;
 $modus-date-picker-calendar-day-disabled-opacity: var(--modus-date-picker-calendar-day-disabled-opacity, 0.3) !default;
+
+// Readonly
+$modus-input-readonly-bg: var(--modus-input-readonly-bg, #e0e1e9) !default;

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
@@ -90,6 +90,11 @@
     }
   }
 
+  .input-container:has(input[readonly]) {
+    background-color: $modus-input-readonly-bg;
+    border-bottom-color: $modus-input-disabled-bottom-line-color;
+  }
+
   .sub-text {
     font-size: $rem-11px;
     margin-top: $rem-4px;

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.vars.scss
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.vars.scss
@@ -15,3 +15,6 @@ $modus-input-disabled-bg: var(--modus-input-disabled-bg, #e0e1e9) !default;
 $modus-input-disabled-border-color: var(--modus-input-disabled-border-color, #e0e1e9) !default;
 $modus-input-disabled-bottom-line-color: var(--modus-input-disabled-bottom-line-color, #a3a6b1) !default;
 $modus-input-disabled-color: var(--modus-input-disabled-color, #a3a6b1) !default;
+
+// Readonly
+$modus-input-readonly-bg: var(--modus-input-readonly-bg, #e0e1e9) !default;

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -134,6 +134,11 @@
     }
   }
 
+  .input-container:has(input[readonly]) {
+    background-color: $modus-input-readonly-bg;
+    border-bottom-color: $modus-input-disabled-bottom-line-color;
+  }
+
   .sub-text {
     font-size: $rem-11px;
     margin-top: $rem-4px;

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.vars.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.vars.scss
@@ -16,3 +16,6 @@ $modus-input-disabled-bg: var(--modus-input-disabled-bg, #e0e1e9) !default;
 $modus-input-disabled-border-color: var(--modus-input-disabled-border-color, #e0e1e9) !default;
 $modus-input-disabled-bottom-line-color: var(--modus-input-disabled-bottom-line-color, #a3a6b1) !default;
 $modus-input-disabled-color: var(--modus-input-disabled-color, #a3a6b1) !default;
+
+// Readonly
+$modus-input-readonly-bg: var(--modus-input-readonly-bg, #e0e1e9) !default;

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.scss
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.scss
@@ -113,6 +113,11 @@
     }
   }
 
+  .input-container:has(input[readonly]) {
+    background-color: $modus-input-readonly-bg;
+    border-bottom-color: $modus-input-disabled-bottom-line-color;
+  }
+
   .sub-text {
     font-size: $rem-11px;
     margin-top: $rem-4px;

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.vars.scss
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.vars.scss
@@ -16,3 +16,6 @@ $modus-input-disabled-bg: var(--modus-input-disabled-bg, #e0e1e9) !default;
 $modus-input-disabled-border-color: var(--modus-input-disabled-border-color, #e0e1e9) !default;
 $modus-input-disabled-bottom-line-color: var(--modus-input-disabled-bottom-line-color, #a3a6b1) !default;
 $modus-input-disabled-color: var(--modus-input-disabled-color, #a3a6b1) !default;
+
+// Readonly
+$modus-input-readonly-bg: var(--modus-input-readonly-bg, #e0e1e9) !default;

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -537,6 +537,9 @@
   --modus-input-disabled-border-color: #464b5266;
   --modus-input-disabled-color: #7d808d66;
 
+  // Input read-only
+  --modus-input-readonly-bg: #353a40;
+
   // Checkbox and Radio button Inputs
   --modus-check-input-bg: transparent;
   --modus-check-input-disabled-opacity: 0.4;

--- a/stencil-workspace/src/sample.html
+++ b/stencil-workspace/src/sample.html
@@ -239,7 +239,7 @@
         <modus-button color="primary" id="toggle_file-dropzone" style="padding: 10px">Toggle File upload dropzone</modus-button>
       </div>
       <div>
-        <modus-file-dropzone aria-Label="dropzone" description="File dropzone description" dropzone-Height="175px" dropzone-Width="400px" label="Dropzone Label" multiple="false"> </modus-file-dropzone>
+        <modus-file-dropzone aria-label="dropzone" description="File dropzone description" dropzone-Height="175px" dropzone-Width="400px" label="Dropzone Label" multiple="false"> </modus-file-dropzone>
       </div>
       <div>
         <modus-button color="primary" id="toggle_message" style="padding: 10px">Toggle Messages theme</modus-button>
@@ -464,6 +464,7 @@
           <modus-data-table />
         </div>
       </div>
+    </div>
     </div>
   </body>
   <script>


### PR DESCRIPTION
## Description

Set background color for readonly text input. This works good in all modern browsers, but it does use the :has selector which is relatively new. (REF: https://caniuse.com/css-has).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v119. Tested in light and dark mode.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
