### PR TITLE
Table - Show original page after adding or removing row

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1317,6 +1317,28 @@ export declare interface ModusTableFillerColumn extends Components.ModusTableFil
 
 
 @ProxyCmp({
+  inputs: ['tableContext']
+})
+@Component({
+  selector: 'modus-table-pagination',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: '<ng-content></ng-content>',
+  // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
+  inputs: ['tableContext'],
+})
+export class ModusTablePagination {
+  protected el: HTMLElement;
+  constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
+    c.detach();
+    this.el = r.nativeElement;
+  }
+}
+
+
+export declare interface ModusTablePagination extends Components.ModusTablePagination {}
+
+
+@ProxyCmp({
   inputs: ['context', 'row']
 })
 @Component({

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/index.ts
@@ -46,6 +46,7 @@ export const DIRECTIVES = [
   d.ModusTableColumnsVisibility,
   d.ModusTableDropdownMenu,
   d.ModusTableFillerColumn,
+  d.ModusTablePagination,
   d.ModusTableRowActions,
   d.ModusTableRowActionsCell,
   d.ModusTableRowActionsMenu,

--- a/react-workspace/react-17/src/components/stencil-generated/index.ts
+++ b/react-workspace/react-17/src/components/stencil-generated/index.ts
@@ -52,6 +52,7 @@ export const ModusTableCellMain = /*@__PURE__*/createReactComponent<JSX.ModusTab
 export const ModusTableColumnsVisibility = /*@__PURE__*/createReactComponent<JSX.ModusTableColumnsVisibility, HTMLModusTableColumnsVisibilityElement>('modus-table-columns-visibility');
 export const ModusTableDropdownMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableDropdownMenu, HTMLModusTableDropdownMenuElement>('modus-table-dropdown-menu');
 export const ModusTableFillerColumn = /*@__PURE__*/createReactComponent<JSX.ModusTableFillerColumn, HTMLModusTableFillerColumnElement>('modus-table-filler-column');
+export const ModusTablePagination = /*@__PURE__*/createReactComponent<JSX.ModusTablePagination, HTMLModusTablePaginationElement>('modus-table-pagination');
 export const ModusTableRowActions = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActions, HTMLModusTableRowActionsElement>('modus-table-row-actions');
 export const ModusTableRowActionsCell = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsCell, HTMLModusTableRowActionsCellElement>('modus-table-row-actions-cell');
 export const ModusTableRowActionsMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsMenu, HTMLModusTableRowActionsMenuElement>('modus-table-row-actions-menu');

--- a/react-workspace/react-18/src/components/stencil-generated/index.ts
+++ b/react-workspace/react-18/src/components/stencil-generated/index.ts
@@ -52,6 +52,7 @@ export const ModusTableCellMain = /*@__PURE__*/createReactComponent<JSX.ModusTab
 export const ModusTableColumnsVisibility = /*@__PURE__*/createReactComponent<JSX.ModusTableColumnsVisibility, HTMLModusTableColumnsVisibilityElement>('modus-table-columns-visibility');
 export const ModusTableDropdownMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableDropdownMenu, HTMLModusTableDropdownMenuElement>('modus-table-dropdown-menu');
 export const ModusTableFillerColumn = /*@__PURE__*/createReactComponent<JSX.ModusTableFillerColumn, HTMLModusTableFillerColumnElement>('modus-table-filler-column');
+export const ModusTablePagination = /*@__PURE__*/createReactComponent<JSX.ModusTablePagination, HTMLModusTablePaginationElement>('modus-table-pagination');
 export const ModusTableRowActions = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActions, HTMLModusTableRowActionsElement>('modus-table-row-actions');
 export const ModusTableRowActionsCell = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsCell, HTMLModusTableRowActionsCellElement>('modus-table-row-actions-cell');
 export const ModusTableRowActionsMenu = /*@__PURE__*/createReactComponent<JSX.ModusTableRowActionsMenu, HTMLModusTableRowActionsMenuElement>('modus-table-row-actions-menu');

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1197,6 +1197,9 @@ export namespace Components {
         "container"?: HTMLElement;
         "summaryRow": boolean;
     }
+    interface ModusTablePagination {
+        "tableContext": TableContext;
+    }
     interface ModusTableRowActions {
         "context": TableContext;
         "row": Row<unknown>;
@@ -1902,6 +1905,12 @@ declare global {
         prototype: HTMLModusTableFillerColumnElement;
         new (): HTMLModusTableFillerColumnElement;
     };
+    interface HTMLModusTablePaginationElement extends Components.ModusTablePagination, HTMLStencilElement {
+    }
+    var HTMLModusTablePaginationElement: {
+        prototype: HTMLModusTablePaginationElement;
+        new (): HTMLModusTablePaginationElement;
+    };
     interface HTMLModusTableRowActionsElement extends Components.ModusTableRowActions, HTMLStencilElement {
     }
     var HTMLModusTableRowActionsElement: {
@@ -2013,6 +2022,7 @@ declare global {
         "modus-table-columns-visibility": HTMLModusTableColumnsVisibilityElement;
         "modus-table-dropdown-menu": HTMLModusTableDropdownMenuElement;
         "modus-table-filler-column": HTMLModusTableFillerColumnElement;
+        "modus-table-pagination": HTMLModusTablePaginationElement;
         "modus-table-row-actions": HTMLModusTableRowActionsElement;
         "modus-table-row-actions-cell": HTMLModusTableRowActionsCellElement;
         "modus-table-row-actions-menu": HTMLModusTableRowActionsMenuElement;
@@ -3370,6 +3380,9 @@ declare namespace LocalJSX {
         "container"?: HTMLElement;
         "summaryRow"?: boolean;
     }
+    interface ModusTablePagination {
+        "tableContext"?: TableContext;
+    }
     interface ModusTableRowActions {
         "context"?: TableContext;
         "onOverflowRowActions"?: (event: ModusTableRowActionsCustomEvent<TableRowActionsMenuEvent>) => void;
@@ -3731,6 +3744,7 @@ declare namespace LocalJSX {
         "modus-table-columns-visibility": ModusTableColumnsVisibility;
         "modus-table-dropdown-menu": ModusTableDropdownMenu;
         "modus-table-filler-column": ModusTableFillerColumn;
+        "modus-table-pagination": ModusTablePagination;
         "modus-table-row-actions": ModusTableRowActions;
         "modus-table-row-actions-cell": ModusTableRowActionsCell;
         "modus-table-row-actions-menu": ModusTableRowActionsMenu;
@@ -3795,6 +3809,7 @@ declare module "@stencil/core" {
              * ModusFillerColumn is to fill empty space within a table or grid when the content in other columns is not wide enough to occupy the entire available width
              */
             "modus-table-filler-column": LocalJSX.ModusTableFillerColumn & JSXBase.HTMLAttributes<HTMLModusTableFillerColumnElement>;
+            "modus-table-pagination": LocalJSX.ModusTablePagination & JSXBase.HTMLAttributes<HTMLModusTablePaginationElement>;
             "modus-table-row-actions": LocalJSX.ModusTableRowActions & JSXBase.HTMLAttributes<HTMLModusTableRowActionsElement>;
             "modus-table-row-actions-cell": LocalJSX.ModusTableRowActionsCell & JSXBase.HTMLAttributes<HTMLModusTableRowActionsCellElement>;
             "modus-table-row-actions-menu": LocalJSX.ModusTableRowActionsMenu & JSXBase.HTMLAttributes<HTMLModusTableRowActionsMenuElement>;

--- a/stencil-workspace/src/components/modus-pagination/readme.md
+++ b/stencil-workspace/src/components/modus-pagination/readme.md
@@ -29,12 +29,12 @@
 
 ### Used by
 
- - [modus-table](../modus-table)
+ - [modus-table-pagination](../modus-table/parts)
 
 ### Graph
 ```mermaid
 graph TD;
-  modus-table --> modus-pagination
+  modus-table-pagination --> modus-pagination
   style modus-pagination fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/stencil-workspace/src/components/modus-select/readme.md
+++ b/stencil-workspace/src/components/modus-select/readme.md
@@ -54,14 +54,14 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [modus-table](../modus-table)
  - [modus-table-cell-editor](../modus-table/parts/cell/modus-table-cell-editor)
+ - [modus-table-pagination](../modus-table/parts)
 
 ### Graph
 ```mermaid
 graph TD;
-  modus-table --> modus-select
   modus-table-cell-editor --> modus-select
+  modus-table-pagination --> modus-select
   style modus-select fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -62,7 +62,6 @@ import {
   ModusTableRowSelectionOptions,
 } from './models/modus-table.models';
 import { ModusTableColumnDropIndicator, ModusTableColumnDragItem } from './parts/columnHeader/modus-table-column-drag-item';
-import { ModusTablePagination } from './parts/modus-table-pagination';
 import { ModusTableFooter } from './parts/modus-table-footer';
 import { TableHeaderDragDrop } from './utilities/table-header-drag-drop.utility';
 import ModusTableCore from './modus-table.core';
@@ -714,7 +713,7 @@ export class ModusTable {
   }
 
   renderPagination(): JSX.Element | null {
-    return this.pagination && <ModusTablePagination context={this._context} />;
+    return this.pagination && <modus-table-pagination tableContext={this._context} />;
   }
 
   render(): void {

--- a/stencil-workspace/src/components/modus-table/parts/modus-table-pagination.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/modus-table-pagination.tsx
@@ -1,76 +1,101 @@
 import {
-  FunctionalComponent,
-  h, // eslint-disable-line @typescript-eslint/no-unused-vars
+  h, // eslint-disable-line @typescript-eslint/no-unused-vars,
+  Component,
+  Prop,
 } from '@stencil/core';
 import { PAGINATION_PAGEVIEW_TEXT, PAGINATION_SUMMARY_TEXT } from '../modus-table.constants';
 import { TableContext } from '../models/table-context.models';
 
-interface ModusTablePaginationProps {
-  context: TableContext;
-}
+@Component({
+  tag: 'modus-table-pagination',
+  shadow: false,
+})
+export class ModusTablePagination {
+  @Prop() tableContext: TableContext;
 
-export const ModusTablePagination: FunctionalComponent<ModusTablePaginationProps> = ({
-  context: { tableInstance: table, pageSizeList, data, manualPaginationOptions },
-}) => {
-  const { options, getState, getPageCount, getExpandedRowModel, setPageIndex, setPageSize } = table;
-  const { pageIndex: pageIndexState, pageSize: pageSizeState } = getState().pagination;
-  const optionsList = pageSizeList.map((option) => ({ display: option }));
+  private pageSize = 0;
+  private totalCount = 0;
+  private pageIndex = 0;
 
-  let pageSize = pageSizeState;
-  let pageIndex = pageIndexState;
-  let totalCount = data.length ?? 0;
-  let activePage = 1;
-
-  if (manualPaginationOptions) {
-    const { totalRecords, currentPageIndex, currentPageSize } = manualPaginationOptions;
-    const manualPageIndex = currentPageIndex ?? activePage;
-    activePage = manualPageIndex <= getPageCount() ? manualPageIndex : activePage;
-    pageIndex = activePage - 1;
-    pageSize = currentPageSize ?? 0;
-    totalCount = totalRecords ?? getExpandedRowModel().rows.length;
+  setPageIndex(pageIndex: number) {
+    // We don't want to update when the page index is unchanged or < 0.
+    const currentPageIndex = this.tableContext.tableInstance.getState().pagination.pageIndex;
+    if (currentPageIndex === pageIndex || pageIndex < 0) return;
+    this.pageIndex = pageIndex;
+    this.tableContext.tableInstance.setPageIndex(this.pageIndex);
   }
 
-  const selectedPageSize = optionsList.find((l) => l.display === pageSize);
+  componentWillRender() {
+    if (this.tableContext.manualPaginationOptions) {
+      this.prepareManualPaginationProperties();
+      return;
+    }
 
-  const handleChange = (event) => {
-    const selectedValue = event.detail;
-    setPageSize(Number(selectedValue?.display));
-  };
+    if (this.tableContext.pagination) {
+      const state = this.tableContext.tableInstance.getState();
+      const maxPageIndex = this.tableContext.tableInstance.getPageCount() - 1;
+      this.setPageIndex(this.pageIndex <= maxPageIndex ? this.pageIndex : maxPageIndex);
 
-  return (
-    <div class="pagination-container">
-      <div class="items-per-page">
-        <span>{PAGINATION_PAGEVIEW_TEXT}</span>
-        <modus-select
-          ariaLabel="Select page size"
-          options-display-prop="display"
-          options={optionsList}
-          onValueChange={handleChange}
-          value={selectedPageSize}></modus-select>
-      </div>
-      <div class="pagination-and-count">
-        <div class="total-count">
-          <span>{PAGINATION_SUMMARY_TEXT}</span>
-          <span>{pageIndex * pageSize + 1}</span>
-          <span>-</span>
-          <span>
-            {pageIndex + 1 === getPageCount()
-              ? !manualPaginationOptions && options.paginateExpandedRows
-                ? getExpandedRowModel().rows.length
-                : totalCount
-              : (pageIndex + 1) * pageSize}
-          </span>
-          <span>of</span>
-          <span>
-            {!manualPaginationOptions && options.paginateExpandedRows ? getExpandedRowModel().rows.length : totalCount}
-          </span>{' '}
+      this.pageSize = state.pagination.pageSize;
+      this.totalCount = this.tableContext.data.length ?? 0;
+    }
+  }
+
+  prepareManualPaginationProperties() {
+    const { totalRecords, currentPageIndex, currentPageSize } = this.tableContext.manualPaginationOptions;
+    this.pageIndex = currentPageIndex - 1;
+    this.pageSize = currentPageSize ?? 0;
+    this.totalCount = totalRecords ?? this.tableContext.tableInstance.getExpandedRowModel().rows.length;
+  }
+
+  render() {
+    const { options, getPageCount, getExpandedRowModel, setPageSize } = this.tableContext.tableInstance;
+    const pageSizeList = this.tableContext.pageSizeList;
+    const manualPaginationOptions = this.tableContext.manualPaginationOptions;
+
+    const optionsList = pageSizeList.map((option) => ({ display: option }));
+    const selectedPageSize = optionsList.find((l) => l.display === this.pageSize);
+    const handleChange = (event) => {
+      const selectedValue = event.detail;
+      setPageSize(Number(selectedValue?.display));
+    };
+    return (
+      <div class="pagination-container">
+        <div class="items-per-page">
+          <span>{PAGINATION_PAGEVIEW_TEXT}</span>
+          <modus-select
+            ariaLabel="Select page size"
+            options-display-prop="display"
+            options={optionsList}
+            onValueChange={handleChange}
+            value={selectedPageSize}></modus-select>
         </div>
-        <modus-pagination
-          active-page={activePage}
-          max-page={getPageCount()}
-          min-page={1}
-          onPageChange={(event) => setPageIndex(event.detail - 1)}></modus-pagination>
+        <div class="pagination-and-count">
+          <div class="total-count">
+            <span>{PAGINATION_SUMMARY_TEXT}</span>
+            <span>{this.pageIndex * this.pageSize + 1}</span>
+            <span>-</span>
+            <span>
+              {this.pageIndex + 1 === getPageCount()
+                ? !manualPaginationOptions && options.paginateExpandedRows
+                  ? getExpandedRowModel().rows.length
+                  : this.totalCount
+                : (this.pageIndex + 1) * this.pageSize}
+            </span>
+            <span>of</span>
+            <span>
+              {!manualPaginationOptions && options.paginateExpandedRows
+                ? getExpandedRowModel().rows.length
+                : this.totalCount}
+            </span>{' '}
+          </div>
+          <modus-pagination
+            active-page={this.pageIndex + 1}
+            max-page={getPageCount()}
+            min-page={1}
+            onPageChange={(event) => this.setPageIndex(event.detail - 1)}></modus-pagination>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}

--- a/stencil-workspace/src/components/modus-table/parts/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/readme.md
@@ -1,0 +1,37 @@
+# modus-table-pagination
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property       | Attribute | Description | Type           | Default     |
+| -------------- | --------- | ----------- | -------------- | ----------- |
+| `tableContext` | --        |             | `TableContext` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [modus-table](..)
+
+### Depends on
+
+- [modus-select](../../modus-select)
+- [modus-pagination](../../modus-pagination)
+
+### Graph
+```mermaid
+graph TD;
+  modus-table-pagination --> modus-select
+  modus-table-pagination --> modus-pagination
+  modus-table --> modus-table-pagination
+  style modus-table-pagination fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+

--- a/stencil-workspace/src/components/modus-table/readme.md
+++ b/stencil-workspace/src/components/modus-table/readme.md
@@ -89,9 +89,8 @@ Type: `Promise<void>`
 
 - [modus-table-toolbar](./parts/panel/modus-table-toolbar)
 - [modus-table-filler-column](./parts/fillerColumn)
+- [modus-table-pagination](parts)
 - [modus-table-row-actions-menu](./parts/row/actions/modus-table-row-actions-menu)
-- [modus-select](../modus-select)
-- [modus-pagination](../modus-pagination)
 - [modus-tooltip](../modus-tooltip)
 - [modus-checkbox](../modus-checkbox)
 - [modus-table-row-actions-cell](./parts/row/actions)
@@ -102,9 +101,8 @@ Type: `Promise<void>`
 graph TD;
   modus-table --> modus-table-toolbar
   modus-table --> modus-table-filler-column
+  modus-table --> modus-table-pagination
   modus-table --> modus-table-row-actions-menu
-  modus-table --> modus-select
-  modus-table --> modus-pagination
   modus-table --> modus-tooltip
   modus-table --> modus-checkbox
   modus-table --> modus-table-row-actions-cell
@@ -113,6 +111,8 @@ graph TD;
   modus-table-dropdown-menu --> modus-table-columns-visibility
   modus-table-columns-visibility --> modus-checkbox
   modus-table-columns-visibility --> modus-button
+  modus-table-pagination --> modus-select
+  modus-table-pagination --> modus-pagination
   modus-table-row-actions-menu --> modus-list
   modus-table-row-actions-menu --> modus-list-item
   modus-table-row-actions-cell --> modus-table-row-actions


### PR DESCRIPTION
## Description
Draft because:
- Would like to get some feedback on the change from functional component to component?
Are the auto updated readme good enough?
- No new e2e tests added yet:
I was unable to add e2e tests, because pagination is not working correctly in puppeteer (also on main). The pagination components are shown, but the data is not filtered. Any suggetions on how to fix this?

References #1996

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Tested by the storybook components (modus-table/manual-pagination and modus-table/pagination)

- Open table at last page
- Remove last item
- Change in pagination should be reflected in the data. 
(In the storybook manual-pagination component, the manual pagination is configured to go to page 1).


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
