### PR TITLE
Navbar: Add 'Sign Out' icon to Navbar profile menu

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.scss
@@ -91,20 +91,26 @@
   }
 
   .sign-out {
+    align-items: center;
     background-color: $modus-navbar-profile-menu-sign-out-background-color;
+    color: $modus-navbar-profile-menu-sign-out-color;
+    cursor: pointer;
+    display: flex;
+    height: $rem-40px;
     user-select: none;
     width: 100%;
 
-    div {
-      color: $modus-navbar-profile-menu-sign-out-color;
-      cursor: pointer;
-      font-size: $rem-14px;
-      padding: $rem-10px $rem-16px;
+    .icon-sign-out {
+      padding: 0 $rem-16px 0 $rem-12px;
+    }
 
-      @media (hover: hover) {
-        &:hover {
-          text-decoration: underline;
-        }
+    .sign-out-text {
+      font-size: $rem-14px;
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        text-decoration: underline;
       }
     }
   }

--- a/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.tsx
+++ b/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.tsx
@@ -68,7 +68,8 @@ export class ModusNavbarProfileMenu {
           onClick={() => this.signOutClick.emit()}
           onKeyDown={(event) => this.signOutKeydownHandler(event)}
           tabIndex={0}>
-          <div>Sign out</div>
+          <ModusIconMap icon="sign_out" size="24" />
+          <div class="sign-out-text">Sign out</div>
         </div>
       </div>
     );

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -41,11 +41,11 @@ export default {
       table: {
         type: { summary: 'ModusNavbarTooltip' },
       },
-    }
+    },
   },
   parameters: {
     actions: {
-      handles: ['searchMenuClick', 'buttonClick', 'productLogoClick'],
+      handles: ['searchMenuClick', 'buttonClick', 'productLogoClick', 'signOutClick'],
     },
     controls: { expanded: true, sort: 'requiredFirst' },
     docs: {
@@ -68,10 +68,10 @@ const Template = ({ profileMenuOptions, buttons, showSearch, enableSearchOverlay
     show-main-menu>
     <div slot="main" style="height:300px;">Render your own main menu.</div>
 
-      <modus-list slot="addMenu">
-        <modus-list-item>Menu Item 1</modus-list-item>
-        <modus-list-item>Menu Item 2</modus-list-item>
-      </modus-list>
+    <modus-list slot="addMenu">
+      <modus-list-item>Menu Item 1</modus-list-item>
+      <modus-list-item>Menu Item 2</modus-list-item>
+    </modus-list>
 
     <div slot="notificationMenu">Render your own notification menu.</div>
     <div slot="profileMenu">Render your own profile menu content.</div>
@@ -86,32 +86,33 @@ Default.args = {
     username: 'Modus User',
     links: [
       {
-        id: "link1",
-        display: "Link 1",
-        icon: "moon"
+        id: 'link1',
+        display: 'Link 1',
+        icon: 'moon',
       },
       {
-        id: "link2",
-        display: "Link 2",
-        icon: "sun"
-      }
+        id: 'link2',
+        display: 'Link 2',
+        icon: 'sun',
+      },
     ],
     tooltip: {
       text: 'User Profile Menu',
-    }
+    },
   },
   buttons: [
     {
-      id: 'addMenu', icon: 'add',
+      id: 'addMenu',
+      icon: 'add',
       tooltip: {
         text: 'Add',
-      }
+      },
     },
     { id: 'notificationMenu', icon: 'notifications' },
   ],
   showSearch: false,
   enableSearchOverlay: false,
-  searchTooltip: undefined
+  searchTooltip: undefined,
 };
 
 const FailedToLoadAvatarTemplate = ({ profileMenuOptions, buttons, showSearch, enableSearchOverlay, searchTooltip }) => html`
@@ -138,7 +139,7 @@ FailedAvatar.args = {
   buttons: [],
   showSearch: false,
   enableSearchOverlay: false,
-  searchTooltip: undefined
+  searchTooltip: undefined,
 };
 const BlueTemplate = ({ profileMenuOptions, buttons, showSearch, enableSearchOverlay, searchTooltip }) => html`
   <modus-navbar
@@ -154,14 +155,14 @@ const BlueTemplate = ({ profileMenuOptions, buttons, showSearch, enableSearchOve
     <div slot="notifications">Render your own notifications.</div>
   </modus-navbar>
   ${setNavbar(
-  false,
-  '#blue-theme',
-  profileMenuOptions,
-  'https://modus-bootstrap.trimble.com/img/trimble-logo-rev.svg',
-  'https://modus-bootstrap.trimble.com/img/trimble-icon-rev.svg',
-  buttons,
-  searchTooltip
-)}
+    false,
+    '#blue-theme',
+    profileMenuOptions,
+    'https://modus-bootstrap.trimble.com/img/trimble-logo-rev.svg',
+    'https://modus-bootstrap.trimble.com/img/trimble-icon-rev.svg',
+    buttons,
+    searchTooltip
+  )}
 `;
 export const BlueNavbar = BlueTemplate.bind({});
 BlueNavbar.args = {
@@ -173,7 +174,7 @@ BlueNavbar.args = {
   buttons: [],
   showSearch: false,
   enableSearchOverlay: false,
-  searchTooltip: undefined
+  searchTooltip: undefined,
 };
 
 const setNavbar = (


### PR DESCRIPTION
## Description

Add the 'Sign Out' icon to the Nabar's Profile Menu
Note: This is a hard coded icon, it is fixed and always shows.

![image](https://github.com/trimble-oss/modus-web-components/assets/84749026/c4918990-d42f-4369-9495-83276ad8d377)

References #2063

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update

## How Has This Been Tested?

I manually tested it in the dev `index.html` and Storybook page

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
