### PR TITLE
Release v0.19.0

### DIFF
--- a/stencil-workspace/package-lock.json
+++ b/stencil-workspace/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@trimble-oss/modus-web-components",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
@@ -39,8 +39,8 @@
         "typescript": "^4.9.5"
       },
       "engines": {
-        "node": ">=14",
-        "npm": ">=7"
+        "node": ">=16",
+        "npm": ">=8"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/stencil-workspace/package.json
+++ b/stencil-workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trimble-oss/modus-web-components",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Trimble Modus Web Component Library",
   "homepage": "https://modus-web-components.trimble.com/",
   "bugs": {
@@ -70,8 +70,8 @@
     "typescript": "^4.9.5"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=7"
+    "node": ">=16",
+    "npm": ">=8"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I bumped Node version requirement because we only test on Node 16 and Node v14 is super-old and unsupported. Some of the linting dev-dependencies require Node 16 at a minimum too and I'm sure next version of Stencil won't support Node v14....

Plus, even if someone is using Modus Web Components with Node 14 it'll still continue to work as before (but they may get a warning in the console).