### PR TITLE
Only deploy to modus-web-components.trimble.com on release

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -1,10 +1,9 @@
 name: Azure Static Web Apps CI/CD
 
 on:
-  pull_request:
-    types: [closed]
-    branches:
-      - main
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -13,8 +12,7 @@ jobs:
   build_and_deploy_job:
     permissions:
       contents: read # for actions/checkout to fetch code
-      pull-requests: write # for Azure/static-web-apps-deploy to comment on PRs
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.repository == 'trimble-oss/modus-web-components'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -29,19 +27,6 @@ jobs:
 
       - run: cd stencil-workspace && npm run full
 
-      - name: Delete duplicate Azure Static Web Apps comments
-        continue-on-error: true
-        run: |
-          gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments `
-            | ConvertFrom-Json `
-            | Where-Object body -like 'Azure Static Web Apps: Your stage site is ready! Visit it here: *' `
-            | ForEach-Object {
-                gh api repos/${{ github.repository }}/issues/comments/$($_.id) -X DELETE
-              }
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -55,15 +40,3 @@ jobs:
           app_location: '/stencil-workspace/storybook/dist/' # App source code path
           api_location: '' # Api source code path - optional
           output_location: '/' # Built app content directory - optional
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_GROUND_0374A1310 }}
-          action: 'close'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 <p align="center">
   <a href="https://modus-web-components.trimble.com/" target="_blank">
-    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg" alt/>
+    <img src="https://cdn.jsdelivr.net/gh/storybookjs/brand@master/badge/badge-storybook.svg" alt="" />
   </a>
   <a href="https://www.npmjs.com/package/@trimble-oss/modus-web-components">
-    <img src="https://img.shields.io/github/package-json/v/trimble-oss/modus-web-components?color=blue&filename=stencil-workspace%2Fpackage.json" alt/>
+    <img src="https://img.shields.io/github/package-json/v/trimble-oss/modus-web-components?color=blue&filename=stencil-workspace%2Fpackage.json" alt="" />
   </a>
   <a href="https://github.com/trimble-oss/modus-web-components/graphs/contributors">
-    <img src="https://img.shields.io/github/contributors/trimble-oss/modus-web-components?color=lightblue" alt/>
+    <img src="https://img.shields.io/github/contributors/trimble-oss/modus-web-components?color=lightblue" alt="" />
   </a>
 </p>
 

--- a/stencil-workspace/storybook/stories/framework-integrations/angular.stories.mdx
+++ b/stencil-workspace/storybook/stories/framework-integrations/angular.stories.mdx
@@ -17,8 +17,6 @@ import { Meta } from '@storybook/addon-docs';
 
 # Modus Angular Components
 
-<modus-alert message="Modus Angular Components are available now !"></modus-alert>
-
 We highly recommend to use the [Modus Angular Components](https://www.npmjs.com/package/@trimble-oss/modus-angular-components) library for Angular based projects. The components are programmatically generated using the [Stencil](https://stenciljs.com/) [Angular Framework Integration](https://stenciljs.com/docs/angular). Please check out the [instructions](https://www.npmjs.com/package/@trimble-oss/modus-angular-components) on how to use the library.
 
 ## Modus Web Components in a Angular project

--- a/stencil-workspace/storybook/stories/framework-integrations/react.stories.mdx
+++ b/stencil-workspace/storybook/stories/framework-integrations/react.stories.mdx
@@ -17,9 +17,7 @@ import { Meta } from '@storybook/addon-docs';
 
 # Modus React Components
 
-<modus-alert message="Modus React Components are available now !"></modus-alert>
-
-We highly recommend to use the [Modus React Components](https://www.npmjs.com/package/@trimble-oss/modus-react-components) library for React based projects. The components are programmatically generated using the [Stencil](https://stenciljs.com/) for React [v17.0.2](https://github.com/facebook/react/blob/main/CHANGELOG.md#1702-march-22-2021). Please check out the [instructions](https://www.npmjs.com/package/@trimble-oss/modus-react-components) on how to use the library.
+We highly recommend to use the [Modus React Components](https://www.npmjs.com/package/@trimble-oss/modus-react-components) library for React based projects. The components are programmatically generated using the [Stencil](https://stenciljs.com/) for React v17 and v18. Please check out the [instructions](https://www.npmjs.com/package/@trimble-oss/modus-react-components) on how to use the library.
 
 ## Modus Web Components in a React project
 

--- a/stencil-workspace/storybook/stories/introduction/contributing.stories.mdx
+++ b/stencil-workspace/storybook/stories/introduction/contributing.stories.mdx
@@ -19,29 +19,21 @@ import { Meta } from '@storybook/addon-docs';
 
 If you're interested in contributing to the project by developing a new component, adding features to an existing one, or fixing bugs, please refer to the [contributing guidelines](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md). These guidelines provide step-by-step instructions on everything from setting up the localhost to [submitting a PR](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md#making-changes-and-submitting-a-pr).
 
-
 ## Framework Outputs
 
-Stencil can automatically generate Framework Wrappers for **React** and **Angular**. The Wrapper components are released in [separate packages](https://www.npmjs.com/search?q=trimble-oss) in npm. For more details about how the wrapper components are generated and released, please refer to the [guidelines](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md#releasing-framework-outputs).
+Stencil can automatically generate Framework Wrappers for **React** and **Angular**. The Wrapper components are released in [separate packages](https://www.npmjs.com/search?q=trimble-oss%20modus%20components) in npm. For more details about how the wrapper components are generated and released, please refer to the [guidelines](https://github.com/trimble-oss/modus-web-components/blob/main/CONTRIBUTING.md#releasing-framework-outputs).
 Please feel free to submit an [GitHub issue](https://github.com/trimble-oss/modus-web-components/issues) to enable support for a specific version for a framework.
-
 
 ## Submitting Issues
 
 Whether you're contributing directly to the code or have suggestions, submitting an issue through GitHub is needed
 for referencing changes. Please submit change items as an Issue [here](https://github.com/trimble-oss/modus-web-components/issues).
 
-If the issue's considered a bug, add the 'bug' label to the issue.
-
-Also add a priority level label to the issue. The priority options are low, medium, and high.
-If you are unsure of its priority, reach out to one of the developers for their opinion.
-
 ## Contact
 
 Please feel free to reach out to [Modus Delivery Team](https://github.com/orgs/trimble-oss/teams/modus) in GitHub, send a message in Modus Design System [Google chat space](https://mail.google.com/chat/u/0/#chat/space/AAAAexugR1k) or send an email to `modus@trimble.com` for more questions.
 
 You can also create conversations, ask questions, and share ideas on the [Trimble GitHub Discussions platform](https://github.com/orgs/trimble-oss/discussions).
-
 
 ## GitHub
 

--- a/stencil-workspace/storybook/stories/introduction/welcome.stories.mdx
+++ b/stencil-workspace/storybook/stories/introduction/welcome.stories.mdx
@@ -41,6 +41,9 @@ The Modus Web Components library allows web development teams to leverage consis
 
 Each component has a Docs page which contains component documentation - how to use the component, its properties, methods, DOM events, and accessibility. Some components also contain a Canvas page that provide a playground to take it for a spin. The Canvas' Controls tab allows you to change the inputs for the components, and see a live re-render! The Canvas' Actions tab displays the component's output DOM events (and the event details) after you interact with it.
 
+- [Production site](https://modus-web-components.trimble.com) (latest release)
+- [Development site](https://moduswebcomponents.netlify.app/) (latest commit)
+
 ## GitHub
 
 <img src={'github.svg'} height={'20'} width={'20'} alt="GitHub Icon" /> <a


### PR DESCRIPTION
## Description

This changes the deploy to Azure GitHub Action so that it only runs when a new release is published - so therefore https://modus-web-components.trimble.com/ will always only show the code from the latest release.

https://moduswebcomponents.netlify.app/ will always show latest dev changes.

+ various docs fixes
+ markdown linting fix for root README.md


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
