### PR TITLE
Badge: Fix issue breaking angular builds

### DIFF
--- a/stencil-workspace/src/components/modus-badge/modus-badge.tsx
+++ b/stencil-workspace/src/components/modus-badge/modus-badge.tsx
@@ -2,7 +2,7 @@
 import { Component, Prop, h } from '@stencil/core';
 
 export type BadgeProperties = {
-  ariaLabel?: string | null;
+  ariaLabel: string | null;
   color?: 'danger' | 'dark' | 'primary' | 'secondary' | 'success' | 'tertiary' | 'warning';
   size?: 'small' | 'medium' | 'large';
   type?: 'counter' | 'default' | 'text';


### PR DESCRIPTION
## Description

The recently introduced BadgeProperties type, which is used to share props between the standalone Badge and the Table's Badge Cell, defined the `ariaLabel` property as optional while the Badge component ultimately extends ARIAMixin which does not define it as optional.  This mismatch caused the conflict that prevented the build.

References #2004

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Ran `npm run build` within `test-web-components` folder (angular app)
- Witness error
- Applied fix
- Ran `npm run build` within `stencil-workspace` 
- Copied `dist` and `loader` folders to overwrite those in `angular-workspace\test-web-components\node_modules\@trimble-oss\modus-web-components\`
- Ran `npm run build` within `test-web-components` folder (angular app)
- Observed passing build

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
