### PR TITLE
Table: Add support for wrapping hyperlink cells

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -197,7 +197,8 @@ table {
     tr {
       color: $modus-table-body-color;
 
-      .truncate-text {
+      .truncate-text,
+      .truncate-text .cell-link {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-link-element.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-link-element.tsx
@@ -20,7 +20,7 @@ export const ModusTableCellLinkElement: FunctionalComponent<ModusTableCellLinkPr
   }
 
   return (
-    <div class="cell-link truncate-text" tabIndex={0} onClick={() => onLinkClick(link)} onKeyDown={handleLinkKeyDown}>
+    <div class="cell-link" tabIndex={0} onClick={() => onLinkClick(link)} onKeyDown={handleLinkKeyDown}>
       {link.display}
     </div>
   );

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -155,19 +155,7 @@ export class ModusTableCellMain {
 
     const { cellLinkClick, wrapText } = this.context;
     const cellDataType = cellValue['_type'] ?? this.cell.column.columnDef[COLUMN_DEF_DATATYPE_KEY];
-
-    let wrap: boolean;
-    switch (cellDataType) {
-      case COLUMN_DEF_DATATYPE_BADGE:
-        wrap = false;
-        break;
-      case COLUMN_DEF_DATATYPE_LINK:
-        wrap = true;
-        break;
-      default:
-        wrap = wrapText;
-        break;
-    }
+    const wrap: boolean = cellDataType === COLUMN_DEF_DATATYPE_BADGE ? false : wrapText;
 
     const classes = {
       'cell-content': true,

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -183,12 +183,7 @@ export class ModusTableCellMain {
       <div class={classes}>
         {this.hasRowsExpandable && <ModusTableCellExpandIcons row={row} />}
 
-        <span
-          class={
-            wrapText && cellDataType !== COLUMN_DEF_DATATYPE_BADGE && cellDataType !== COLUMN_DEF_DATATYPE_LINK
-              ? 'wrap-text'
-              : 'truncate-text'
-          }>
+        <span class={wrapText && cellDataType !== COLUMN_DEF_DATATYPE_BADGE ? 'wrap-text' : 'truncate-text'}>
           {renderCell()}
         </span>
       </div>

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -155,10 +155,24 @@ export class ModusTableCellMain {
 
     const { cellLinkClick, wrapText } = this.context;
     const cellDataType = cellValue['_type'] ?? this.cell.column.columnDef[COLUMN_DEF_DATATYPE_KEY];
+
+    let wrap: boolean;
+    switch (cellDataType) {
+      case COLUMN_DEF_DATATYPE_BADGE:
+        wrap = false;
+        break;
+      case COLUMN_DEF_DATATYPE_LINK:
+        wrap = true;
+        break;
+      default:
+        wrap = wrapText;
+        break;
+    }
+
     const classes = {
       'cell-content': true,
-      'truncate-text': !wrapText,
-      'wrap-text': wrapText,
+      'truncate-text': !wrap,
+      'wrap-text': wrap,
       'text-align-right': cellDataType === COLUMN_DEF_DATATYPE_INTEGER,
     };
 
@@ -183,9 +197,7 @@ export class ModusTableCellMain {
       <div class={classes}>
         {this.hasRowsExpandable && <ModusTableCellExpandIcons row={row} />}
 
-        <span class={wrapText && cellDataType !== COLUMN_DEF_DATATYPE_BADGE ? 'wrap-text' : 'truncate-text'}>
-          {renderCell()}
-        </span>
+        <span class={wrap ? 'wrap-text' : 'truncate-text'}>{renderCell()}</span>
       </div>
     );
   }


### PR DESCRIPTION
## Description
Wrap the hyperlink in the modus-table when `wrapText` is enabled.
![image](https://github.com/trimble-oss/modus-web-components/assets/135632243/51c7c979-3929-4a8d-b65b-a7092621f0ef)


References #1998

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
