### PR TITLE
Navbar: Add hover border/outline to profile menu icon

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -156,13 +156,14 @@ nav {
           width: 32px;
         }
 
-        > :first-child:hover,
-        > :first-child:focus {
-          border: $rem-4px solid $modus-navbar-icon-color;
+        > :first-child:hover {
+          border: $rem-4px solid $modus-navbar-icon-hover-bg;
         }
 
-        > :first-child:active {
-          outline: $rem-4px solid $modus-navbar-profile-icon-active-border-color;
+        > :first-child:active,
+        > :first-child:focus {
+          border: $rem-4px solid $modus-navbar-profile-icon-active-border-color;
+          outline: none;
         }
 
         &:hover {
@@ -220,13 +221,21 @@ nav {
           color: $modus-navbar-blue-profile-icon-initials-color;
         }
 
-        > :first-child:hover,
-        > :first-child:focus {
-          border-color: $modus-navbar-blue-icon-color;
+        > :first-child:hover {
+          border-color: $modus-navbar-blue-icon-hover-bg;
+          border-radius: 50%;
+          outline: $rem-2px solid $modus-navbar-blue-profile-icon-active-border-color;
         }
 
-        > :first-child:active {
-          outline: $rem-4px solid $modus-navbar-blue-profile-icon-active-border-color;
+        > :first-child:active,
+        > :first-child:focus {
+          border-color: $modus-navbar-blue-profile-icon-active-border-color;
+          border-radius: 50%;
+          outline: none;
+        }
+
+        &:hover {
+          cursor: pointer;
         }
       }
     }

--- a/stencil-workspace/src/components/modus-switch/modus-switch.scss
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.scss
@@ -28,6 +28,7 @@
         transform: translateX($rem-14px);
       }
     }
+
     label {
       font-size: $rem-12px;
     }
@@ -95,8 +96,8 @@
 
   label {
     color: $modus-switch-label-color;
-    margin-left: $rem-8px;
     margin-bottom: 0.01rem;
+    margin-left: $rem-8px;
   }
 
   &.disabled {


### PR DESCRIPTION
## Description

Added outline and border color to the profile menu icon when in a hover state.

References [#2088](https://github.com/trimble-oss/modus-web-components/issues/2088) 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
