### PR TITLE
Sentiment Scale: Remove hover state for disabled state

### DIFF
--- a/stencil-workspace/src/components/modus-sentiment-scale/modus-sentiment-scale.scss
+++ b/stencil-workspace/src/components/modus-sentiment-scale/modus-sentiment-scale.scss
@@ -26,6 +26,10 @@
     margin-right: 10px;
   }
 
+  &[aria-disabled='true'] {
+    pointer-events: none;
+  }
+
   .disabled {
     opacity: $modus-sentiment-scale-disabled-opacity;
 


### PR DESCRIPTION
## Description

REF: https://modus-web-components.trimble.com/?path=/story/components-sentiment-scale--default&args=ariaLabel:was+this+page;disabled:true

Disabled sentiment scale was displaying as if it was enabled with hover state color change and pointer change. This PR removes the pointer events.

References #<!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
