### PR TITLE
Fixed uneven width on rowSelection and rowAction columns

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -31,6 +31,7 @@ table {
   font-size: $rem-14px;
   height: fit-content;
   width: 100%;
+  table-layout: fixed;
 
   &.cell-borderless {
     th,

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-header.tsx
@@ -56,7 +56,7 @@ export const ModusTableHeader: FunctionalComponent<ModusTableHeaderProps> = ({
               />
             );
           })}
-          {rowActions.length > 0 && <th class="sticky-right" style={{ width: `${rowActionsLength}px` }}></th>}
+          {rowActions.length > 0 && <th class="sticky-right" style={{ width:'30px'}}></th>}
         </tr>
       ))}
     </thead>

--- a/stencil-workspace/src/components/modus-table/parts/row/selection/modus-table-header-checkbox.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/row/selection/modus-table-header-checkbox.tsx
@@ -14,7 +14,7 @@ export const ModusTableHeaderCheckbox: FunctionalComponent<ModusTableHeaderCheck
     rowSelectionOptions,
   } = context;
   return (
-    <th class="row-checkbox sticky-left">
+    <th class="row-checkbox sticky-left" style={{width:'30px'}}>
       {rowSelectionOptions?.multiple && (
         <modus-checkbox
           ariaLabel="Select all rows"


### PR DESCRIPTION
## Description

1. Fixed uneven width on rowSelection and rowAction columns by making it's width as 30px. This worked fine only after adding table-layout: fixed style. 
2. Please find below attached gif.
![Modus-Bug-UnevenWidth](https://github.com/trimble-oss/modus-web-components/assets/139101668/da2374c4-b6d6-4d05-891a-f2d7572bdec4)
3. Still it not fine when i remove fullWidth and I am looking forward for few hints to fix this too

References #1922 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
