### PR TITLE
Fixed issue with manual pagination

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
@@ -394,7 +394,6 @@ describe('modus-table', () => {
     const component = await page.find('modus-table');
 
     component.setProperty('columns', MockColumns);
-    component.setProperty('manualPaginationOptions', {});
     component.setProperty('data', MockData);
     component.setProperty('pagination', false);
 

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -157,6 +157,10 @@ export class ModusTable {
       newVal?.currentPageSize !== oldVal?.currentPageSize
     ) {
       this.tableCore?.setOptions('pageCount', newVal.pageCount);
+      this.tableCore?.setState('pagination', {
+        pageIndex: newVal.currentPageIndex - 1,
+        pageSize: newVal.currentPageSize
+      });
       this.manualPaginationOptions = { ...newVal };
     }
   }

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -156,7 +156,7 @@ export class ModusTable {
       newVal?.currentPageIndex !== oldVal?.currentPageIndex ||
       newVal?.currentPageSize !== oldVal?.currentPageSize
     ) {
-      this.tableCore.setOptions('pageCount', newVal.pageCount);
+      this.tableCore?.setOptions('pageCount', newVal.pageCount);
       this.manualPaginationOptions = { ...newVal };
     }
   }
@@ -169,16 +169,16 @@ export class ModusTable {
   ) {
     if (newVal?.currentSortingState.length === 0) {
       if (oldVal && oldVal.currentSortingState.length > 0) {
-        this.tableCore.setOptions('manualSorting', true);
-        this.tableCore.setState('sorting', newVal.currentSortingState);
+        this.tableCore?.setOptions('manualSorting', true);
+        this.tableCore?.setState('sorting', newVal.currentSortingState);
         this.manualSortingOptions = { ...newVal };
       }
     } else if (
       newVal?.currentSortingState[0]?.id !== oldVal?.currentSortingState[0]?.id ||
       newVal?.currentSortingState[0]?.desc !== oldVal?.currentSortingState[0]?.desc
     ) {
-      this.tableCore.setOptions('manualSorting', true);
-      this.tableCore.setState('sorting', newVal.currentSortingState);
+      this.tableCore?.setOptions('manualSorting', true);
+      this.tableCore?.setState('sorting', newVal.currentSortingState);
       this.manualSortingOptions = { ...newVal };
     }
   }

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -152,9 +152,9 @@ export class ModusTable {
     oldVal: ModusTableManualPaginationOptions
   ) {
     if (
-      newVal.pageCount !== oldVal.pageCount ||
-      newVal.currentPageIndex !== oldVal.currentPageIndex ||
-      newVal.currentPageSize !== oldVal.currentPageSize
+      newVal?.pageCount !== oldVal?.pageCount ||
+      newVal?.currentPageIndex !== oldVal?.currentPageIndex ||
+      newVal?.currentPageSize !== oldVal?.currentPageSize
     ) {
       this.tableCore.setOptions('pageCount', newVal.pageCount);
       this.manualPaginationOptions = { ...newVal };
@@ -169,7 +169,7 @@ export class ModusTable {
   ) {
     if (newVal?.currentSortingState.length === 0) {
       if (oldVal && oldVal.currentSortingState.length > 0) {
-        this.tableCore.setOptions('manualPagination', true);
+        this.tableCore.setOptions('manualSorting', true);
         this.tableCore.setState('sorting', newVal.currentSortingState);
         this.manualSortingOptions = { ...newVal };
       }
@@ -177,7 +177,7 @@ export class ModusTable {
       newVal?.currentSortingState[0]?.id !== oldVal?.currentSortingState[0]?.id ||
       newVal?.currentSortingState[0]?.desc !== oldVal?.currentSortingState[0]?.desc
     ) {
-      this.tableCore.setOptions('manualPagination', true);
+      this.tableCore.setOptions('manualSorting', true);
       this.tableCore.setState('sorting', newVal.currentSortingState);
       this.manualSortingOptions = { ...newVal };
     }

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-pagination.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-pagination.tsx
@@ -13,16 +13,18 @@ export const ModusTablePagination: FunctionalComponent<ModusTablePaginationProps
   context: { tableInstance: table, pageSizeList, data, manualPaginationOptions },
 }) => {
   const { options, getState, getPageCount, getExpandedRowModel, setPageIndex, setPageSize } = table;
-  const { pageIndex, pageSize: pageSizeState } = getState().pagination;
+  const { pageIndex: pageIndexState, pageSize: pageSizeState } = getState().pagination;
   const optionsList = pageSizeList.map((option) => ({ display: option }));
 
   let pageSize = pageSizeState;
+  let pageIndex = pageIndexState;
   let totalCount = data.length ?? 0;
   let activePage = 1;
 
   if (manualPaginationOptions) {
     const { totalRecords, currentPageSize } = manualPaginationOptions;
     activePage = manualPaginationOptions?.currentPageIndex ?? activePage;
+    pageIndex = activePage - 1;
     pageSize = currentPageSize ?? 0;
     totalCount = totalRecords ?? 0;
   }
@@ -52,7 +54,7 @@ export const ModusTablePagination: FunctionalComponent<ModusTablePaginationProps
           <span>-</span>
           <span>
             {pageIndex + 1 === getPageCount()
-              ? options.paginateExpandedRows
+              ? !manualPaginationOptions && options.paginateExpandedRows
                 ? getExpandedRowModel().rows.length
                 : totalCount
               : (pageIndex + 1) * pageSize}

--- a/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-table/modus-table.stories.tsx
@@ -50,7 +50,7 @@ function makeData(...lens): object[] {
 function initializeTable(columns, data, pageSizeList, toolbarOptions, displayOptions, rowSelectionOptions, rowActions, manualPaginationOptions, manualSortingOptions) {
   const tag = document.createElement('script');
   tag.innerHTML = `
-  var modusTable = document.querySelector('modus-table')
+  var modusTable = document.querySelector('modus-table');
   modusTable.columns = ${JSON.stringify(columns)};
   modusTable.data = ${JSON.stringify(data)};
   modusTable.pageSizeList = ${JSON.stringify(pageSizeList)};
@@ -61,8 +61,10 @@ function initializeTable(columns, data, pageSizeList, toolbarOptions, displayOpt
   modusTable.manualPaginationOptions = ${JSON.stringify(manualPaginationOptions)};
   modusTable.manualSortingOptions = ${JSON.stringify(manualSortingOptions)};
 
+  let globalData = ${JSON.stringify(data)};
+
   if(!!modusTable.manualSortingOptions){
-    let currentData = modusTable.data;
+    let currentData = globalData;
     const accessorKey = getAccessortKey(modusTable.columns, modusTable.manualSortingOptions.currentSortingState[0].id);
     currentData.sort(compareValues(accessorKey, modusTable.manualSortingOptions.currentSortingState[0].desc));
     if(!!modusTable.manualPaginationOptions){
@@ -71,6 +73,11 @@ function initializeTable(columns, data, pageSizeList, toolbarOptions, displayOpt
     } else {
       modusTable.data = currentData;
     }
+  } else if(!!modusTable.manualPaginationOptions){
+    modusTable.data = globalData.slice((modusTable.manualPaginationOptions.currentPageIndex - 1) * modusTable.manualPaginationOptions.currentPageSize,
+      modusTable.manualPaginationOptions.currentPageIndex * modusTable.manualPaginationOptions.currentPageSize);
+  } else {
+    modusTable.data = globalData;
   }
 
   function compareValues(key, desc) {
@@ -633,15 +640,15 @@ export const Pagination = Template.bind({});
 Pagination.args = { ...DefaultArgs, pagination: true, data: makeData(50), pageSizeList: [5, 10, 50] };
 
 export const ManualPagination = Template.bind({});
-
 ManualPagination.args = {
   ...DefaultArgs,
   pagination: true,
+  data: makeData(50),
   manualPaginationOptions: {
     currentPageIndex: 1,
     currentPageSize: 5,
-    pageCount: DefaultArgs.data.length / 5,
-    totalRecords: DefaultArgs.data.length,
+    pageCount: 10,
+    totalRecords: 50,
   },
   pageSizeList: [5, 10, 50],
 };


### PR DESCRIPTION
## Description

- Fixed issue when the manualPaginationOptions value is undefined and the property is set to something else. Code was throwing an exception trying to access oldVal.pageCount value in the conditional statement.
- Fixed typo setting manualPagination option instead of manualSorting in the onManualSortOptionsChange watch. 

References #1908

NAV-409

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

All test passed. The manual pagination test was updated to ensure the initial value is undefined. 

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
