### PR TITLE
Accordion: Use Modus Icons for Expand/Collapse

### DIFF
--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.e2e.ts
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.e2e.ts
@@ -55,7 +55,7 @@ describe('modus-accordion-item', () => {
     await page.setContent('<modus-accordion-item></modus-accordion-item>');
     const component = await page.find('modus-accordion-item');
     const headerElement = await page.find('modus-accordion-item >>> .header');
-    const iconElement = await page.find('modus-accordion-item >>> .icon-chevron-down-thick');
+    const iconElement = await page.find('modus-accordion-item >>> .icon-expand-more');
     let iconComputedStyle = await iconElement.getComputedStyle();
     expect(headerElement).toHaveClass('standard');
     expect(iconComputedStyle['height']).toEqual('24px');

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.scss
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.scss
@@ -36,21 +36,21 @@
     }
 
     .title {
-      padding-left: $rem-4px;
+      padding-left: $rem-8px;
     }
 
     .chevron-container {
       align-items: center;
       display: flex;
       margin-left: auto;
+      margin-right: $rem-8px;
       transition: transform 0.2s ease-in-out;
 
       &.reverse {
         transform: rotate(-180deg);
       }
 
-      .icon-chevron-up-thick,
-      .icon-chevron-down-thick {
+      svg {
         path {
           fill: $modus-accordion-item-chevron-color;
         }

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.spec.ts
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.spec.ts
@@ -14,8 +14,8 @@ describe('modus-accordion-item', () => {
             <div aria-controls="mwc_id_0_accordion-item" aria-expanded="false" class="header standard" role="button" tabindex="0">
               <span class="title"></span>
               <div class="chevron-container">
-                <svg class="icon-chevron-down-thick" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-                <path d="M15.88 9.29 12 13.17 8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0z" />
+                <svg class="icon-expand-more" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15.88 9.29 12 13.17 8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0" />
                 </svg>
               </div>
             </div>
@@ -42,8 +42,8 @@ describe('modus-accordion-item', () => {
             <div aria-controls="mwc_id_1_accordion-item" aria-expanded="false" class="header standard" role="button" tabindex="0">
               <span class="title"></span>
               <div class="chevron-container">
-                <svg class="icon-chevron-down-thick" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-                <path d="M15.88 9.29 12 13.17 8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0z" />
+                <svg class="icon-expand-more" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M15.88 9.29 12 13.17 8.12 9.29a.996.996 0 1 0-1.41 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59a.996.996 0 0 0 0-1.41c-.39-.38-1.03-.39-1.42 0" />
                 </svg>
               </div>
             </div>

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line
 import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
-import { IconChevronDownThick } from '../../icons/svgs/icon-chevron-down-thick';
+import { IconExpandMore } from '../../icons/generated-icons/IconExpandMore';
 import { generateElementId } from '../../utils/utils';
 
 @Component({
@@ -132,7 +132,7 @@ export class ModusAccordionItem {
             <div
               class={`chevron-container ${this.expanded ? 'reverse' : ''} `}
               ref={(el) => (this.chevronContainerRef = el)}>
-              <IconChevronDownThick size="24"></IconChevronDownThick>
+              <IconExpandMore size="24"></IconExpandMore>
             </div>
           }
         </div>

--- a/stencil-workspace/src/components/modus-accordion/modus-accordion.scss
+++ b/stencil-workspace/src/components/modus-accordion/modus-accordion.scss
@@ -1,4 +1,6 @@
 .accordion {
+  border-radius: 4px;
+  box-shadow: 0 0 2px rgba(37, 42, 46, 0.3);
   font-family: $primary-font;
   position: relative;
 }

--- a/stencil-workspace/src/components/modus-accordion/modus-accordion.tsx
+++ b/stencil-workspace/src/components/modus-accordion/modus-accordion.tsx
@@ -1,4 +1,4 @@
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Component, h, Prop } from '@stencil/core';
 
 @Component({


### PR DESCRIPTION
## Description

+ Use Modus Icons for Expand/Collapse
+ Improved horizontal padding (increased from 4px to 8px)
+ Add shadow
+ Add `border-radius: 4px`

References #<!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-2236--moduswebcomponents.netlify.app/?path=/story/components-accordion--default

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
