### PR TITLE
Breadcrumb: Remove unnecessary `role="navigation"` from navs

### DIFF
--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.spec.ts
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.spec.ts
@@ -10,7 +10,7 @@ describe('modus-breadcrumb', () => {
     expect(root).toEqualHtml(`
       <modus-breadcrumb>
         <mock:shadow-root>
-          <nav role='navigation'>
+          <nav>
             <ol></ol>
           </nav>
         </mock:shadow-root>

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
@@ -23,7 +23,7 @@ export class ModusBreadcrumb {
 
   render(): unknown {
     return (
-      <nav aria-label={this.ariaLabel} role="navigation">
+      <nav aria-label={this.ariaLabel}>
         <ol>
           {this.crumbs.map((crumb, index) => (
             <li key={crumb.id}>

--- a/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.spec.tsx
+++ b/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.spec.tsx
@@ -11,7 +11,7 @@ describe('modus-side-navigation', () => {
     expect(page.root).toEqualHtml(`
       <modus-side-navigation>
         <mock:shadow-root>
-          <nav role="navigation"
+          <nav
             class="side-nav-panel"
             aria-label="side navigation">
             <div class="side-nav-level center">
@@ -24,6 +24,7 @@ describe('modus-side-navigation', () => {
       </modus-side-navigation>
     `);
   });
+  ``;
   it('renders root with item', async () => {
     const page = await newSpecPage({
       components: [ModusSideNavigation],
@@ -40,7 +41,7 @@ describe('modus-side-navigation', () => {
     expect(page.root).toEqualHtml(`
       <modus-side-navigation>
         <mock:shadow-root>
-          <nav role="navigation"
+          <nav
             class="side-nav-panel"
             aria-label="side navigation">
             <div class="side-nav-level center">

--- a/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.tsx
+++ b/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.tsx
@@ -370,7 +370,6 @@ export class ModusSideNavigation {
   render() {
     return (
       <nav
-        role="navigation"
         class={`side-nav-panel${this.expanded ? ' expanded' : ''}`}
         style={{ width: this.expanded ? this.maxWidth : null }}
         onKeyDown={(e) => this.handleKeyDown(e)}


### PR DESCRIPTION
## Description

REF: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role#:~:text=Note%3A%20Using%20the%20%3Cnav%3E%20element%20will%20automatically%20communicate%20a%20section%20has%20a%20role%20of%20navigation.%20Developers%20should%20always%20prefer%20using%20the%20correct%20semantic%20HTML%20element%20over%20using%20ARIA

Fixes: #2165

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v121 and NVDA for Windows

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
