### PR TITLE
Autocomplete: Use input `type="search"`

### DIFF
--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.spec.ts
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.spec.ts
@@ -11,7 +11,7 @@ describe('modus-autocomplete', () => {
     <modus-autocomplete>
       <mock:shadow-root>
         <div class="autocomplete medium">
-          <modus-text-input autocomplete="off" includesearchicon="" size="medium"></modus-text-input>
+          <modus-text-input autocomplete="off" includesearchicon="" size="medium" type="search"></modus-text-input>
           <div class="options-container" style="max-height: 300px; z-index: 1; overflow-y: auto;">
             <ul></ul>
           </div>
@@ -38,7 +38,7 @@ describe('modus-autocomplete', () => {
     <modus-autocomplete>
       <mock:shadow-root>
         <div class="autocomplete medium">
-          <modus-text-input autocomplete="off" includesearchicon="" size="medium"></modus-text-input>
+          <modus-text-input autocomplete="off" includesearchicon="" size="medium" type="search"></modus-text-input>
           <div class="options-container" style="max-height: 300px; z-index: 1; overflow-y: auto;">
             <ul></ul>
           </div>

--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.tsx
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.tsx
@@ -261,6 +261,7 @@ export class ModusAutocomplete {
       placeholder={this.placeholder}
       required={this.required}
       size={this.size}
+      type="search"
       value={this.value}
       onBlur={this.handleInputBlur}
     />


### PR DESCRIPTION
## Description

This means that user can press <kbd>Escape</kbd> key to clear the input.

References #2044 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v120 on Windows 11.

Preview:
https://deploy-preview-2061--moduswebcomponents.netlify.app/?path=/story/user-inputs-autocomplete--default

Type in something and then press <kbd>Escape</kbd> key to clear the input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
