### PR TITLE
Button: Fix icon-only button width inconsistency

### DIFF
--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -67,6 +67,7 @@ button {
     &.icon-only {
       height: 24px;
       padding: 0;
+      width: 24px;
 
       &.has-caret {
         padding: 0 4px;
@@ -100,6 +101,7 @@ button {
     &.icon-only {
       height: 40px;
       padding: 0;
+      width: 40px;
 
       &.has-caret {
         padding: 0 4px;
@@ -133,6 +135,7 @@ button {
     &.icon-only {
       height: 48px;
       padding: 0;
+      width: 48px;
 
       &.has-caret {
         padding: 0 8px 0 4px;


### PR DESCRIPTION
## Description

This PR changes icon-only buttons to be the same set height as width.

References #1626

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v121

Preview URL: https://deploy-preview-2148--moduswebcomponents.netlify.app/?path=/story/components-button--icon-only&args=size:medium

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
