### PR TITLE
Navbar: add tab index to logo and trigger productLogoClick with keyboard

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/product-logo/modus-navbar-product-logo.tsx
+++ b/stencil-workspace/src/components/modus-navbar/product-logo/modus-navbar-product-logo.tsx
@@ -8,17 +8,17 @@ export const ModusNavbarProductLogo: FunctionalComponent<{
 }> = ({ logos, onClick }) => {
   const { primary, secondary } = logos || {};
 
-const logoKeydownHandler = (event: KeyboardEvent) => {
-  if (event.key !== 'Enter') {
-    return;
-  }
-  if (onClick) {
-    onClick(event);
-  }
-};
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Enter' || event.key !== ' ') {
+      return;
+    }
+    if (onClick) {
+      onClick(event);
+    }
+  };
 
   return (
-    <div onClick={onClick} onKeyDown={logoKeydownHandler} tabindex="0" class="product-logo">
+    <div aria-label="Logo" onClick={onClick} onKeyDown={handleKeyDown} tabindex="0" role="button" class="product-logo">
       {primary && (
         <img
           class={secondary && 'product-logo-primary'}

--- a/stencil-workspace/src/components/modus-navbar/product-logo/modus-navbar-product-logo.tsx
+++ b/stencil-workspace/src/components/modus-navbar/product-logo/modus-navbar-product-logo.tsx
@@ -9,7 +9,7 @@ export const ModusNavbarProductLogo: FunctionalComponent<{
   const { primary, secondary } = logos || {};
 
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key !== 'Enter' || event.key !== ' ') {
+    if (event.key !== 'Enter' && event.key !== ' ') {
       return;
     }
     if (onClick) {

--- a/stencil-workspace/src/components/modus-navbar/product-logo/modus-navbar-product-logo.tsx
+++ b/stencil-workspace/src/components/modus-navbar/product-logo/modus-navbar-product-logo.tsx
@@ -8,8 +8,17 @@ export const ModusNavbarProductLogo: FunctionalComponent<{
 }> = ({ logos, onClick }) => {
   const { primary, secondary } = logos || {};
 
+const logoKeydownHandler = (event: KeyboardEvent) => {
+  if (event.key !== 'Enter') {
+    return;
+  }
+  if (onClick) {
+    onClick(event);
+  }
+};
+
   return (
-    <div onClick={onClick} class="product-logo">
+    <div onClick={onClick} onKeyDown={logoKeydownHandler} tabindex="0" class="product-logo">
       {primary && (
         <img
           class={secondary && 'product-logo-primary'}

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -38,7 +38,7 @@ export default {
   },
   parameters: {
     actions: {
-      handles: ['searchMenuClick', 'buttonClick'],
+      handles: ['searchMenuClick', 'buttonClick', 'productLogoClick'],
     },
     controls: { expanded: true, sort: 'requiredFirst' },
     docs: {


### PR DESCRIPTION
## Description

Added tab index to the e-builder log so it can now be tabbed to. Also added a keydown function so that when the enter key is hit on the logo, it will copy the functionality of clicking it. 

References [#2040](https://github.com/trimble-oss/modus-web-components/issues/2040) 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
