### PR TITLE
Table: Bold table header text on sort

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
+++ b/stencil-workspace/src/components/modus-table/modus-table.e2e.ts
@@ -298,6 +298,30 @@ describe('modus-table', () => {
     expect(tooltipText).toEqual('Sorted Ascending');
   });
 
+  it('Displays bold header text when sorted', async () => {
+    page = await newE2EPage();
+    await page.setContent('<modus-table />');
+
+    const component = await page.find('modus-table');
+
+    component.setProperty('columns', MockColumns);
+    component.setProperty('data', MockData);
+    component.setProperty('sort', true);
+    await page.waitForChanges();
+
+    let sortHeader = await page.find('modus-table >>> div.can-sort > span');
+    let style = await sortHeader.getComputedStyle();
+    expect(style['font-weight']).toBe('600');
+
+    const header = await page.find('modus-table >>> .sort-icon');
+    await header.click();
+    await page.waitForChanges();
+
+    sortHeader = await page.find('modus-table >>> div.can-sort > span');
+    style = await sortHeader.getComputedStyle();
+    expect(style['font-weight']).toBe('700');
+  });
+
   it('Render pagination when pagination is enabled', async () => {
     page = await newE2EPage();
     await page.setContent('<modus-table />');

--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -112,6 +112,10 @@ table {
           display: flex;
           justify-content: space-between;
 
+          .sorted {
+            font-weight: bold;
+          }
+
           .sort-icon-container {
             cursor: pointer;
             padding: $rem-2px $rem-2px 0;

--- a/stencil-workspace/src/components/modus-table/parts/columnHeader/modus-table-column-header.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/columnHeader/modus-table-column-header.tsx
@@ -74,7 +74,7 @@ export const ModusTableColumnHeader: FunctionalComponent<ModusTableColumnHeaderP
       }}>
       {isPlaceholder ? null : ( // header.isPlaceholder is Required for nested column headers to display empty cell
         <div class={column.getCanSort() && 'can-sort'}>
-          <span>{column.columnDef.header}</span>
+          <span class={column.getCanSort() && column.getIsSorted() ? 'sorted' : ''}>{column.columnDef.header}</span>
           {column.getCanSort() && (
             <ModusTableColumnSortIcon
               column={column}


### PR DESCRIPTION
## Description

Bold table column header text when sorting by column.

We received feedback from users that it is difficult to see what column is used for sorting. Bolding the header text would draw attention and make the sorted column stand out from the rest.

References #2097 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added e2e test to validate
All unit and e2e tests passed when executing `npm run test`
Exploratory testing also performed in browser using modus-table component

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
