### PR TITLE
Form inputs: CSS change to `border-radius: 4px`

### DIFF
--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.scss
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.scss
@@ -11,6 +11,7 @@
 
   .options-container {
     background-color: $modus-autocomplete-options-background-color;
+    border-radius: 4px;
     box-shadow: $box-shadow;
     font-family: $primary-font;
     margin: 0;
@@ -54,6 +55,7 @@
     .no-results {
       align-items: center;
       border: 1px solid $modus-autocomplete-options-border-color;
+      border-radius: 4px;
       display: flex;
       flex-direction: column;
       height: 100px;

--- a/stencil-workspace/src/components/modus-date-input/modus-date-input.scss
+++ b/stencil-workspace/src/components/modus-date-input/modus-date-input.scss
@@ -43,6 +43,7 @@
     background-color: $modus-input-bg;
     border: $rem-1px solid $modus-input-border-color;
     border-bottom-color: $modus-input-bottom-line-color;
+    border-radius: 4px;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.scss
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.scss
@@ -38,6 +38,7 @@
 
   .calendar-container {
     background-color: $modus-date-picker-calendar-body-bg;
+    border-radius: 4px;
     box-shadow: 0 0 4px #00000029;
     display: flex;
     flex-direction: column;
@@ -49,6 +50,8 @@
     .calendar-header {
       align-items: center;
       background-color: $modus-date-picker-calendar-header-bg;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
       color: $modus-date-picker-calendar-header-color;
       display: flex;
       font: normal normal 600 16px/22px $primary-font;

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
@@ -32,6 +32,7 @@
     background-color: $modus-input-bg;
     border: $rem-1px solid $modus-input-border-color;
     border-bottom-color: $modus-input-bottom-line-color;
+    border-radius: 4px;
     display: flex;
     flex-direction: row;
     height: 32px;

--- a/stencil-workspace/src/components/modus-select/modus-select.scss
+++ b/stencil-workspace/src/components/modus-select/modus-select.scss
@@ -32,6 +32,7 @@
       background-color: $modus-input-bg;
       border: solid $rem-1px $modus-input-border-color;
       border-bottom-color: $modus-input-bottom-line-color;
+      border-radius: 4px;
       color: $modus-select-color;
       display: flex;
       font-family: $primary-font;

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -1,6 +1,7 @@
 @import './modus-text-input.vars';
 
 .modus-text-input {
+  border-radius: 4px;
   display: inline-flex;
   flex-direction: column;
   font-family: $primary-font;
@@ -33,6 +34,7 @@
     background-color: $modus-input-bg;
     border: $rem-1px solid $modus-input-border-color;
     border-bottom-color: $modus-input-bottom-line-color;
+    border-radius: 4px;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.scss
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.scss
@@ -49,6 +49,7 @@
     background-color: $modus-input-bg;
     border: $rem-1px solid $modus-input-border-color;
     border-bottom-color: $modus-input-bottom-line-color;
+    border-radius: 4px;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
## Description

Change Form inputs to have `border-radius: 4px` for form inputs:
- Autocomplete
- Text Input
- Date Input
- Number Input

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Storybook with Edge v121 on Windows 11

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
