### PR TITLE
Docs: Add aria-label to icon-only buttons

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
@@ -81,7 +81,7 @@ For Icon only Buttons,
 
 ### Icon with Text Button
 
-<modus-button size="small" left-icon="notifications" >Primary</modus-button>
+<modus-button size="small" left-icon="notifications">Primary</modus-button>
 <modus-button color="secondary" right-icon="notifications">Secondary</modus-button>
 <modus-button size="large" left-icon="notifications" color="tertiary" right-icon="notifications">Tertiary</modus-button>
 <modus-button size="large" left-icon="add" color="danger" right-icon="remove">Danger</modus-button>
@@ -92,20 +92,20 @@ For Icon only Buttons,
 
 #### Solid
 
-<modus-button size="small" color="primary" icon-only="notifications"></modus-button>
-<modus-button color="secondary" icon-only="notifications"></modus-button>
-<modus-button size="large" color="tertiary" icon-only="notifications"></modus-button>
+<modus-button size="small" color="primary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button color="secondary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button size="large" color="tertiary" icon-only="notifications" aria-label="Notifications"></modus-button>
 
 #### Outline
 
-<modus-button button-style="outline" color="primary" icon-only="notifications"></modus-button>
-<modus-button button-style="outline" color="secondary" icon-only="notifications"></modus-button>
+<modus-button button-style="outline" color="primary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button button-style="outline" color="secondary" icon-only="notifications" aria-label="Notifications"></modus-button>
 
 #### Borderless
 
-<modus-button button-style="borderless" color="primary" icon-only="notifications"></modus-button>
-<modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
-<modus-button button-style="borderless" color="tertiary" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="primary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button button-style="borderless" color="secondary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button button-style="borderless" color="tertiary" icon-only="notifications" aria-label="Notifications"></modus-button>
 
 ```html
 <!-- Icon with Text Buttons -->
@@ -115,18 +115,18 @@ For Icon only Buttons,
 <modus-button size="large" left-icon="add" color="danger" right-icon="remove">Danger</modus-button>
 
 <!-- Icon only Buttons - Default(Fill) -->
-<modus-button size="small" color="primary" icon-only="notifications"></modus-button>
-<modus-button color="secondary" icon-only="notifications"></modus-button>
-<modus-button size="large" color="tertiary" icon-only="notifications"></modus-button>
+<modus-button size="small" color="primary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button color="secondary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button size="large" color="tertiary" icon-only="notifications" aria-label="Notifications"></modus-button>
 
 <!-- Icon only Buttons - Outline -->
-<modus-button button-style="outline" color="primary" icon-only="notifications"></modus-button>
-<modus-button button-style="outline" color="secondary" icon-only="notifications"></modus-button>
+<modus-button button-style="outline" color="primary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button button-style="outline" color="secondary" icon-only="notifications" aria-label="Notifications"></modus-button>
 
 <!-- Icon only Buttons - Borderless -->
-<modus-button button-style="borderless" color="primary" icon-only="notifications"></modus-button>
-<modus-button button-style="borderless" color="secondary" icon-only="notifications"></modus-button>
-<modus-button button-style="borderless" color="tertiary" icon-only="notifications"></modus-button>
+<modus-button button-style="borderless" color="primary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button button-style="borderless" color="secondary" icon-only="notifications" aria-label="Notifications"></modus-button>
+<modus-button button-style="borderless" color="tertiary" icon-only="notifications" aria-label="Notifications"></modus-button>
 ```
 
 <Anchor storyId="components-button--with-caret" />


### PR DESCRIPTION
## Description

Add `aria-label` to icon-only buttons on Storybook site.

References #2077

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Locally with Edge v121

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
