### PR TITLE
Dropdown: Change border-radius to 4px

### DIFF
--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.scss
@@ -10,7 +10,7 @@
 
   .dropdown-list {
     border-collapse: collapse;
-    border-radius: $rem-1px !important;
+    border-radius: $rem-4px;
     display: none;
     max-height: 200px;
     max-width: 300px;

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -4,6 +4,7 @@ li {
   align-items: center;
   background-color: $modus-list-item-bg;
   border: 1px solid $modus-list-item-border-color;
+  border-radius: 4px;
   box-sizing: border-box;
   color: $modus-list-item-color;
   display: flex;

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
@@ -21,7 +21,7 @@ export default {
 };
 
 const Template = () => html`
-  <modus-dropdown toggle-element-id="toggleElement">
+  <modus-dropdown toggle-element-id="toggleElement" aria-label="Dropdown">
   <modus-button id="toggleElement" slot="dropdownToggle" show-caret="true">Dropdown</modus-button>
   <modus-list slot="dropdownList">
     <modus-list-item size="condensed" borderless>Item 1</modus-list-item>


### PR DESCRIPTION
## Description

I also made a small change to the Storybook Canvas demo to fix one of the two accessibility issues (by adding aria-label to the dropdown).

Partial fix for: #1195

Preview: https://deploy-preview-2164--moduswebcomponents.netlify.app/?path=/story/components-dropdown--default

![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/fb74d1b4-b516-4daf-aaac-0abbf107b492)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Locally with Edge v121 on Windows 11 Pro

https://deploy-preview-2164--moduswebcomponents.netlify.app/?path=/story/components-dropdown--default

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
