### PR TITLE
Data Table: Remove row action menu dropdown border

### DIFF
--- a/stencil-workspace/src/components/modus-data-table/parts/modus-data-table-row-action-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-data-table/parts/modus-data-table-row-action-dropdown.tsx
@@ -15,7 +15,8 @@ export const ModusDataTableRowActionDropdown: FunctionalComponent<Props> = (prop
     <modus-dropdown
       toggle-element-id={`dropdownToggle-${props.rowId}`}
       animate-list={props.animateDropdown}
-      customPlacement={{ left: -194 }}>
+      customPlacement={{ left: -194 }}
+      showDropdownListBorder={false}>
       <div class="row-action" id={`dropdownToggle-${props.rowId}`} slot="dropdownToggle">
         <ModusIconMap icon="more_vertical" size="24" />
       </div>


### PR DESCRIPTION
## Description

Remove the border on the deprecated table's context menu dropdown

References #2229

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
