### PR TITLE
fix the input height

### DIFF
--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -18,8 +18,7 @@
   }
 
   .label-container {
-    display: flex;
-
+    display: inline-block;
     .required {
       bottom: $rem-1px;
       color: $modus-input-validation-error-color;


### PR DESCRIPTION
#1722

## Description

Display flex was increaseing the height by 1 px when the required field is enabled. So I changed it to display inlineblock in the input.

References #1722

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Manually inspected the height of the input control with required flag turned off and on

## Checklist

- [ X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings


## Screenshot
![alignment](https://github.com/trimble-oss/modus-web-components/assets/60956922/90290087-8287-41c7-b0e4-ecfcd1b5d0d3)

