### PR TITLE
Navbar: Wrap link item text

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/profile-menu/modus-navbar-profile-menu.scss
@@ -80,6 +80,8 @@
       align-items: center;
       display: flex;
       flex-direction: row;
+      white-space: normal;
+      word-wrap: break-word;
     }
 
     .icon {


### PR DESCRIPTION
## Description

Wrap the Navbar's link item text so that it doesn't overflow the width of the menu

References #2085

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
