### PR TITLE
Change border radius from 2px to 4px for components

### DIFF
--- a/stencil-workspace/src/components/modus-alert/modus-alert.scss
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.scss
@@ -4,7 +4,7 @@ div.alert {
   align-items: center;
   border: 1px solid;
   border-left-width: $alert-left-border-width;
-  border-radius: 2px;
+  border-radius: 4px;
   box-sizing: border-box;
   display: flex;
   font-family: $primary-font;

--- a/stencil-workspace/src/components/modus-badge/modus-badge.scss
+++ b/stencil-workspace/src/components/modus-badge/modus-badge.scss
@@ -3,7 +3,7 @@
 div.badge {
   align-items: center;
   background-color: $modus-badge-primary-bg;
-  border-radius: 2px;
+  border-radius: 4px;
   color: $modus-badge-primary-color;
   display: inline-flex;
   font-family: $primary-font;

--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -9,7 +9,7 @@
 button {
   align-items: center;
   border: $rem-1px solid transparent;
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   cursor: default;
   display: inline-flex;
   font-family: $primary-font;

--- a/stencil-workspace/src/components/modus-card/modus-card.e2e.ts
+++ b/stencil-workspace/src/components/modus-card/modus-card.e2e.ts
@@ -57,7 +57,7 @@ describe('modus-card', () => {
     const component = await page.find('modus-card');
     const element = await page.find('modus-card >>> article');
     let computedStyle = await element.getComputedStyle();
-    expect(computedStyle['borderRadius']).toEqual('2px');
+    expect(computedStyle['borderRadius']).toEqual('4px');
 
     component.setProperty('borderRadius', '10px');
     await page.waitForChanges();

--- a/stencil-workspace/src/components/modus-card/modus-card.scss
+++ b/stencil-workspace/src/components/modus-card/modus-card.scss
@@ -4,7 +4,7 @@ article {
   background-color: $modus-card-bg;
   border: $rem-1px solid;
   border-color: transparent;
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   color: $modus-card-color;
   font-family: $primary-font;
   overflow: hidden;

--- a/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.scss
+++ b/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.scss
@@ -29,7 +29,7 @@
   .dropzone {
     align-items: center;
     background-color: $modus-file-upload-dropzone-bg;
-    border: $rem-1px dashed $modus-file-upload-dropzone-border-color;
+    border: $rem-2px dashed $modus-file-upload-dropzone-border-color;
     border-radius: $rem-4px;
     color: $modus-file-upload-dropzone-color;
     display: flex;

--- a/stencil-workspace/src/components/modus-list/modus-list.scss
+++ b/stencil-workspace/src/components/modus-list/modus-list.scss
@@ -1,5 +1,5 @@
 ul {
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   display: flex;
   flex-direction: column;
   font-family: $primary-font;

--- a/stencil-workspace/src/components/modus-message/modus-message.scss
+++ b/stencil-workspace/src/components/modus-message/modus-message.scss
@@ -2,7 +2,7 @@
 
 .modus-message {
   align-items: center;
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   display: flex;
   font-family: $primary-font;
   font-size: $rem-14px;

--- a/stencil-workspace/src/components/modus-modal/modus-modal.scss
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.scss
@@ -23,7 +23,7 @@
   .content {
     background-color: $modus-modal-bg;
     border: 1px solid $modus-modal-border-color;
-    border-radius: $rem-2px;
+    border-radius: $rem-4px;
     color: $modus-modal-color;
     display: flex;
     fill: $modus-modal-color;

--- a/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/apps-menu/modus-navbar-apps-menu.scss
@@ -21,7 +21,7 @@
 
   .app {
     border-color: $menu-border-color;
-    border-radius: $rem-2px;
+    border-radius: $rem-4px;
     box-sizing: border-box;
     color: $menu-color;
     cursor: default;

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -22,7 +22,7 @@ nav {
   .icon-menu,
   .icon-close,
   .icon-button svg {
-    border-radius: $rem-2px;
+    border-radius: $rem-4px;
     padding: $rem-12px;
 
     path {

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.vars.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.vars.scss
@@ -2,7 +2,7 @@
 @mixin custom-navbar-menu {
   background-color: var(--modus-body-bg, $col_white);
   border: $rem-1px solid var(--modus-navbar-popup-border-color, #cbcdd6);
-  border-radius: $rem_2px;
+  border-radius: $rem_4px;
   box-shadow: $box-shadow-lg;
   color: var(--modus-body-color, #252a2e);
   display: flex;

--- a/stencil-workspace/src/components/modus-pagination/modus-pagination.scss
+++ b/stencil-workspace/src/components/modus-pagination/modus-pagination.scss
@@ -3,12 +3,11 @@
 nav {
   align-items: center;
   background-color: transparent;
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   color: $modus-pagination-color;
   display: inline-flex;
   font-family: $primary-font;
   justify-content: center;
-  user-select: none;
   width: 100%;
 
   svg path {
@@ -24,11 +23,13 @@ nav {
 
     li {
       align-items: center;
+      border-radius: 4px;
       display: flex;
       flex-direction: row;
       justify-content: center;
       list-style-type: none;
       min-width: min-content;
+      user-select: none;
 
       &.active {
         background-color: $modus-pagination-active-bg;

--- a/stencil-workspace/src/components/modus-tabs/modus-tabs.scss
+++ b/stencil-workspace/src/components/modus-tabs/modus-tabs.scss
@@ -20,7 +20,7 @@
   .tab {
     align-items: center;
     border: solid transparent $rem-3px;
-    border-radius: $rem-2px $rem-2px 0 0;
+    border-radius: $rem-4px $rem-4px 0 0;
     color: $modus-tab-color;
     display: flex;
     font-weight: $font-weight-semi-bold;

--- a/stencil-workspace/src/components/modus-toast/modus-toast.scss
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.scss
@@ -4,7 +4,7 @@
   align-items: center;
   background-color: $modus-toast-bg;
   border: $rem-1px solid $modus-toast-border-color;
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   box-shadow: 0 0 8px rgba(36, 35, 45, 0.3);
   color: $modus-toast-color;
   display: flex;

--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
@@ -2,7 +2,7 @@
 
 .tooltip {
   background: $modus-tooltip-bg;
-  border-radius: $rem-2px;
+  border-radius: $rem-4px;
   color: $modus-tooltip-color;
   display: none;
   font-family: $primary-font;

--- a/stencil-workspace/src/global/modus-variables.scss
+++ b/stencil-workspace/src/global/modus-variables.scss
@@ -77,8 +77,8 @@ $disabled-opacity: 0.3 !default;
 //
 // Define common padding and border radius sizes and more.
 
-$border-radius: $rem-2px !default;
-$border-radius-lg: $rem-2px !default;
+$border-radius: $rem-4px !default;
+$border-radius-lg: $rem-4px !default;
 $border-radius-sm: $rem-2px !default;
 
 // Typography

--- a/stencil-workspace/src/global/shared-mixins.scss
+++ b/stencil-workspace/src/global/shared-mixins.scss
@@ -1,6 +1,6 @@
 @mixin navbar-menu {
   background-color: $col_white;
-  border-radius: $rem_2px;
+  border-radius: $rem_4px;
   box-shadow: $box-shadow-lg;
   display: flex;
   flex-direction: column;

--- a/stencil-workspace/storybook/stories/components/modus-card/modus-card-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-card/modus-card-storybook-docs.mdx
@@ -13,7 +13,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
 <Story id="components-card--default" height={'150px'} />
 
 ```html
-<modus-card aria-label="Card" height="270px" width="250px" border-radius="1px" show-card-border="true" show-shadow-on-hover="true">
+<modus-card height="270px" width="250px" show-card-border="true" show-shadow-on-hover="true">
     <!-- Render anything here -->
     <div style="padding:10px">
       <h4>Card title</h4>
@@ -30,11 +30,11 @@ This component utilizes the slot element, allowing you to render your own HTML i
 | Property            | Attribute              | Description                                                                            | Type      | Default     |
 | ------------------- | ---------------------- | -------------------------------------------------------------------------------------- | --------- | ----------- |
 | `ariaLabel`         | `aria-label`           | (optional) The card's aria-label.                                                      | `string`  | `undefined` |
-| `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `undefined` |
-| `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `'269px'`   |
+| `borderRadius`      | `border-radius`        | (optional) The border radius of the card.                                              | `string`  | `4px`       |
+| `height`            | `height`               | (optional) The height of the card.                                                     | `string`  | `269px`   |
 | `showCardBorder`    | `show-card-border`     | (optional) A flag that controls the display of border.                                 | `boolean` | `true`      |
 | `showShadowOnHover` | `show-shadow-on-hover` | (optional) A flag that controls the display of shadow box when the element is hovered. | `boolean` | `true`      |
-| `width`             | `width`                | (optional) The width of the card.                                                      | `string`  | `'240px'`   |
+| `width`             | `width`                | (optional) The width of the card.                                                      | `string`  | `240px`   |
 
 ---
 

--- a/stencil-workspace/storybook/stories/components/modus-card/modus-card.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-card/modus-card.stories.tsx
@@ -75,10 +75,10 @@ const Template = ({
 `;
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: 'Card',
+  ariaLabel: '',
   height: '270px',
   width: '250px',
-  borderRadius: '2px',
+  borderRadius: '4px',
   showCardBorder: true,
   showShadowOnHover: true
 };


### PR DESCRIPTION
## Description

- Change border radius from 2px to 4px for components
- Change Border-width for File Upload Dropzone from 1px to 2px
- Remove `aria-label="Card"` from card example on docs (not needed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v120 on Windows 11

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
