### PR TITLE
Select: Use Custom Modus Icon

### DIFF
--- a/stencil-workspace/src/components/modus-select/modus-select.scss
+++ b/stencil-workspace/src/components/modus-select/modus-select.scss
@@ -29,7 +29,12 @@
 
     select {
       align-items: center;
+      appearance: none;
       background-color: $modus-input-bg;
+      background-image: $modus-select-bg-image;
+      background-position: right 0.5rem center;
+      background-repeat: no-repeat;
+      background-size: 16px 12px;
       border: solid $rem-1px $modus-input-border-color;
       border-bottom-color: $modus-input-bottom-line-color;
       border-radius: 4px;
@@ -39,6 +44,7 @@
       font-size: $rem-12px;
       height: $rem-32px;
       padding-left: $rem-10px;
+      padding-right: 2rem;
       position: relative;
       width: 100%;
 

--- a/stencil-workspace/src/components/modus-select/modus-select.vars.scss
+++ b/stencil-workspace/src/components/modus-select/modus-select.vars.scss
@@ -6,6 +6,10 @@ $modus-input-bottom-line-active-color: var(--modus-input-bottom-line-active-colo
 $modus-input-label-color: var(--modus-input-label-color, #464b52) !default;
 $modus-input-helper-icon-color: var(--modus-input-helper-icon-color, #6a6e79);
 $modus-select-color: var(--modus-input-color, #464b52) !default;
+$modus-select-bg-image: var(
+  --modus-select-bg-image,
+  url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"%3e%3cpath fill="none" stroke="%231b1a26" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m2 5 6 6 6-6"/%3e%3c/svg>')
+) !default;
 
 // Validation
 $modus-input-validation-success-color: var(--modus-input-validation-success-color, #006638) !default;

--- a/stencil-workspace/src/global/themes.scss
+++ b/stencil-workspace/src/global/themes.scss
@@ -549,6 +549,9 @@
   // Input read-only
   --modus-input-readonly-bg: #353a40;
 
+  // Select
+  --modus-select-bg-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"%3e%3cpath fill="none" stroke="%23fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m2 5 6 6 6-6"/%3e%3c/svg>');
+
   // Checkbox and Radio button Inputs
   --modus-check-input-bg: transparent;
   --modus-check-input-disabled-opacity: 0.4;


### PR DESCRIPTION
## Description

Select: Use Custom Modus Icon

Fixes: #2125

This is a big improvement - improved padding and icon is less thick!
BEFORE:
![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/2b1b7d07-1f9b-41f6-8bcb-0e37ec01a356)

AFTER:
![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/d092ed22-af6c-4e3b-837a-ceccdbfd7e37)

PREVIEW: https://deploy-preview-2127--moduswebcomponents.netlify.app/?path=/docs/user-inputs-select--default

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Firefox, Edge, Chrome

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
