### PR TITLE
Breadcrumbs: Add underline property

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -176,14 +176,14 @@ export declare interface ModusBadge extends Components.ModusBadge {}
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'crumbs']
+  inputs: ['ariaLabel', 'crumbs', 'underline']
 })
 @Component({
   selector: 'modus-breadcrumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'crumbs'],
+  inputs: ['ariaLabel', 'crumbs', 'underline'],
 })
 export class ModusBreadcrumb {
   protected el: HTMLElement;

--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -176,14 +176,14 @@ export declare interface ModusBadge extends Components.ModusBadge {}
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'crumbs', 'underline']
+  inputs: ['ariaLabel', 'crumbs', 'underlineLinks']
 })
 @Component({
   selector: 'modus-breadcrumb',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'crumbs', 'underline'],
+  inputs: ['ariaLabel', 'crumbs', 'underlineLinks'],
 })
 export class ModusBreadcrumb {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -226,7 +226,7 @@ export namespace Components {
         /**
           * (optional) A flag that controls the display of underline
          */
-        "underline": boolean;
+        "underlineLinks": boolean;
     }
     interface ModusButton {
         /**
@@ -2318,7 +2318,7 @@ declare namespace LocalJSX {
         /**
           * (optional) A flag that controls the display of underline
          */
-        "underline"?: boolean;
+        "underlineLinks"?: boolean;
     }
     interface ModusButton {
         /**

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -223,6 +223,10 @@ export namespace Components {
           * The breadcrumbs to render.
          */
         "crumbs": Crumb[];
+        /**
+          * (optional) A flag that controls the display of underline
+         */
+        "underline": boolean;
     }
     interface ModusButton {
         /**
@@ -2311,6 +2315,10 @@ declare namespace LocalJSX {
           * (optional) An event that fires on breadcrumb click.
          */
         "onCrumbClick"?: (event: ModusBreadcrumbCustomEvent<Crumb>) => void;
+        /**
+          * (optional) A flag that controls the display of underline
+         */
+        "underline"?: boolean;
     }
     interface ModusButton {
         /**

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.scss
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.scss
@@ -30,6 +30,12 @@ nav {
           }
         }
 
+        &.underline {
+          a {
+            text-decoration: underline;
+          }
+        }
+
         .divider {
           color: $modus-breadcrumb-divider-color;
           cursor: default;

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
@@ -19,7 +19,7 @@ export class ModusBreadcrumb {
   @Prop() crumbs: Crumb[] = [];
 
   /**(optional) A flag that controls the display of underline */
-  @Prop() underline: boolean;
+  @Prop() underlineLinks: boolean;
 
   /** (optional) An event that fires on breadcrumb click. */
   @Event() crumbClick: EventEmitter<Crumb>;
@@ -31,7 +31,7 @@ export class ModusBreadcrumb {
           {this.crumbs.map((crumb, index) => (
             <li key={crumb.id}>
               {index < this.crumbs.length - 1 ? (
-                <span class={`crumb ${this.underline ? 'underline' : ''}`}>
+                <span class={`crumb ${this.underlineLinks ? 'underline' : ''}`}>
                   <a onClick={() => this.crumbClick.emit(crumb)}>{crumb.display}</a>
                   <span class="divider">{'>'}</span>
                 </span>

--- a/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
+++ b/stencil-workspace/src/components/modus-breadcrumb/modus-breadcrumb.tsx
@@ -18,6 +18,9 @@ export class ModusBreadcrumb {
   /** The breadcrumbs to render. */
   @Prop() crumbs: Crumb[] = [];
 
+  /**(optional) A flag that controls the display of underline */
+  @Prop() underline: boolean;
+
   /** (optional) An event that fires on breadcrumb click. */
   @Event() crumbClick: EventEmitter<Crumb>;
 
@@ -28,7 +31,7 @@ export class ModusBreadcrumb {
           {this.crumbs.map((crumb, index) => (
             <li key={crumb.id}>
               {index < this.crumbs.length - 1 ? (
-                <span class="crumb">
+                <span class={`crumb ${this.underline ? 'underline' : ''}`}>
                   <a onClick={() => this.crumbClick.emit(crumb)}>{crumb.display}</a>
                   <span class="divider">{'>'}</span>
                 </span>

--- a/stencil-workspace/src/components/modus-breadcrumb/readme.md
+++ b/stencil-workspace/src/components/modus-breadcrumb/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                              | Type      | Default     |
-| ----------- | ------------ | -------------------------------------------------------- | --------- | ----------- |
-| `ariaLabel` | `aria-label` | The breadcrumb's aria-label.                             | `string`  | `undefined` |
-| `crumbs`    | --           | The breadcrumbs to render.                               | `Crumb[]` | `[]`        |
-| `underline` | `underline`  | (optional) A flag that controls the display of underline | `boolean` | `undefined` |
+| Property         | Attribute         | Description                                              | Type      | Default     |
+| ---------------- | ----------------- | -------------------------------------------------------- | --------- | ----------- |
+| `ariaLabel`      | `aria-label`      | The breadcrumb's aria-label.                             | `string`  | `undefined` |
+| `crumbs`         | --                | The breadcrumbs to render.                               | `Crumb[]` | `[]`        |
+| `underlineLinks` | `underline-links` | (optional) A flag that controls the display of underline | `boolean` | `undefined` |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-breadcrumb/readme.md
+++ b/stencil-workspace/src/components/modus-breadcrumb/readme.md
@@ -7,10 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                  | Type      | Default     |
-| ----------- | ------------ | ---------------------------- | --------- | ----------- |
-| `ariaLabel` | `aria-label` | The breadcrumb's aria-label. | `string`  | `undefined` |
-| `crumbs`    | --           | The breadcrumbs to render.   | `Crumb[]` | `[]`        |
+| Property    | Attribute    | Description                                     | Type      | Default     |
+| ----------- | ------------ | ----------------------------------------------- | --------- | ----------- |
+| `ariaLabel` | `aria-label` | The breadcrumb's aria-label.                    | `string`  | `undefined` |
+| `crumbs`    | --           | The breadcrumbs to render.                      | `Crumb[]` | `[]`        |
+| `underline` | `underline`  | (optional) The breadcrumbs to have an underline | `boolean` | `undefined` |
 
 
 ## Events

--- a/stencil-workspace/src/components/modus-breadcrumb/readme.md
+++ b/stencil-workspace/src/components/modus-breadcrumb/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property    | Attribute    | Description                                     | Type      | Default     |
-| ----------- | ------------ | ----------------------------------------------- | --------- | ----------- |
-| `ariaLabel` | `aria-label` | The breadcrumb's aria-label.                    | `string`  | `undefined` |
-| `crumbs`    | --           | The breadcrumbs to render.                      | `Crumb[]` | `[]`        |
-| `underline` | `underline`  | (optional) The breadcrumbs to have an underline | `boolean` | `undefined` |
+| Property    | Attribute    | Description                                              | Type      | Default     |
+| ----------- | ------------ | -------------------------------------------------------- | --------- | ----------- |
+| `ariaLabel` | `aria-label` | The breadcrumb's aria-label.                             | `string`  | `undefined` |
+| `crumbs`    | --           | The breadcrumbs to render.                               | `Crumb[]` | `[]`        |
+| `underline` | `underline`  | (optional) A flag that controls the display of underline | `boolean` | `undefined` |
 
 
 ## Events

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
@@ -44,7 +44,7 @@ A new TypeScript typing has been provided named Crumb defined as:
 | ------------ | --------------------------------------------- | --------- | ------- | ------------- | -------- |
 | `ariaLabel`  | The breadcrumb's aria-label                   | `string`  |         |               |          |
 | `crumbs`     | The breadcrumbs to render                     | `Crumb[]` |         | `[]`          | &#10004; |
-| `underline`  | A flag that controls the display of underline | `boolean` |         | `false`       |          |
+| `underlineLinks`  | A flag that controls the display of underline | `boolean` |         | `false`       |          |
 
 
 ### DOM Events

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
@@ -40,69 +40,19 @@ A new TypeScript typing has been provided named Crumb defined as:
 
 ### Properties
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Type</th>
-        <th>Options</th>
-        <th>Default Value</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>crumbs</td>
-        <td>The breadcrumbs to render</td>
-        <td>Crumb[]</td>
-        <td></td>
-        <td>[]</td>
-        <td>
-          <span class="material-icons">&#10004;</span>
-        </td>
-      </tr>
-      <tr>
-        <td>aria-label</td>
-        <td>The breadcrumb's aria-label</td>
-        <td>string</td>
-        <td></td>
-        <td></td>
-        <td></td>
-      </tr>
-      <tr>
-        <td>underline</td>
-        <td>A flag that controls the display of underline</td>
-        <td>boolean</td>
-        <td></td>
-        <td>false</td>
-        <td></td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name         | Description                                   | Type      | Options | Default Value | Required |
+| ------------ | --------------------------------------------- | --------- | ------- | ------------- | -------- |
+| `ariaLabel`  | The breadcrumb's aria-label                   | `string`  |         |               |          |
+| `crumbs`     | The breadcrumbs to render                     | `Crumb[]` |         | `[]`          | &#10004; |
+| `underline`  | A flag that controls the display of underline | `boolean` |         | `false`       |          |
+
 
 ### DOM Events
 
-<section>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Description</th>
-        <th>Emits</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>crumbClick</td>
-        <td>Fires on breadcrumb click</td>
-        <td>The clicked crumb object</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
+| Name         | Description               | Emits                    |
+| ------------ | ------------------------- | ------------------------ |
+| `crumbClick` | Fires on breadcrumb click | The clicked crumb object |
+
 
 ### Accessibility
 

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb-storybook-docs.mdx
@@ -71,6 +71,14 @@ A new TypeScript typing has been provided named Crumb defined as:
         <td></td>
         <td></td>
       </tr>
+      <tr>
+        <td>underline</td>
+        <td>A flag that controls the display of underline</td>
+        <td>boolean</td>
+        <td></td>
+        <td>false</td>
+        <td></td>
+      </tr>
     </tbody>
   </table>
 </section>

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
@@ -29,26 +29,18 @@ export default {
   },
 };
 
+const defaultCrumbs = [
+  { id: '1', display: 'Crumb 1' },
+  { id: '2', display: 'Crumb 2' },
+  { id: '3', display: 'Crumb 3' },
+  { id: '4', display: 'Crumb 4' },
+];
+
 const Template = ({underline}) => html`
-  <modus-breadcrumb underline=${underline}></modus-breadcrumb>
-  ${setBreadcrumb()}
+  <modus-breadcrumb underline=${underline} .crumbs=${defaultCrumbs}></modus-breadcrumb>
 `;
 export const Default = Template.bind({});
 Default.args = { underline: false };
+
 export const Underline = Template.bind({});
 Underline.args = { underline: true };
-// The <script> tag cannot be used in the MDX file, so we use this method to
-// set the breadcrumbs for the default story.
-const setBreadcrumb = () => {
-  const tag = document.createElement('script');
-  tag.innerHTML = `
-   document.querySelector('modus-breadcrumb').crumbs = [
-      { id: '1', display: 'Crumb 1' },
-      { id: '2', display: 'Crumb 2' },
-      { id: '3', display: 'Crumb 3' },
-      { id: '4', display: 'Crumb 4' },
-    ];
-  `;
-
-  return tag;
-};

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
@@ -4,13 +4,24 @@ import { html } from 'lit-html';
 
 export default {
   title: 'Components/Breadcrumb',
+  argTypes: {
+    underline:{
+      name: 'underline',
+      description: 'A flag that controls the display of underline',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
+    },
   parameters: {
     docs: {
       inlineStories: false,
       page: docs,
     },
     controls: {
-      disabled: true,
+      disabled: false,
+      expanded: true,
     },
     options: {
       isToolshown: true,
@@ -18,12 +29,14 @@ export default {
   },
 };
 
-const Template = () => html`
-  <modus-breadcrumb></modus-breadcrumb>
+const Template = ({underline}) => html`
+  <modus-breadcrumb underline=${underline}></modus-breadcrumb>
   ${setBreadcrumb()}
 `;
 export const Default = Template.bind({});
-
+Default.args = { underline: false };
+export const Underline = Template.bind({});
+Underline.args = { underline: true };
 // The <script> tag cannot be used in the MDX file, so we use this method to
 // set the breadcrumbs for the default story.
 const setBreadcrumb = () => {

--- a/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-breadcrumb/modus-breadcrumb.stories.tsx
@@ -5,8 +5,8 @@ import { html } from 'lit-html';
 export default {
   title: 'Components/Breadcrumb',
   argTypes: {
-    underline:{
-      name: 'underline',
+    underlineLinks:{
+      name: 'underlineLinks',
       description: 'A flag that controls the display of underline',
       table: {
         defaultValue: { summary: false },
@@ -36,11 +36,11 @@ const defaultCrumbs = [
   { id: '4', display: 'Crumb 4' },
 ];
 
-const Template = ({underline}) => html`
-  <modus-breadcrumb underline=${underline} .crumbs=${defaultCrumbs}></modus-breadcrumb>
+const Template = ({underlineLinks}) => html`
+  <modus-breadcrumb underline-links=${underlineLinks} .crumbs=${defaultCrumbs}></modus-breadcrumb>
 `;
 export const Default = Template.bind({});
-Default.args = { underline: false };
+Default.args = { underlineLinks: false };
 
 export const Underline = Template.bind({});
-Underline.args = { underline: true };
+Underline.args = { underlineLinks: true };


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Added a prop `underline`  for the underline to be displayed with the breadcrumbs.

References #<!-- issue number -->
#2168 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

https://deploy-preview-2196--moduswebcomponents.netlify.app/?path=/story/components-breadcrumb--default&args=underline:true

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
