### PR TITLE
Autocomplete: Tab "X" icon is part of the tabbing sequence / Should clear on enter or space

### DIFF
--- a/stencil-workspace/generate-icons/ModusIconMap.template.ejs
+++ b/stencil-workspace/generate-icons/ModusIconMap.template.ejs
@@ -11,8 +11,10 @@ import { <%= icon.name %> } from './generated-icons/<%= icon.name %>';
 export interface IconProps {
     color?: string;
     onClick?: (event?) => void;
+    onKeyDown?: (event?) => void;
     size?: string;
     pressed?: boolean;
+    tabindex?: number;
 }
 
 interface ModusIconMapProps extends IconProps {

--- a/stencil-workspace/src/components/modus-modal/modus-modal.spec.ts
+++ b/stencil-workspace/src/components/modus-modal/modus-modal.spec.ts
@@ -15,7 +15,7 @@ describe('modus-modal', () => {
                 <div id="startTrap" tabindex="0" aria-hidden="true"></div>
                  <header>
                   <div role="button" tabindex="0" aria-label="Close">
-                      <svg class="icon-close" height="20" width="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <svg class="icon-close" height="20" width="20" tabindex="0" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <g clip-path="url(#clip0)">
                             <path d="M19 7.30929L17.6907 6L12.5 11.1907L7.30929 6L6 7.30929L11.1907 12.5L6 17.6907L7.30929 19L12.5 13.8093L17.6907 19L19 17.6907L13.8093 12.5L19 7.30929Z" fill="currentColor"></path>
                         </g>

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.e2e.ts
@@ -279,4 +279,44 @@ describe('modus-text-input', () => {
     const input = await page.find('modus-text-input >>> input');
     expect(await input.getProperty('autocomplete')).toEqual('off');
   });
+
+  it('should clear on Enter', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-text-input clearable value="Some value"></modus-text-input>');
+
+    const input = await page.find('modus-text-input');
+    input.click();
+    await page.waitForChanges();
+
+    await page.keyboard.press('Tab');
+
+    const valueChange = await page.spyOnEvent('valueChange');
+    await page.keyboard.press('Enter');
+    await page.waitForChanges();
+
+    const textInput = await page.find('modus-text-input');
+    expect(await textInput.getProperty('value')).toBeFalsy();
+    expect(valueChange).toHaveReceivedEvent();
+  });
+
+  it('should clear on space', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-text-input clearable value="Some value"></modus-text-input>');
+
+    const input = await page.find('modus-text-input');
+    input.click();
+    await page.waitForChanges();
+
+    await page.keyboard.press('Tab');
+
+    const valueChange = await page.spyOnEvent('valueChange');
+    await page.keyboard.press(' ');
+    await page.waitForChanges();
+
+    const textInput = await page.find('modus-text-input');
+    expect(await textInput.getProperty('value')).toBeFalsy();
+    expect(valueChange).toHaveReceivedEvent();
+  });
 });

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -97,6 +97,14 @@ export class ModusTextInput {
     this.valueChange.emit(null);
   }
 
+  handleKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter' || e.key === ' ') {
+      this.handleClear();
+      this.focusInput();
+      e.preventDefault();
+    }
+  }
+
   handleOnInput(event: Event): void {
     const value = (event.currentTarget as HTMLInputElement).value;
     this.value = value;
@@ -194,7 +202,7 @@ export class ModusTextInput {
           )}
           {showClearIcon && (
             <span class="icons clear" role="button" aria-label="Clear entry">
-              <IconClose onClick={() => this.handleClear()} size="16" />
+              <IconClose onClick={() => this.handleClear()} onKeyDown={(e) => this.handleKeyDown(e)} size="16" />
             </span>
           )}
         </div>

--- a/stencil-workspace/src/icons/svgs/icon-close.tsx
+++ b/stencil-workspace/src/icons/svgs/icon-close.tsx
@@ -7,7 +7,9 @@ export const IconClose: FunctionalComponent<IconProps> = (props: IconProps) => (
     class={`icon-close ${props.pressed ? 'pressed' : ''}`}
     height={props.size ?? 16}
     width={props.size ?? 16}
+    tabindex={props.tabindex ?? 0}
     onClick={props.onClick ? () => props.onClick() : null}
+    onKeyDown={props.onKeyDown ? (e) => props.onKeyDown(e) : null}
     viewBox="0 0 24 24"
     fill="none"
     xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION

## Description

Autocomplete: Tab "X" icon is part of the tabbing sequence / Should clear on enter or space

References https://github.com/trimble-oss/modus-web-components/issues/2132

https://e-builderinc.atlassian.net/browse/EPD-12104

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
