### PR TITLE
Bump follow-redirects to 1.15.4

### DIFF
--- a/.github/workflows/issue-thanks.yml
+++ b/.github/workflows/issue-thanks.yml
@@ -9,12 +9,12 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'coliff' && github.actor != 'egunther39' && github.actor != 'enowak1031' && github.actor != 'msankaran0712' && github.actor != 'soniakaukonen' && github.repository == 'trimble-oss/modus-web-components' }}
+    if: ${{ github.actor != 'cjwinsor' && github.actor != 'coliff' && github.actor != 'egunther39' && github.actor != 'enowak1031' && github.actor != 'msankaran0712' && github.actor != 'rthanga1' && github.repository == 'trimble-oss/modus-web-components' }}
     steps:
       - name: awaiting reply
         uses: actions-cool/issues-helper@v3
         with:
-          actions: "create-comment"
+          actions: 'create-comment'
           body: |
             Hello @${{ github.event.issue.user.login }}! Thanks for opening an issue. The Modus core team will get back to you soon (usually within 24-hours) and provide guidance on how to proceed. Contributors are welcome to participate in the discussion and provide their input on how to best solve the issue, and even submit a PR if they want to.
 

--- a/angular-workspace/ng16/package-lock.json
+++ b/angular-workspace/ng16/package-lock.json
@@ -279,6 +279,34 @@
         }
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/vite/node_modules/postcss": {
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.1601.6",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1601.6.tgz",
@@ -5912,9 +5940,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {
@@ -8263,9 +8291,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true,
       "funding": [
         {
@@ -12022,6 +12050,19 @@
             "fsevents": "~2.3.2",
             "postcss": "^8.4.23",
             "rollup": "^3.21.0"
+          },
+          "dependencies": {
+            "postcss": {
+              "version": "8.4.33",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+              "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+              "dev": true,
+              "requires": {
+                "nanoid": "^3.3.7",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^1.0.2"
+              }
+            }
           }
         }
       }
@@ -16097,9 +16138,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true
     },
     "foreground-child": {
@@ -17861,9 +17902,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "dev": true
     },
     "needle": {

--- a/angular-workspace/test-ng14/package-lock.json
+++ b/angular-workspace/test-ng14/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "modus-angular-components-test-0.3.0-ng14",
+  "name": "modus-angular-components-test-ng14",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "modus-angular-components-test-0.3.0-ng14",
+      "name": "modus-angular-components-test-ng14",
       "version": "0.1.0",
       "dependencies": {
         "@angular/animations": "^14.1.1",
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^14.1.1",
         "@angular/platform-browser-dynamic": "^14.1.1",
         "@angular/router": "^14.1.1",
-        "@trimble-oss/modus-angular-components": "0.6.0-ng14",
+        "@trimble-oss/modus-angular-components": "0.11.0-ng14",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -3211,9 +3211,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-angular-components": {
-      "version": "0.6.0-ng14",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.6.0-ng14.tgz",
-      "integrity": "sha512-LcoWaLjs5zHSIPgi4khlU8uRglJpzkvXSScdvYnHOVNYp0G4noNJwSD7jWpo4vYiTDbjLUKEDYUU4umXfFfjRA==",
+      "version": "0.11.0-ng14",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.11.0-ng14.tgz",
+      "integrity": "sha512-9h/Ak4Of34yuwJqwrcS/824h23M9vVBpORCSLdJW0CSeC1nbsI9Df8j5NLL0cJYsdEMuHe+JvIWDn7TkumHTYQ==",
       "dependencies": {
         "tslib": "^2.5.3"
       },
@@ -3223,13 +3223,13 @@
       "peerDependencies": {
         "@angular/common": "^14.1.1",
         "@angular/core": "^14.1.1",
-        "@trimble-oss/modus-web-components": "0.6.0"
+        "@trimble-oss/modus-web-components": "0.11.0"
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.6.0.tgz",
-      "integrity": "sha512-FU29m371WzkG95XTM60cQuUJh/dfEXTVhpRwQVvDm2xnv3R97fFZcmDSRyj2Ngs5/WWWsCCQQtwTgRXXza32pQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -14595,9 +14595,9 @@
       "peer": true
     },
     "@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
       "peer": true
     },
     "@tootallnate/once": {
@@ -14607,17 +14607,17 @@
       "dev": true
     },
     "@trimble-oss/modus-angular-components": {
-      "version": "0.6.0-ng14",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.6.0-ng14.tgz",
-      "integrity": "sha512-LcoWaLjs5zHSIPgi4khlU8uRglJpzkvXSScdvYnHOVNYp0G4noNJwSD7jWpo4vYiTDbjLUKEDYUU4umXfFfjRA==",
+      "version": "0.11.0-ng14",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.11.0-ng14.tgz",
+      "integrity": "sha512-9h/Ak4Of34yuwJqwrcS/824h23M9vVBpORCSLdJW0CSeC1nbsI9Df8j5NLL0cJYsdEMuHe+JvIWDn7TkumHTYQ==",
       "requires": {
         "tslib": "^2.5.3"
       }
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.6.0.tgz",
-      "integrity": "sha512-FU29m371WzkG95XTM60cQuUJh/dfEXTVhpRwQVvDm2xnv3R97fFZcmDSRyj2Ngs5/WWWsCCQQtwTgRXXza32pQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "peer": true,
       "requires": {
         "@popperjs/core": "^2.11.8",

--- a/angular-workspace/test-ng14/package.json
+++ b/angular-workspace/test-ng14/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "modus-angular-components-test-0.3.0-ng14",
+  "name": "modus-angular-components-test-ng14",
   "version": "0.1.0",
   "description": "Test application for Modus Angular Components Library for Angular 14",
   "scripts": {
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^14.1.1",
     "@angular/platform-browser-dynamic": "^14.1.1",
     "@angular/router": "^14.1.1",
-    "@trimble-oss/modus-angular-components": "0.6.0-ng14",
+    "@trimble-oss/modus-angular-components": "0.11.0-ng14",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/angular-workspace/test-ng15/package-lock.json
+++ b/angular-workspace/test-ng15/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "modus-angular-components-test-0.3.0-ng15",
+  "name": "modus-angular-components-test-ng15",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "modus-angular-components-test-0.3.0-ng15",
+      "name": "modus-angular-components-test-ng15",
       "version": "0.1.0",
       "dependencies": {
         "@angular/animations": "^15.2.9",
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^15.2.9",
         "@angular/platform-browser-dynamic": "^15.2.9",
         "@angular/router": "^15.2.9",
-        "@trimble-oss/modus-angular-components": "^0.6.0-ng15",
+        "@trimble-oss/modus-angular-components": "0.11.0-ng15",
         "rxjs": "~7.8.1",
         "tslib": "^2.5.3",
         "zone.js": "~0.12.0"
@@ -3526,9 +3526,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -3548,9 +3548,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-angular-components": {
-      "version": "0.6.0-ng15",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.6.0-ng15.tgz",
-      "integrity": "sha512-K/3J6xfoRB9JhNG1Is9k7r60Q9F8f33oGNusCjkDIiu0sKD9VIVrR1AYN/dRtX7c1HkFLxYpXmwzaGdNXSl0wg==",
+      "version": "0.11.0-ng15",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.11.0-ng15.tgz",
+      "integrity": "sha512-KMjyuoJBaPFcY+aGu2Nap9b36LavDYGI8u+oomRkE+/4HOcm7hoqKS/RXW77Ij+gUuWlcD/sfk5Vd1RhT6NZhg==",
       "dependencies": {
         "tslib": "^2.5.3"
       },
@@ -3560,13 +3560,13 @@
       "peerDependencies": {
         "@angular/common": "^15.2.9",
         "@angular/core": "^15.2.9",
-        "@trimble-oss/modus-web-components": "0.6.0"
+        "@trimble-oss/modus-web-components": "0.11.0"
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.6.0.tgz",
-      "integrity": "sha512-FU29m371WzkG95XTM60cQuUJh/dfEXTVhpRwQVvDm2xnv3R97fFZcmDSRyj2Ngs5/WWWsCCQQtwTgRXXza32pQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -15063,9 +15063,9 @@
       "peer": true
     },
     "@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
       "peer": true
     },
     "@tootallnate/once": {
@@ -15075,17 +15075,17 @@
       "dev": true
     },
     "@trimble-oss/modus-angular-components": {
-      "version": "0.6.0-ng15",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.6.0-ng15.tgz",
-      "integrity": "sha512-K/3J6xfoRB9JhNG1Is9k7r60Q9F8f33oGNusCjkDIiu0sKD9VIVrR1AYN/dRtX7c1HkFLxYpXmwzaGdNXSl0wg==",
+      "version": "0.11.0-ng15",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-angular-components/-/modus-angular-components-0.11.0-ng15.tgz",
+      "integrity": "sha512-KMjyuoJBaPFcY+aGu2Nap9b36LavDYGI8u+oomRkE+/4HOcm7hoqKS/RXW77Ij+gUuWlcD/sfk5Vd1RhT6NZhg==",
       "requires": {
         "tslib": "^2.5.3"
       }
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.6.0.tgz",
-      "integrity": "sha512-FU29m371WzkG95XTM60cQuUJh/dfEXTVhpRwQVvDm2xnv3R97fFZcmDSRyj2Ngs5/WWWsCCQQtwTgRXXza32pQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "peer": true,
       "requires": {
         "@popperjs/core": "^2.11.8",

--- a/angular-workspace/test-ng15/package.json
+++ b/angular-workspace/test-ng15/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "modus-angular-components-test-0.3.0-ng15",
+  "name": "modus-angular-components-test-ng15",
   "version": "0.1.0",
   "description": "Test application for Modus Angular Components Library for Angular 15",
   "scripts": {
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^15.2.9",
     "@angular/platform-browser-dynamic": "^15.2.9",
     "@angular/router": "^15.2.9",
-    "@trimble-oss/modus-angular-components": "^0.6.0-ng15",
+    "@trimble-oss/modus-angular-components": "0.11.0-ng15",
     "rxjs": "~7.8.1",
     "tslib": "^2.5.3",
     "zone.js": "~0.12.0"

--- a/angular-workspace/test-web-components/package-lock.json
+++ b/angular-workspace/test-web-components/package-lock.json
@@ -6258,9 +6258,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {

--- a/react-workspace/test-react-v17/package-lock.json
+++ b/react-workspace/test-react-v17/package-lock.json
@@ -8,7 +8,7 @@
       "name": "test-react-v17",
       "version": "0.1.0",
       "dependencies": {
-        "@trimble-oss/modus-react-components": "0.7.0-react17",
+        "@trimble-oss/modus-react-components": "0.11.0-react17",
         "@types/node": "^16.11.26",
         "@types/react": "^17.0.40",
         "@types/react-dom": "^17.0.13",
@@ -3823,9 +3823,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
       "engines": {
         "node": ">=12"
       },
@@ -3844,11 +3844,11 @@
       }
     },
     "node_modules/@trimble-oss/modus-react-components": {
-      "version": "0.7.0-react17",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.7.0-react17.tgz",
-      "integrity": "sha512-HO4Fe6SMjk/RTIgxWsuiHZfgG8FQCYW+xD2udGXb3I5c2NBhennk7as23sYko9avWBOBo9S3XEX1r5m09I8k+w==",
+      "version": "0.11.0-react17",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.11.0-react17.tgz",
+      "integrity": "sha512-VqOUfHl9bSOvVYWfZ7Oh9v/arABGXfWzzxC1SR0ywm7HLNVI6jyM+xg34cJNzvRz9D6pPu/x8W3HkndyU/Niyw==",
       "dependencies": {
-        "@trimble-oss/modus-web-components": "0.7.0"
+        "@trimble-oss/modus-web-components": "0.11.0"
       },
       "peerDependencies": {
         "react": "^17.0.2",
@@ -3856,9 +3856,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.7.0.tgz",
-      "integrity": "sha512-lzpQ7Hd/34s0aLGMMmgbhu0MvQcSGGica8R/+pwlGXQqtA3fDv1V/mAdwq0+3ePbBA+jEj1L7keKW+XbVsJ51g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "^3.3.0",
@@ -8395,9 +8395,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true,
       "funding": [
         {
@@ -21264,9 +21264,9 @@
       }
     },
     "@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw=="
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -21275,17 +21275,17 @@
       "dev": true
     },
     "@trimble-oss/modus-react-components": {
-      "version": "0.7.0-react17",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.7.0-react17.tgz",
-      "integrity": "sha512-HO4Fe6SMjk/RTIgxWsuiHZfgG8FQCYW+xD2udGXb3I5c2NBhennk7as23sYko9avWBOBo9S3XEX1r5m09I8k+w==",
+      "version": "0.11.0-react17",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.11.0-react17.tgz",
+      "integrity": "sha512-VqOUfHl9bSOvVYWfZ7Oh9v/arABGXfWzzxC1SR0ywm7HLNVI6jyM+xg34cJNzvRz9D6pPu/x8W3HkndyU/Niyw==",
       "requires": {
-        "@trimble-oss/modus-web-components": "0.7.0"
+        "@trimble-oss/modus-web-components": "0.11.0"
       }
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.7.0.tgz",
-      "integrity": "sha512-lzpQ7Hd/34s0aLGMMmgbhu0MvQcSGGica8R/+pwlGXQqtA3fDv1V/mAdwq0+3ePbBA+jEj1L7keKW+XbVsJ51g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "requires": {
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "^3.3.0",
@@ -24790,9 +24790,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "dev": true
     },
     "for-each": {

--- a/react-workspace/test-react-v17/package.json
+++ b/react-workspace/test-react-v17/package.json
@@ -4,7 +4,7 @@
   "description": "Test application for Modus React Component Library for React v17",
   "private": true,
   "dependencies": {
-    "@trimble-oss/modus-react-components": "0.7.0-react17",
+    "@trimble-oss/modus-react-components": "0.11.0-react17",
     "@types/node": "^16.11.26",
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.13",

--- a/react-workspace/test-react-v18/package-lock.json
+++ b/react-workspace/test-react-v18/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "@trimble-oss/modus-react-components": "0.7.0-react18",
+        "@trimble-oss/modus-react-components": "0.11.0-react18",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.18.36",
         "@types/react": "^18.2.21",
@@ -3618,9 +3618,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ==",
       "engines": {
         "node": ">=12"
       },
@@ -3940,11 +3940,11 @@
       }
     },
     "node_modules/@trimble-oss/modus-react-components": {
-      "version": "0.7.0-react18",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.7.0-react18.tgz",
-      "integrity": "sha512-m+sjhPJbqP52aMxd5yfNsqjam4WMr3ZsPjr5w1aXvLavLRwot86pZ/J1kvZ6HuVFchYyrv8rRtPqYbeyMojaBw==",
+      "version": "0.11.0-react18",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.11.0-react18.tgz",
+      "integrity": "sha512-VJLFF+faKYy13DQgwgQbxeEBcrzBt0AbZ3x6/lDGFhrhbMO8N70GomnVMsaiO68tnN9dXFe8VoEno5YavmwZvw==",
       "dependencies": {
-        "@trimble-oss/modus-web-components": "0.7.0"
+        "@trimble-oss/modus-web-components": "0.11.0"
       },
       "peerDependencies": {
         "react": "^18.2.0",
@@ -3952,9 +3952,9 @@
       }
     },
     "node_modules/@trimble-oss/modus-web-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.7.0.tgz",
-      "integrity": "sha512-lzpQ7Hd/34s0aLGMMmgbhu0MvQcSGGica8R/+pwlGXQqtA3fDv1V/mAdwq0+3ePbBA+jEj1L7keKW+XbVsJ51g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "^3.3.0",
@@ -19701,9 +19701,9 @@
       }
     },
     "@tanstack/table-core": {
-      "version": "8.10.7",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.10.7.tgz",
-      "integrity": "sha512-KQk5OMg5OH6rmbHZxuNROvdI+hKDIUxANaHlV+dPlNN7ED3qYQ/WkpY2qlXww1SIdeMlkIhpN/2L00rof0fXFw=="
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.11.3.tgz",
+      "integrity": "sha512-nkcFIL696wTf1QMvhGR7dEg60OIRwEZm1OqFTYYDTRc4JOWspgrsJO3IennsOJ7ptumHWLDjV8e5BjPkZcSZAQ=="
     },
     "@testing-library/dom": {
       "version": "9.3.1",
@@ -19934,17 +19934,17 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@trimble-oss/modus-react-components": {
-      "version": "0.7.0-react18",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.7.0-react18.tgz",
-      "integrity": "sha512-m+sjhPJbqP52aMxd5yfNsqjam4WMr3ZsPjr5w1aXvLavLRwot86pZ/J1kvZ6HuVFchYyrv8rRtPqYbeyMojaBw==",
+      "version": "0.11.0-react18",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-react-components/-/modus-react-components-0.11.0-react18.tgz",
+      "integrity": "sha512-VJLFF+faKYy13DQgwgQbxeEBcrzBt0AbZ3x6/lDGFhrhbMO8N70GomnVMsaiO68tnN9dXFe8VoEno5YavmwZvw==",
       "requires": {
-        "@trimble-oss/modus-web-components": "0.7.0"
+        "@trimble-oss/modus-web-components": "0.11.0"
       }
     },
     "@trimble-oss/modus-web-components": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.7.0.tgz",
-      "integrity": "sha512-lzpQ7Hd/34s0aLGMMmgbhu0MvQcSGGica8R/+pwlGXQqtA3fDv1V/mAdwq0+3ePbBA+jEj1L7keKW+XbVsJ51g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-web-components/-/modus-web-components-0.11.0.tgz",
+      "integrity": "sha512-x168WjWBSeIF9v65u4zlHe24twMWCA1v+lMCW/lSicYObyraC2VF7ysPEM8kGbQhOuw37iaGQEz3vnUOjPghKA==",
       "requires": {
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "^3.3.0",

--- a/react-workspace/test-react-v18/package.json
+++ b/react-workspace/test-react-v18/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@trimble-oss/modus-react-components": "0.7.0-react18",
+    "@trimble-oss/modus-react-components": "0.11.0-react18",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.18.36",
     "@types/react": "^18.2.21",

--- a/react-workspace/test-web-components/package-lock.json
+++ b/react-workspace/test-web-components/package-lock.json
@@ -8101,9 +8101,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
@@ -23344,9 +23344,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
     },
     "for-each": {
       "version": "0.3.3",


### PR DESCRIPTION
Note: This pull request resolved a Dependabot alert on follow-redirects.

Fixes many of these in a single PR to cut down on multiple Dependabot PRs being merged:
![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/35f96599-64c1-496a-a0c1-de62d4061287)
