### PR TITLE
Fix storybook issue with icon names being cropped

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-icons/modus-icons.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-icons/modus-icons.stories.tsx
@@ -46,20 +46,21 @@ export default {
 };
 
 const StyledIcon = `
-  display:flex;
-  flex-direction:column;
-  width: 100px;
   align-items: center;
-  padding: 10px;
-  outline: 1px dashed;
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
   justify-content: space-between;
+  min-width: 100px;
+  outline: 1px dashed;
+  padding: 10px;
 `;
 
 const StyledContent = `
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
-  gap:10px;
-  flex-direction:row;
+  gap: 10px;
 `;
 
 const DefaultTemplateArgs = {


### PR DESCRIPTION
## Description

Changes that box wrapper from `width: 100px` to `min-width: 100px` and alpha-sorts the CSS (as we do that everywhere else).

References #2103

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Locally with Edge v121 on Windows 11.

![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/294207ba-7131-47b8-aa95-1b5c38fd37e5)

PREVIEW: https://deploy-preview-2104--moduswebcomponents.netlify.app/?path=/story/components-icons--default&args=name:battery_charging_horizontal

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
