### PR TITLE
List: Add support for sub-text in list item

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -501,7 +501,7 @@ export declare interface ModusList extends Components.ModusList {}
 
 
 @ProxyCmp({
-  inputs: ['borderless', 'disabled', 'selected', 'size', 'subText', 'type'],
+  inputs: ['borderless', 'disabled', 'selected', 'size', 'subText', 'type', 'wrapSubText'],
   methods: ['focusItem']
 })
 @Component({
@@ -509,7 +509,7 @@ export declare interface ModusList extends Components.ModusList {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['borderless', 'disabled', 'selected', 'size', 'subText', 'type'],
+  inputs: ['borderless', 'disabled', 'selected', 'size', 'subText', 'type', 'wrapSubText'],
 })
 export class ModusListItem {
   protected el: HTMLElement;

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -501,7 +501,7 @@ export declare interface ModusList extends Components.ModusList {}
 
 
 @ProxyCmp({
-  inputs: ['borderless', 'disabled', 'selected', 'size', 'type'],
+  inputs: ['borderless', 'disabled', 'selected', 'size', 'subText', 'type'],
   methods: ['focusItem']
 })
 @Component({
@@ -509,7 +509,7 @@ export declare interface ModusList extends Components.ModusList {}
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['borderless', 'disabled', 'selected', 'size', 'type'],
+  inputs: ['borderless', 'disabled', 'selected', 'size', 'subText', 'type'],
 })
 export class ModusListItem {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -583,6 +583,10 @@ export namespace Components {
           * (optional) The type of list item
          */
         "type": string;
+        /**
+          * (optional) Whether to wrap the sub text.
+         */
+        "wrapSubText": true | false;
     }
     interface ModusMessage {
         /**
@@ -2601,6 +2605,10 @@ declare namespace LocalJSX {
           * (optional) The type of list item
          */
         "type"?: string;
+        /**
+          * (optional) Whether to wrap the sub text.
+         */
+        "wrapSubText"?: true | false;
     }
     interface ModusMessage {
         /**

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -576,6 +576,10 @@ export namespace Components {
          */
         "size": 'condensed' | 'large' | 'standard';
         /**
+          * (optional) Whether to show Subtext below the Slot content or not
+         */
+        "subText": string;
+        /**
           * (optional) The type of list item
          */
         "type": string;
@@ -2585,6 +2589,10 @@ declare namespace LocalJSX {
           * (optional) The size of list item
          */
         "size"?: 'condensed' | 'large' | 'standard';
+        /**
+          * (optional) Whether to show Subtext below the Slot content or not
+         */
+        "subText"?: string;
         /**
           * (optional) The type of list item
          */

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.e2e.ts
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.e2e.ts
@@ -78,4 +78,18 @@ describe('modus-list-item', () => {
     await page.waitForChanges();
     expect(itemClick).not.toHaveReceivedEvent();
   });
+
+  it('should show subText below slot in the list item', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-list-item></modus-list-item>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-list-item');
+    component.setProperty('subText', 'test');
+    await page.waitForChanges();
+
+    const element = await page.find('modus-list-item >>> li >>> .sub-text');
+    expect(element.textContent).toEqual('test');
+  });
 });

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -7,13 +7,14 @@ li {
   color: $modus-list-item-color;
   display: flex;
   fill: $modus-list-item-color;
-  flex-wrap: wrap;
   font-family: $primary-font;
   font-size: $rem-16px;
   min-height: $list-group-item-height;
   padding: 0 $rem-16px;
 
   .slot {
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -40,6 +41,10 @@ li {
     min-height: $list-group-item-height-sm;
   }
 
+  &.standard {
+    font-size: $rem-14px;
+  }
+
   &.large {
     min-height: $list-group-item-height-lg;
   }
@@ -58,7 +63,6 @@ li {
   }
 
   .sub-text {
-    flex-basis: 100%;
-    font-size: 12px;
+    font-size: $rem-12px;
   }
 }

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -8,19 +8,38 @@ li {
   display: flex;
   fill: $modus-list-item-color;
   font-family: $primary-font;
-  font-size: $rem-14px;
-  min-height: $list-group-item-height;
-  padding: 0 $rem-16px;
+  gap: $rem-16px;
+  min-height: $rem-40px;
+  padding: $rem-6px $rem-12px;
 
-  .slot {
+  .text-container {
     display: flex;
     flex-direction: column;
+    flex-grow: 1;
+    justify-content: center;
+    min-width: 0;
+  }
+
+  .slot,
+  .sub-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
+  .slot {
+    font-size: $rem-14px;
+    line-height: $rem-18px;
+  }
+
+  .sub-text {
+    display: block;
+    font-size: $rem-12px;
+    line-height: $rem-16px;
+  }
+
   .icon-check {
+    flex-shrink: 0;
     margin-left: auto;
   }
 
@@ -37,17 +56,24 @@ li {
   }
 
   &.small {
-    font-size: $rem-12px;
-    min-height: $list-group-item-height-sm;
-  }
+    gap: $rem-10px;
+    min-height: $rem-32px;
+    padding: $rem-4px $rem-10px;
 
-  &.standard {
-    font-size: $rem-14px;
+    .slot {
+      font-size: $rem-12px;
+      line-height: $rem-14px;
+    }
+
+    .sub-text {
+      font-size: $rem-10px;
+      line-height: $rem-12px;
+    }
   }
 
   &.large {
-    font-size: $rem-16px;
-    min-height: $list-group-item-height-lg;
+    min-height: $rem-48px;
+    padding: $rem-10px $rem-16px;
   }
 
   &.disabled {
@@ -61,9 +87,5 @@ li {
     border: 1px solid $modus-list-item-selected-border-color;
     color: $modus-list-item-color;
     fill: $modus-list-item-color;
-  }
-
-  .sub-text {
-    font-size: $rem-12px;
   }
 }

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -9,7 +9,7 @@ li {
   fill: $modus-list-item-color;
   font-family: $primary-font;
   gap: $rem-16px;
-  min-height: $rem-40px;
+  min-height: $rem-26px;
   padding: $rem-6px $rem-12px;
 
   .text-container {
@@ -20,22 +20,28 @@ li {
     min-width: 0;
   }
 
-  .slot,
-  .sub-text {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
   .slot {
     font-size: $rem-14px;
     line-height: $rem-18px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .sub-text {
     display: block;
     font-size: $rem-12px;
     line-height: $rem-16px;
+  }
+
+  .wrap {
+    word-wrap: break-word;
+  }
+
+  .no-wrap {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .icon-check {
@@ -57,7 +63,7 @@ li {
 
   &.small {
     gap: $rem-10px;
-    min-height: $rem-32px;
+    min-height: $rem-22px;
     padding: $rem-4px $rem-10px;
 
     .slot {
@@ -72,7 +78,7 @@ li {
   }
 
   &.large {
-    min-height: $rem-48px;
+    min-height: $rem-26px;
     padding: $rem-10px $rem-16px;
   }
 

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -4,12 +4,14 @@ li {
   align-items: center;
   background-color: $modus-list-item-bg;
   border: 1px solid $modus-list-item-border-color;
+  box-sizing: border-box;
   color: $modus-list-item-color;
   display: flex;
   fill: $modus-list-item-color;
   font-family: $primary-font;
   gap: $rem-16px;
-  min-height: $rem-26px;
+  justify-content: space-between;
+  min-height: $rem-40px;
   padding: $rem-6px $rem-12px;
 
   .text-container {
@@ -63,7 +65,7 @@ li {
 
   &.small {
     gap: $rem-10px;
-    min-height: $rem-22px;
+    min-height: $rem-32px;
     padding: $rem-4px $rem-10px;
 
     .slot {
@@ -78,7 +80,7 @@ li {
   }
 
   &.large {
-    min-height: $rem-26px;
+    min-height: $rem-48px;
     padding: $rem-10px $rem-16px;
   }
 

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -7,6 +7,7 @@ li {
   color: $modus-list-item-color;
   display: flex;
   fill: $modus-list-item-color;
+  flex-wrap: wrap;
   font-family: $primary-font;
   font-size: $rem-16px;
   min-height: $list-group-item-height;
@@ -54,5 +55,10 @@ li {
     border: 1px solid $modus-list-item-selected-border-color;
     color: $modus-list-item-color;
     fill: $modus-list-item-color;
+  }
+
+  .sub-text {
+    flex-basis: 100%;
+    font-size: 12px;
   }
 }

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.spec.ts
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.spec.ts
@@ -11,9 +11,11 @@ describe('modus-list-item', () => {
       <modus-list-item>
         <mock:shadow-root>
           <li class='standard' tabindex="0">
+           <div class="text-container">
             <span class='slot'>
               <slot></slot>
             </span>
+           </div>  
           </li>
         </mock:shadow-root>
       </modus-list-item>
@@ -29,9 +31,11 @@ describe('modus-list-item', () => {
       <modus-list-item>
         <mock:shadow-root>
           <li class='standard' tabindex="0">
+           <div class="text-container">
             <span class='slot'>
               <slot></slot>
             </span>
+           </div>  
           </li>
         </mock:shadow-root>
         List Item

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
@@ -23,6 +23,9 @@ export class ModusListItem {
   /** (optional) Whether to show Subtext below the Slot content or not  */
   @Prop() subText: string;
 
+  /** (optional) Whether to wrap the sub text. */
+  @Prop() wrapSubText: boolean;
+
   /** (optional) The type of list item */
   @Prop() type = 'standard'; // Future support for 'checkbox' | 'icon' | 'menu' | 'standard' | 'switchLeft' | 'switchRight'
 
@@ -64,8 +67,8 @@ export class ModusListItem {
         <div class="text-container">
           <span class="slot">
             <slot />
-            {this.subText && <span class="sub-text">{this.subText}</span>}
           </span>
+          {this.subText && <span class={'sub-text ' + (this.wrapSubText ? 'wrap' : 'no-wrap')}>{this.subText}</span>}
         </div>
         {this.selected && <IconCheck size={iconCheckSize} />}
       </li>

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
@@ -63,9 +63,9 @@ export class ModusListItem {
         onKeyDown={(e) => this.handleKeydown(e)}>
         <span class="slot">
           <slot />
+          {this.subText && <span class="sub-text">{this.subText}</span>}
         </span>
         {this.selected && <IconCheck size={iconCheckSize} />}
-        {this.subText && <span class="sub-text">{this.subText}</span>}
       </li>
     );
   }

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
@@ -61,10 +61,12 @@ export class ModusListItem {
         tabIndex={this.disabled ? -1 : 0}
         onClick={() => (!this.disabled ? this.itemClick.emit() : null)}
         onKeyDown={(e) => this.handleKeydown(e)}>
-        <span class="slot">
-          <slot />
-          {this.subText && <span class="sub-text">{this.subText}</span>}
-        </span>
+        <div class="text-container">
+          <span class="slot">
+            <slot />
+            {this.subText && <span class="sub-text">{this.subText}</span>}
+          </span>
+        </div>
         {this.selected && <IconCheck size={iconCheckSize} />}
       </li>
     );

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
@@ -24,7 +24,7 @@ export class ModusListItem {
   @Prop() subText: string;
 
   /** (optional) Whether to wrap the sub text. */
-  @Prop() wrapSubText: boolean;
+  @Prop() wrapSubText: true | false = true;
 
   /** (optional) The type of list item */
   @Prop() type = 'standard'; // Future support for 'checkbox' | 'icon' | 'menu' | 'standard' | 'switchLeft' | 'switchRight'

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.tsx
@@ -20,6 +20,9 @@ export class ModusListItem {
   /** (optional) The size of list item */
   @Prop() size: 'condensed' | 'large' | 'standard' = 'standard';
 
+  /** (optional) Whether to show Subtext below the Slot content or not  */
+  @Prop() subText: string;
+
   /** (optional) The type of list item */
   @Prop() type = 'standard'; // Future support for 'checkbox' | 'icon' | 'menu' | 'standard' | 'switchLeft' | 'switchRight'
 
@@ -62,6 +65,7 @@ export class ModusListItem {
           <slot />
         </span>
         {this.selected && <IconCheck size={iconCheckSize} />}
+        {this.subText && <span class="sub-text">{this.subText}</span>}
       </li>
     );
   }

--- a/stencil-workspace/src/components/modus-list-item/readme.md
+++ b/stencil-workspace/src/components/modus-list-item/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                                                      | Type                                   | Default      |
-| ------------ | ------------ | ---------------------------------------------------------------- | -------------------------------------- | ------------ |
-| `borderless` | `borderless` | (optional) Whether the list item has a border or not             | `boolean`                              | `undefined`  |
-| `disabled`   | `disabled`   | (optional) Disables the list item                                | `boolean`                              | `undefined`  |
-| `selected`   | `selected`   | (optional) The selected state of the list item                   | `boolean`                              | `undefined`  |
-| `size`       | `size`       | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
-| `subText`    | `sub-text`   | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
-| `type`       | `type`       | (optional) The type of list item                                 | `string`                               | `'standard'` |
+| Property      | Attribute       | Description                                                      | Type                                   | Default      |
+| ------------- | --------------- | ---------------------------------------------------------------- | -------------------------------------- | ------------ |
+| `borderless`  | `borderless`    | (optional) Whether the list item has a border or not             | `boolean`                              | `undefined`  |
+| `disabled`    | `disabled`      | (optional) Disables the list item                                | `boolean`                              | `undefined`  |
+| `selected`    | `selected`      | (optional) The selected state of the list item                   | `boolean`                              | `undefined`  |
+| `size`        | `size`          | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
+| `subText`     | `sub-text`      | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
+| `type`        | `type`          | (optional) The type of list item                                 | `string`                               | `'standard'` |
+| `wrapSubText` | `wrap-sub-text` | (optional) Whether to wrap the sub text.                         | `boolean`                              | `undefined`  |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-list-item/readme.md
+++ b/stencil-workspace/src/components/modus-list-item/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property     | Attribute    | Description                                          | Type                                   | Default      |
-| ------------ | ------------ | ---------------------------------------------------- | -------------------------------------- | ------------ |
-| `borderless` | `borderless` | (optional) Whether the list item has a border or not | `boolean`                              | `undefined`  |
-| `disabled`   | `disabled`   | (optional) Disables the list item                    | `boolean`                              | `undefined`  |
-| `selected`   | `selected`   | (optional) The selected state of the list item       | `boolean`                              | `undefined`  |
-| `size`       | `size`       | (optional) The size of list item                     | `"condensed" \| "large" \| "standard"` | `'standard'` |
-| `type`       | `type`       | (optional) The type of list item                     | `string`                               | `'standard'` |
+| Property     | Attribute    | Description                                                      | Type                                   | Default      |
+| ------------ | ------------ | ---------------------------------------------------------------- | -------------------------------------- | ------------ |
+| `borderless` | `borderless` | (optional) Whether the list item has a border or not             | `boolean`                              | `undefined`  |
+| `disabled`   | `disabled`   | (optional) Disables the list item                                | `boolean`                              | `undefined`  |
+| `selected`   | `selected`   | (optional) The selected state of the list item                   | `boolean`                              | `undefined`  |
+| `size`       | `size`       | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
+| `subText`    | `sub-text`   | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
+| `type`       | `type`       | (optional) The type of list item                                 | `string`                               | `'standard'` |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-list-item/readme.md
+++ b/stencil-workspace/src/components/modus-list-item/readme.md
@@ -15,7 +15,7 @@
 | `size`        | `size`          | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
 | `subText`     | `sub-text`      | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
 | `type`        | `type`          | (optional) The type of list item                                 | `string`                               | `'standard'` |
-| `wrapSubText` | `wrap-sub-text` | (optional) Whether to wrap the sub text.                         | `boolean`                              | `undefined`  |
+| `wrapSubText` | `wrap-sub-text` | (optional) Whether to wrap the sub text.                         | `boolean`                              | `true`       |
 
 
 ## Events

--- a/stencil-workspace/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
@@ -36,7 +36,7 @@ The `<modus-list-item>` utilizes the slot element, allowing you to render your o
   <modus-list-item selected size="condensed"
     >Condensed & Selected</modus-list-item
   >
-  <modus-list-item>Default</modus-list-item>
+  <modus-list-item wrap-sub-text="true" sub-text="default">Default</modus-list-item>
   <modus-list-item selected>Selected</modus-list-item>
   <modus-list-item disabled>Disabled</modus-list-item>
   <modus-list-item size="large">Large</modus-list-item>
@@ -49,15 +49,15 @@ The `<modus-list-item>` utilizes the slot element, allowing you to render your o
 
 ##### Modus List Item
 
-| Property     | Attribute    | Description                                                      | Type                                   | Default      |
-| ------------ | ------------ | ---------------------------------------------------------------- | -------------------------------------- | ------------ |
-| `borderless` | `borderless` | (optional) Whether the list item has a border or not             | `boolean`                              | `undefined`  |
-| `disabled`   | `disabled`   | (optional) Disables the list item                                | `boolean`                              | `undefined`  |
-| `selected`   | `selected`   | (optional) The selected state of the list item                   | `boolean`                              | `undefined`  |
-| `size`       | `size`       | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
-| `subText`    | `sub-text`   | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
-| `type`       | `type`       | (optional) The type of list item                                 | `string`                               | `'standard'` |
-
+| Property      | Attribute       | Description                                                      | Type                                   | Default      |
+| ------------- | --------------- | ---------------------------------------------------------------- | -------------------------------------- | ------------ |
+| `borderless`  | `borderless`    | (optional) Whether the list item has a border or not             | `boolean`                              | `undefined`  |
+| `disabled`    | `disabled`      | (optional) Disables the list item                                | `boolean`                              | `undefined`  |
+| `selected`    | `selected`      | (optional) The selected state of the list item                   | `boolean`                              | `undefined`  |
+| `size`        | `size`          | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
+| `subText`     | `sub-text`      | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
+| `type`        | `type`          | (optional) The type of list item                                 | `string`                               | `'standard'` |
+| `wrapSubText` | `wrap-sub-text` | (optional) Whether to wrap the sub text.                         | `boolean`                              | `undefined`  |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
@@ -57,7 +57,7 @@ The `<modus-list-item>` utilizes the slot element, allowing you to render your o
 | `size`        | `size`          | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
 | `subText`     | `sub-text`      | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
 | `type`        | `type`          | (optional) The type of list item                                 | `string`                               | `'standard'` |
-| `wrapSubText` | `wrap-sub-text` | (optional) Whether to wrap the sub text.                         | `boolean`                              | `undefined`  |
+| `wrapSubText` | `wrap-sub-text` | (optional) Whether to wrap the sub text.                         | `boolean`                              | `true`       |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-list/modus-list-storybook-docs.mdx
@@ -9,6 +9,7 @@ The `<modus-list-item>` utilizes the slot element, allowing you to render your o
 #### Implementation Details
 
 - To support a wide variety of selection methods (single, multi, etc) it is up to the implementation to control which items are selected.
+- If `sub-text` is provided, it shows below the slot dynamically
 
 ### Default
 
@@ -48,13 +49,14 @@ The `<modus-list-item>` utilizes the slot element, allowing you to render your o
 
 ##### Modus List Item
 
-| Property     | Attribute    | Description                                          | Type                                   | Default      |
-| ------------ | ------------ | ---------------------------------------------------- | -------------------------------------- | ------------ |
-| `borderless` | `borderless` | (optional) Whether the list item has a border or not | `boolean`                              | `undefined`  |
-| `disabled`   | `disabled`   | (optional) Disables the list item                    | `boolean`                              | `undefined`  |
-| `selected`   | `selected`   | (optional) The selected state of the list item       | `boolean`                              | `undefined`  |
-| `size`       | `size`       | (optional) The size of list item                     | `"condensed", "large", "standard"` | `'standard'` |
-| `type`       | `type`       | (optional) The type of list item                     | `string`                               | `'standard'` |
+| Property     | Attribute    | Description                                                      | Type                                   | Default      |
+| ------------ | ------------ | ---------------------------------------------------------------- | -------------------------------------- | ------------ |
+| `borderless` | `borderless` | (optional) Whether the list item has a border or not             | `boolean`                              | `undefined`  |
+| `disabled`   | `disabled`   | (optional) Disables the list item                                | `boolean`                              | `undefined`  |
+| `selected`   | `selected`   | (optional) The selected state of the list item                   | `boolean`                              | `undefined`  |
+| `size`       | `size`       | (optional) The size of list item                                 | `"condensed" \| "large" \| "standard"` | `'standard'` |
+| `subText`    | `sub-text`   | (optional) Whether to show Subtext below the Slot content or not | `string`                               | `undefined`  |
+| `type`       | `type`       | (optional) The type of list item                                 | `string`                               | `'standard'` |
 
 
 ### DOM Events

--- a/stencil-workspace/storybook/stories/components/modus-list/modus-list.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-list/modus-list.stories.tsx
@@ -4,12 +4,20 @@ import { html } from 'lit-html';
 
 export default {
   title: 'Components/List',
+  argTypes: {
+    subText: {
+      description: "set the sub-text for the list-item",
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+  },
   parameters: {
     docs: {
       page: docs,
     },
     controls: {
-      disabled: true,
+      expanded: true,
     },
     options: {
       isToolshown: true,
@@ -17,11 +25,15 @@ export default {
   },
 };
 
-const Template = () => html`
+const Template = ({ subText }) => html`
   <modus-list>
-    <modus-list-item>Default</modus-list-item>
+    <modus-list-item sub-text=${subText}>Default</modus-list-item>
     <modus-list-item selected>Selected</modus-list-item>
     <modus-list-item disabled>Disabled</modus-list-item>
   </modus-list>
 `;
 export const Default = Template.bind({});
+
+Default.args = {
+  subText: 'default'
+};

--- a/stencil-workspace/storybook/stories/components/modus-list/modus-list.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-list/modus-list.stories.tsx
@@ -11,6 +11,12 @@ export default {
         type: { summary: 'string' },
       },
     },
+    wrapSubText: {
+      description: 'Whether to wrap the sub text',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
   },
   parameters: {
     docs: {
@@ -25,9 +31,9 @@ export default {
   },
 };
 
-const Template = ({ subText }) => html`
+const Template = ({ subText, wrapSubText }) => html`
   <modus-list>
-    <modus-list-item sub-text=${subText}>Default</modus-list-item>
+    <modus-list-item wrap-sub-text=${wrapSubText} sub-text=${subText}>Default</modus-list-item>
     <modus-list-item selected>Selected</modus-list-item>
     <modus-list-item disabled>Disabled</modus-list-item>
   </modus-list>
@@ -35,5 +41,6 @@ const Template = ({ subText }) => html`
 export const Default = Template.bind({});
 
 Default.args = {
-  subText: 'default'
-};
+  subText: 'default',
+  wrapSubText: true
+}


### PR DESCRIPTION
Added support for sub-text in the modus list item component

## Description

Added support for sub-text in the modus list item component

References #1957 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

We have to provide a value for the sub-text property and that value should be rendered below the slot in the modus list item.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
