### PR TITLE
Fix for font-size for list item

### DIFF
--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -8,7 +8,7 @@ li {
   display: flex;
   fill: $modus-list-item-color;
   font-family: $primary-font;
-  font-size: $rem-16px;
+  font-size: $rem-14px;
   min-height: $list-group-item-height;
   padding: 0 $rem-16px;
 
@@ -40,6 +40,7 @@ li {
   }
 
   &.large {
+    font-size: $rem-16px;
     min-height: $list-group-item-height-lg;
   }
 


### PR DESCRIPTION
Default list-item font-size was 16px but should be 14px. Large size remains the same (16px).

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

References #<!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
