### PR TITLE
Fix miscellaneous Navbar issues

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -395,14 +395,14 @@ export declare interface ModusDatePicker extends Components.ModusDatePicker {}
 
 
 @ProxyCmp({
-  inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'toggleElementId']
+  inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'showDropdownListBorder', 'toggleElementId']
 })
 @Component({
   selector: 'modus-dropdown',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'toggleElementId'],
+  inputs: ['animateList', 'ariaLabel', 'customPlacement', 'disabled', 'placement', 'showDropdownListBorder', 'toggleElementId'],
 })
 export class ModusDropdown {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -483,6 +483,10 @@ export namespace Components {
          */
         "placement": 'top' | 'right' | 'bottom' | 'left';
         /**
+          * (optional) Whether to show the dropdown list's border.
+         */
+        "showDropdownListBorder": boolean;
+        /**
           * (required) The element id that the list renders near and that triggers the toggling of the list.
          */
         "toggleElementId": string;
@@ -2521,6 +2525,10 @@ declare namespace LocalJSX {
           * (optional) The placement of the dropdown in related to the toggleElement.
          */
         "placement"?: 'top' | 'right' | 'bottom' | 'left';
+        /**
+          * (optional) Whether to show the dropdown list's border.
+         */
+        "showDropdownListBorder"?: boolean;
         /**
           * (required) The element id that the list renders near and that triggers the toggling of the list.
          */

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.e2e.ts
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.e2e.ts
@@ -49,6 +49,26 @@ describe('modus-dropdown', () => {
     expect(element).toHaveClass('top');
   });
 
+  it('renders changes to the showDropdownListBorder prop', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id' show-dropdown-list-border="true">
+        <modus-button id='toggle-id'>Dropdown</modus-button>
+        <modus-list>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+    const component = await page.find('modus-dropdown');
+    const element = await page.find('modus-dropdown >>> .dropdown-list');
+    expect(element).toHaveClass('list-border');
+
+    component.setProperty('showDropdownListBorder', 'false');
+    await page.waitForChanges();
+    expect(element).not.toHaveClass('list-border');
+  });
+
   it('renders changes to div.dropdown-list on toggle', async () => {
     const page = await newE2EPage();
 

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
@@ -9,7 +9,6 @@
   }
 
   .dropdown-list {
-    border: 1px solid $modus-dropdown-list-border-color;
     border-collapse: collapse;
     border-radius: $rem-1px !important;
     display: none;
@@ -33,6 +32,10 @@
       opacity: 1;
       overflow: visible;
       visibility: visible;
+    }
+
+    &.list-border {
+      border: 1px solid $modus-dropdown-list-border-color;
     }
 
     &.top {

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.spec.ts
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.spec.ts
@@ -15,7 +15,7 @@ describe('modus-dropdown', () => {
         <mock:shadow-root>
           <div class="dropdown" role="listbox">
             <slot name='dropdownToggle'></slot>
-            <div class='bottom dropdown-list hidden' style='left: unset; min-width: 0px;'>
+            <div class='bottom dropdown-list hidden list-border' style='left: unset; min-width: 0px;'>
               <slot name='dropdownList'></slot>
             </div>
           </div>

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
@@ -30,6 +30,9 @@ export class ModusDropdown {
   /** (optional) The placement of the dropdown in related to the toggleElement. */
   @Prop() placement: 'top' | 'right' | 'bottom' | 'left' = 'bottom';
 
+  /** (optional) Whether to show the dropdown list's border. */
+  @Prop() showDropdownListBorder = true;
+
   /** (required) The element id that the list renders near and that triggers the toggling of the list. */
   @Prop() toggleElementId: string;
 
@@ -85,8 +88,8 @@ export class ModusDropdown {
 
   render(): unknown {
     const listContainerClass = `dropdown-list ${this.visible ? 'visible' : 'hidden'} ${
-      this.animateList ? 'animate-list' : ''
-    } ${this.classByPlacement.get(this.placement)}`;
+      this.showDropdownListBorder ? 'list-border' : ''
+    } ${this.animateList ? 'animate-list' : ''} ${this.classByPlacement.get(this.placement)}`;
     const left = this.placement === 'right' ? `${this.toggleElement?.offsetWidth}px` : 'unset';
     const width = `${this.toggleElement?.offsetWidth ? this.toggleElement?.offsetWidth : 0}px`;
 

--- a/stencil-workspace/src/components/modus-dropdown/readme.md
+++ b/stencil-workspace/src/components/modus-dropdown/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property          | Attribute           | Description                                                                                      | Type                                                                | Default     |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ----------- |
-| `animateList`     | `animate-list`      | Whether to apply list opening animation.                                                         | `boolean`                                                           | `false`     |
-| `ariaLabel`       | `aria-label`        | (optional) The dropdown's aria-label.                                                            | `string`                                                            | `undefined` |
-| `customPlacement` | --                  | (optional) Determines custom dropdown placement offset.                                          | `{ top?: number; right?: number; bottom?: number; left?: number; }` | `undefined` |
-| `disabled`        | `disabled`          | (optional) Disables the dropdown.                                                                | `boolean`                                                           | `undefined` |
-| `placement`       | `placement`         | (optional) The placement of the dropdown in related to the toggleElement.                        | `"bottom" \| "left" \| "right" \| "top"`                            | `'bottom'`  |
-| `toggleElementId` | `toggle-element-id` | (required) The element id that the list renders near and that triggers the toggling of the list. | `string`                                                            | `undefined` |
+| Property                 | Attribute                   | Description                                                                                      | Type                                                                | Default     |
+| ------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ----------- |
+| `animateList`            | `animate-list`              | Whether to apply list opening animation.                                                         | `boolean`                                                           | `false`     |
+| `ariaLabel`              | `aria-label`                | (optional) The dropdown's aria-label.                                                            | `string`                                                            | `undefined` |
+| `customPlacement`        | --                          | (optional) Determines custom dropdown placement offset.                                          | `{ top?: number; right?: number; bottom?: number; left?: number; }` | `undefined` |
+| `disabled`               | `disabled`                  | (optional) Disables the dropdown.                                                                | `boolean`                                                           | `undefined` |
+| `placement`              | `placement`                 | (optional) The placement of the dropdown in related to the toggleElement.                        | `"bottom" \| "left" \| "right" \| "top"`                            | `'bottom'`  |
+| `showDropdownListBorder` | `show-dropdown-list-border` | (optional) Whether to show the dropdown list's border.                                           | `boolean`                                                           | `true`      |
+| `toggleElementId`        | `toggle-element-id`         | (required) The element id that the list renders near and that triggers the toggling of the list. | `string`                                                            | `undefined` |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.scss
@@ -8,6 +8,7 @@
   cursor: default;
   max-height: 605px;
   overflow-y: auto;
+  padding: $rem-8px;
   width: max-content;
 
   &.reverse {
@@ -63,7 +64,7 @@
   }
 
   .category {
-    border-top: 1px solid $menu-border-color;
+    border-top: $rem-1px solid $menu-border-color;
     color: $menu-color;
     font-size: $rem-12px;
     font-weight: $font-weight-semi-bold;

--- a/stencil-workspace/src/components/modus-navbar/button-list/modus-navbar-button-list.tsx
+++ b/stencil-workspace/src/components/modus-navbar/button-list/modus-navbar-button-list.tsx
@@ -15,7 +15,7 @@ export const ModusNavbarButtonList: FunctionalComponent<{
 
   return navbarButtons.map((button, index) => (
     <div onClick={(event) => onClick(event, button)}>
-      <modus-dropdown toggle-element-id={'navbar-button-' + index}>
+      <modus-dropdown toggle-element-id={'navbar-button-' + index} showDropdownListBorder={false}>
         <div class="navbar-button" id={'navbar-button-' + index} slot="dropdownToggle">
           <span class="navbar-button-icon" tabIndex={0}>
             <modus-tooltip text={button.tooltip?.text} position="bottom">

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -233,6 +233,8 @@ nav {
   }
 
   .product-logo {
+    display: flex;
+    justify-content: center;
     user-select: none;
 
     @media screen and (width > 576px) {

--- a/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.scss
@@ -35,26 +35,27 @@
       justify-content: center;
     }
 
-    .username {
+    .user-details {
       align-items: center;
       display: flex;
-      font-size: $rem-16px;
-      font-weight: $font-weight-semi-bold;
+      flex-direction: column;
       justify-content: center;
-      max-width: 10rem;
-      overflow-wrap: break-word;
-      padding: 0 $rem-4px;
-    }
-
-    .email {
-      align-items: center;
-      display: flex;
-      font-size: $rem-12px;
-      justify-content: center;
+      max-width: 16rem;
       margin-bottom: $rem-16px;
-      max-width: 10rem;
-      overflow-wrap: break-word;
-      padding: 0 $rem-4px;
+
+      .username {
+        font-size: $rem-16px;
+        font-weight: $font-weight-semi-bold;
+        width: fit-content;
+        overflow-wrap: break-word;
+        text-align: center;
+      }
+
+      .email {
+        font-size: $rem-12px;
+        overflow-wrap: anywhere;
+        text-align: center;
+      }
     }
   }
 

--- a/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.tsx
+++ b/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.tsx
@@ -39,7 +39,7 @@ export class ModusNavbarProfileMenu {
           ) : (
             <span class="initials">{this.initials}</span>
           )}
-          <div>
+          <div class="user-details">
             <div class="username">{this.username}</div>
             <div class="email">{this.email}</div>
           </div>

--- a/stencil-workspace/src/components/modus-radio-group/readme.md
+++ b/stencil-workspace/src/components/modus-radio-group/readme.md
@@ -13,7 +13,7 @@
 | `checkedId`    | `checked-id` | The ID of the checked radio button.     | `string`              | `undefined` |
 | `name`         | `name`       | The radio button group name.            | `string`              | `undefined` |
 | `radioButtons` | --           | The radio buttons to render.            | `RadioButton[]`       | `[]`        |
-| `size`         | `size`       | (optional) The size of the radiobutton. | `"medium" , "small"` | `'medium'`  |
+| `size`         | `size`       | (optional) The size of the radiobutton. | `"medium" \| "small"` | `'medium'`  |
 
 
 ## Events

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -15,29 +15,7 @@
     <link rel="stylesheet" src="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" />
   </head>
 
-  <body>
+  <body data-mwc-theme="dark">
     <!-- Test components -->
-    <div>
-    <modus-radio-group checked-id="1" size="small" name="my-group"></modus-radio-group>
-    <modus-radio-group checked-id="1" size="default" name="my-group2"></modus-radio-group>
-    <script>
-      const modusRadioGroup = document.querySelector('modus-radio-group');
-      modusRadioGroup.radioButtons = [
-        {
-          id: '0',
-          label: 'Radio 2',
-        },
-        {
-          id: '1',
-          checked: true,
-          label: 'Radio 2',
-        },
-        {
-          id: '2',
-          label: 'Radio 3',
-        },
-      ];
-    </script>
-    </div>
  </body>
 </html>

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" src="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" />
   </head>
 
-  <body data-mwc-theme="dark">
+  <body data-mwc-theme="light">
     <!-- Test components -->
  </body>
 </html>

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
@@ -37,14 +37,15 @@
 
 ### Properties
 
-| Property          | Attribute           | Description                                                                                      | Type                                                                | Default     |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ----------- |
-| `animateList`     | `animate-list`      | Whether to apply list opening animation.                                                         | `boolean`                                                           | `false`     |
-| `ariaLabel`       | `aria-label`        | (optional) The dropdown's aria-label.                                                            | `string`                                                            | `undefined` |
-| `customPlacement` | --                  | (optional) Determines custom dropdown placement offset.                                          | `{ top?: number; right?: number; bottom?: number; left?: number; }` | `undefined` |
-| `disabled`        | `disabled`          | (optional) Disables the dropdown.                                                                | `boolean`                                                           | `undefined` |
-| `placement`       | `placement`         | (optional) The placement of the dropdown in related to the toggleElement.                        | `"bottom", "left", "right", "top"`                                  | `'bottom'`  |
-| `toggleElementId` | `toggle-element-id` | (required) The element id that the list renders near and that triggers the toggling of the list. | `string`                                                            | `undefined` |
+| Property                 | Attribute                   | Description                                                                                      | Type                                                                | Default     |
+| ------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ----------- |
+| `animateList`            | `animate-list`              | Whether to apply list opening animation.                                                         | `boolean`                                                           | `false`     |
+| `ariaLabel`              | `aria-label`                | (optional) The dropdown's aria-label.                                                            | `string`                                                            | `undefined` |
+| `customPlacement`        | --                          | (optional) Determines custom dropdown placement offset.                                          | `{ top?: number; right?: number; bottom?: number; left?: number; }` | `undefined` |
+| `disabled`               | `disabled`                  | (optional) Disables the dropdown.                                                                | `boolean`                                                           | `undefined` |
+| `placement`              | `placement`                 | (optional) The placement of the dropdown in related to the toggleElement.                        | `"bottom", "left", "right", "top"`                                  | `'bottom'`  |
+| `showDropdownListBorder` | `show-dropdown-list-border` | (optional) Whether to show the dropdown list's border.                                           | `boolean`                                                           | `true`      |
+| `toggleElementId`        | `toggle-element-id`         | (required) The element id that the list renders near and that triggers the toggling of the list. | `string`                                                            | `undefined` |
 
 ### Events
 


### PR DESCRIPTION
## Description

This PR fixes some issues around the Modus Navbar:
- Navbar Buttons using a `<modus-dropdown />` displayed the dropdown list's border. Make this border default but optional using the `showDropdownListBorder` property. 
- Add `8px` of padding to the Navbar's Apps menu
- Fully center the product logo image
- Update Navbar's User menu to handle long name and email centering

### Dropdown and padding
![image](https://github.com/trimble-oss/modus-web-components/assets/84749026/487686b0-3e14-4740-bec5-fde293af75e8)

### Product logo centering
![image](https://github.com/trimble-oss/modus-web-components/assets/84749026/70cad554-1ce1-43f0-b469-9b256b4529cf)

### User menu centering
![image](https://github.com/trimble-oss/modus-web-components/assets/84749026/67f6f03e-ac1a-47b3-8d93-3976bde7dd29)

References #1959

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

## How Has This Been Tested?

Unit/E2e tests.
Manually installed package into our application for verification.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

