### PR TITLE
Button: Add type option (`button`, `submit`, `reset`)

### DIFF
--- a/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -206,7 +206,7 @@ export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'showCaret', 'size'],
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'showCaret', 'size', 'type'],
   methods: ['focusButton']
 })
 @Component({
@@ -214,7 +214,7 @@ export declare interface ModusBreadcrumb extends Components.ModusBreadcrumb {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'showCaret', 'size'],
+  inputs: ['ariaLabel', 'buttonStyle', 'color', 'disabled', 'iconOnly', 'leftIcon', 'rightIcon', 'showCaret', 'size', 'type'],
 })
 export class ModusButton {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -269,6 +269,10 @@ export namespace Components {
           * (optional) The size of the button.
          */
         "size": 'small' | 'medium' | 'large';
+        /**
+          * (Optional) Button types
+         */
+        "type": 'button' | 'reset' | 'submit';
     }
     interface ModusCard {
         /**
@@ -1722,25 +1726,72 @@ declare global {
         prototype: HTMLModusAccordionElement;
         new (): HTMLModusAccordionElement;
     };
+    interface HTMLModusAccordionItemElementEventMap {
+        "closed": any;
+        "opened": any;
+    }
     interface HTMLModusAccordionItemElement extends Components.ModusAccordionItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusAccordionItemElementEventMap>(type: K, listener: (this: HTMLModusAccordionItemElement, ev: ModusAccordionItemCustomEvent<HTMLModusAccordionItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusAccordionItemElementEventMap>(type: K, listener: (this: HTMLModusAccordionItemElement, ev: ModusAccordionItemCustomEvent<HTMLModusAccordionItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusAccordionItemElement: {
         prototype: HTMLModusAccordionItemElement;
         new (): HTMLModusAccordionItemElement;
     };
+    interface HTMLModusActionBarElementEventMap {
+        "actionBarClick": any;
+    }
     interface HTMLModusActionBarElement extends Components.ModusActionBar, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusActionBarElementEventMap>(type: K, listener: (this: HTMLModusActionBarElement, ev: ModusActionBarCustomEvent<HTMLModusActionBarElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusActionBarElementEventMap>(type: K, listener: (this: HTMLModusActionBarElement, ev: ModusActionBarCustomEvent<HTMLModusActionBarElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusActionBarElement: {
         prototype: HTMLModusActionBarElement;
         new (): HTMLModusActionBarElement;
     };
+    interface HTMLModusAlertElementEventMap {
+        "dismissClick": any;
+        "actionClick": any;
+    }
     interface HTMLModusAlertElement extends Components.ModusAlert, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusAlertElementEventMap>(type: K, listener: (this: HTMLModusAlertElement, ev: ModusAlertCustomEvent<HTMLModusAlertElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusAlertElementEventMap>(type: K, listener: (this: HTMLModusAlertElement, ev: ModusAlertCustomEvent<HTMLModusAlertElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusAlertElement: {
         prototype: HTMLModusAlertElement;
         new (): HTMLModusAlertElement;
     };
+    interface HTMLModusAutocompleteElementEventMap {
+        "optionSelected": string;
+        "valueChange": string;
+    }
     interface HTMLModusAutocompleteElement extends Components.ModusAutocomplete, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusAutocompleteElementEventMap>(type: K, listener: (this: HTMLModusAutocompleteElement, ev: ModusAutocompleteCustomEvent<HTMLModusAutocompleteElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusAutocompleteElementEventMap>(type: K, listener: (this: HTMLModusAutocompleteElement, ev: ModusAutocompleteCustomEvent<HTMLModusAutocompleteElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusAutocompleteElement: {
         prototype: HTMLModusAutocompleteElement;
@@ -1752,13 +1803,35 @@ declare global {
         prototype: HTMLModusBadgeElement;
         new (): HTMLModusBadgeElement;
     };
+    interface HTMLModusBreadcrumbElementEventMap {
+        "crumbClick": Crumb;
+    }
     interface HTMLModusBreadcrumbElement extends Components.ModusBreadcrumb, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusBreadcrumbElementEventMap>(type: K, listener: (this: HTMLModusBreadcrumbElement, ev: ModusBreadcrumbCustomEvent<HTMLModusBreadcrumbElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusBreadcrumbElementEventMap>(type: K, listener: (this: HTMLModusBreadcrumbElement, ev: ModusBreadcrumbCustomEvent<HTMLModusBreadcrumbElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusBreadcrumbElement: {
         prototype: HTMLModusBreadcrumbElement;
         new (): HTMLModusBreadcrumbElement;
     };
+    interface HTMLModusButtonElementEventMap {
+        "buttonClick": any;
+    }
     interface HTMLModusButtonElement extends Components.ModusButton, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusButtonElementEventMap>(type: K, listener: (this: HTMLModusButtonElement, ev: ModusButtonCustomEvent<HTMLModusButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusButtonElementEventMap>(type: K, listener: (this: HTMLModusButtonElement, ev: ModusButtonCustomEvent<HTMLModusButtonElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusButtonElement: {
         prototype: HTMLModusButtonElement;
@@ -1770,25 +1843,76 @@ declare global {
         prototype: HTMLModusCardElement;
         new (): HTMLModusCardElement;
     };
+    interface HTMLModusCheckboxElementEventMap {
+        "checkboxClick": boolean;
+    }
     interface HTMLModusCheckboxElement extends Components.ModusCheckbox, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusCheckboxElementEventMap>(type: K, listener: (this: HTMLModusCheckboxElement, ev: ModusCheckboxCustomEvent<HTMLModusCheckboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusCheckboxElementEventMap>(type: K, listener: (this: HTMLModusCheckboxElement, ev: ModusCheckboxCustomEvent<HTMLModusCheckboxElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusCheckboxElement: {
         prototype: HTMLModusCheckboxElement;
         new (): HTMLModusCheckboxElement;
     };
+    interface HTMLModusChipElementEventMap {
+        "chipClick": any;
+        "closeClick": any;
+    }
     interface HTMLModusChipElement extends Components.ModusChip, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusChipElementEventMap>(type: K, listener: (this: HTMLModusChipElement, ev: ModusChipCustomEvent<HTMLModusChipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusChipElementEventMap>(type: K, listener: (this: HTMLModusChipElement, ev: ModusChipCustomEvent<HTMLModusChipElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusChipElement: {
         prototype: HTMLModusChipElement;
         new (): HTMLModusChipElement;
     };
+    interface HTMLModusDataTableElementEventMap {
+        "cellLinkClick": ModusDataTableCellLink;
+        "rowDoubleClick": string;
+        "selection": string[];
+        "sort": ModusDataTableSortEvent;
+        "rowActionClick": ModusDataTableRowActionClickEvent;
+    }
     interface HTMLModusDataTableElement extends Components.ModusDataTable, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusDataTableElementEventMap>(type: K, listener: (this: HTMLModusDataTableElement, ev: ModusDataTableCustomEvent<HTMLModusDataTableElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusDataTableElementEventMap>(type: K, listener: (this: HTMLModusDataTableElement, ev: ModusDataTableCustomEvent<HTMLModusDataTableElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusDataTableElement: {
         prototype: HTMLModusDataTableElement;
         new (): HTMLModusDataTableElement;
     };
+    interface HTMLModusDateInputElementEventMap {
+        "calendarIconClicked": ModusDateInputEventDetails;
+        "dateInputBlur": ModusDateInputEventDetails;
+        "valueChange": ModusDateInputEventDetails;
+    }
     interface HTMLModusDateInputElement extends Components.ModusDateInput, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusDateInputElementEventMap>(type: K, listener: (this: HTMLModusDateInputElement, ev: ModusDateInputCustomEvent<HTMLModusDateInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusDateInputElementEventMap>(type: K, listener: (this: HTMLModusDateInputElement, ev: ModusDateInputCustomEvent<HTMLModusDateInputElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusDateInputElement: {
         prototype: HTMLModusDateInputElement;
@@ -1800,19 +1924,52 @@ declare global {
         prototype: HTMLModusDatePickerElement;
         new (): HTMLModusDatePickerElement;
     };
+    interface HTMLModusDropdownElementEventMap {
+        "dropdownClose": any;
+    }
     interface HTMLModusDropdownElement extends Components.ModusDropdown, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusDropdownElementEventMap>(type: K, listener: (this: HTMLModusDropdownElement, ev: ModusDropdownCustomEvent<HTMLModusDropdownElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusDropdownElementEventMap>(type: K, listener: (this: HTMLModusDropdownElement, ev: ModusDropdownCustomEvent<HTMLModusDropdownElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusDropdownElement: {
         prototype: HTMLModusDropdownElement;
         new (): HTMLModusDropdownElement;
     };
+    interface HTMLModusFileDropzoneElementEventMap {
+        "files": [File[], string | null];
+    }
     interface HTMLModusFileDropzoneElement extends Components.ModusFileDropzone, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusFileDropzoneElementEventMap>(type: K, listener: (this: HTMLModusFileDropzoneElement, ev: ModusFileDropzoneCustomEvent<HTMLModusFileDropzoneElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusFileDropzoneElementEventMap>(type: K, listener: (this: HTMLModusFileDropzoneElement, ev: ModusFileDropzoneCustomEvent<HTMLModusFileDropzoneElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusFileDropzoneElement: {
         prototype: HTMLModusFileDropzoneElement;
         new (): HTMLModusFileDropzoneElement;
     };
+    interface HTMLModusIconElementEventMap {
+        "iconClick": any;
+    }
     interface HTMLModusIconElement extends Components.ModusIcon, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusIconElementEventMap>(type: K, listener: (this: HTMLModusIconElement, ev: ModusIconCustomEvent<HTMLModusIconElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusIconElementEventMap>(type: K, listener: (this: HTMLModusIconElement, ev: ModusIconCustomEvent<HTMLModusIconElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusIconElement: {
         prototype: HTMLModusIconElement;
@@ -1824,7 +1981,18 @@ declare global {
         prototype: HTMLModusListElement;
         new (): HTMLModusListElement;
     };
+    interface HTMLModusListItemElementEventMap {
+        "itemClick": any;
+    }
     interface HTMLModusListItemElement extends Components.ModusListItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusListItemElementEventMap>(type: K, listener: (this: HTMLModusListItemElement, ev: ModusListItemCustomEvent<HTMLModusListItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusListItemElementEventMap>(type: K, listener: (this: HTMLModusListItemElement, ev: ModusListItemCustomEvent<HTMLModusListItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusListItemElement: {
         prototype: HTMLModusListItemElement;
@@ -1836,19 +2004,66 @@ declare global {
         prototype: HTMLModusMessageElement;
         new (): HTMLModusMessageElement;
     };
+    interface HTMLModusModalElementEventMap {
+        "closed": any;
+        "opened": any;
+        "primaryButtonClick": any;
+        "secondaryButtonClick": any;
+    }
     interface HTMLModusModalElement extends Components.ModusModal, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusModalElementEventMap>(type: K, listener: (this: HTMLModusModalElement, ev: ModusModalCustomEvent<HTMLModusModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusModalElementEventMap>(type: K, listener: (this: HTMLModusModalElement, ev: ModusModalCustomEvent<HTMLModusModalElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusModalElement: {
         prototype: HTMLModusModalElement;
         new (): HTMLModusModalElement;
     };
+    interface HTMLModusNavbarElementEventMap {
+        "appsMenuOpen": void;
+        "appsMenuAppOpen": ModusNavbarApp;
+        "buttonClick": string;
+        "helpOpen": void;
+        "mainMenuClick": KeyboardEvent | MouseEvent;
+        "notificationsMenuOpen": void;
+        "productLogoClick": MouseEvent;
+        "profileMenuLinkClick": string;
+        "profileMenuOpen": void;
+        "profileMenuSignOutClick": KeyboardEvent | MouseEvent;
+        "searchChange": string;
+        "searchMenuClick": void;
+    }
     interface HTMLModusNavbarElement extends Components.ModusNavbar, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusNavbarElementEventMap>(type: K, listener: (this: HTMLModusNavbarElement, ev: ModusNavbarCustomEvent<HTMLModusNavbarElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusNavbarElementEventMap>(type: K, listener: (this: HTMLModusNavbarElement, ev: ModusNavbarCustomEvent<HTMLModusNavbarElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusNavbarElement: {
         prototype: HTMLModusNavbarElement;
         new (): HTMLModusNavbarElement;
     };
+    interface HTMLModusNavbarAppsMenuElementEventMap {
+        "appOpen": ModusNavbarApp1;
+    }
     interface HTMLModusNavbarAppsMenuElement extends Components.ModusNavbarAppsMenu, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusNavbarAppsMenuElementEventMap>(type: K, listener: (this: HTMLModusNavbarAppsMenuElement, ev: ModusNavbarAppsMenuCustomEvent<HTMLModusNavbarAppsMenuElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusNavbarAppsMenuElementEventMap>(type: K, listener: (this: HTMLModusNavbarAppsMenuElement, ev: ModusNavbarAppsMenuCustomEvent<HTMLModusNavbarAppsMenuElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusNavbarAppsMenuElement: {
         prototype: HTMLModusNavbarAppsMenuElement;
@@ -1872,25 +2087,71 @@ declare global {
         prototype: HTMLModusNavbarNotificationsMenuElement;
         new (): HTMLModusNavbarNotificationsMenuElement;
     };
+    interface HTMLModusNavbarProfileMenuElementEventMap {
+        "linkClick": string;
+        "signOutClick": MouseEvent;
+    }
     interface HTMLModusNavbarProfileMenuElement extends Components.ModusNavbarProfileMenu, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusNavbarProfileMenuElementEventMap>(type: K, listener: (this: HTMLModusNavbarProfileMenuElement, ev: ModusNavbarProfileMenuCustomEvent<HTMLModusNavbarProfileMenuElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusNavbarProfileMenuElementEventMap>(type: K, listener: (this: HTMLModusNavbarProfileMenuElement, ev: ModusNavbarProfileMenuCustomEvent<HTMLModusNavbarProfileMenuElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusNavbarProfileMenuElement: {
         prototype: HTMLModusNavbarProfileMenuElement;
         new (): HTMLModusNavbarProfileMenuElement;
     };
+    interface HTMLModusNavbarSearchOverlayElementEventMap {
+        "close": void;
+        "search": string;
+    }
     interface HTMLModusNavbarSearchOverlayElement extends Components.ModusNavbarSearchOverlay, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusNavbarSearchOverlayElementEventMap>(type: K, listener: (this: HTMLModusNavbarSearchOverlayElement, ev: ModusNavbarSearchOverlayCustomEvent<HTMLModusNavbarSearchOverlayElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusNavbarSearchOverlayElementEventMap>(type: K, listener: (this: HTMLModusNavbarSearchOverlayElement, ev: ModusNavbarSearchOverlayCustomEvent<HTMLModusNavbarSearchOverlayElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusNavbarSearchOverlayElement: {
         prototype: HTMLModusNavbarSearchOverlayElement;
         new (): HTMLModusNavbarSearchOverlayElement;
     };
+    interface HTMLModusNumberInputElementEventMap {
+        "valueChange": string;
+    }
     interface HTMLModusNumberInputElement extends Components.ModusNumberInput, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusNumberInputElementEventMap>(type: K, listener: (this: HTMLModusNumberInputElement, ev: ModusNumberInputCustomEvent<HTMLModusNumberInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusNumberInputElementEventMap>(type: K, listener: (this: HTMLModusNumberInputElement, ev: ModusNumberInputCustomEvent<HTMLModusNumberInputElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusNumberInputElement: {
         prototype: HTMLModusNumberInputElement;
         new (): HTMLModusNumberInputElement;
     };
+    interface HTMLModusPaginationElementEventMap {
+        "pageChange": number;
+    }
     interface HTMLModusPaginationElement extends Components.ModusPagination, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusPaginationElementEventMap>(type: K, listener: (this: HTMLModusPaginationElement, ev: ModusPaginationCustomEvent<HTMLModusPaginationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusPaginationElementEventMap>(type: K, listener: (this: HTMLModusPaginationElement, ev: ModusPaginationCustomEvent<HTMLModusPaginationElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusPaginationElement: {
         prototype: HTMLModusPaginationElement;
@@ -1902,37 +2163,108 @@ declare global {
         prototype: HTMLModusProgressBarElement;
         new (): HTMLModusProgressBarElement;
     };
+    interface HTMLModusRadioGroupElementEventMap {
+        "buttonClick": string;
+    }
     interface HTMLModusRadioGroupElement extends Components.ModusRadioGroup, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusRadioGroupElementEventMap>(type: K, listener: (this: HTMLModusRadioGroupElement, ev: ModusRadioGroupCustomEvent<HTMLModusRadioGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusRadioGroupElementEventMap>(type: K, listener: (this: HTMLModusRadioGroupElement, ev: ModusRadioGroupCustomEvent<HTMLModusRadioGroupElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusRadioGroupElement: {
         prototype: HTMLModusRadioGroupElement;
         new (): HTMLModusRadioGroupElement;
     };
+    interface HTMLModusSelectElementEventMap {
+        "valueChange": unknown;
+        "inputBlur": FocusEvent;
+    }
     interface HTMLModusSelectElement extends Components.ModusSelect, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusSelectElementEventMap>(type: K, listener: (this: HTMLModusSelectElement, ev: ModusSelectCustomEvent<HTMLModusSelectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusSelectElementEventMap>(type: K, listener: (this: HTMLModusSelectElement, ev: ModusSelectCustomEvent<HTMLModusSelectElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusSelectElement: {
         prototype: HTMLModusSelectElement;
         new (): HTMLModusSelectElement;
     };
+    interface HTMLModusSentimentScaleElementEventMap {
+        "sentimentSelection": any;
+    }
     interface HTMLModusSentimentScaleElement extends Components.ModusSentimentScale, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusSentimentScaleElementEventMap>(type: K, listener: (this: HTMLModusSentimentScaleElement, ev: ModusSentimentScaleCustomEvent<HTMLModusSentimentScaleElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusSentimentScaleElementEventMap>(type: K, listener: (this: HTMLModusSentimentScaleElement, ev: ModusSentimentScaleCustomEvent<HTMLModusSentimentScaleElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusSentimentScaleElement: {
         prototype: HTMLModusSentimentScaleElement;
         new (): HTMLModusSentimentScaleElement;
     };
+    interface HTMLModusSideNavigationElementEventMap {
+        "sideNavExpand": boolean;
+    }
     interface HTMLModusSideNavigationElement extends Components.ModusSideNavigation, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusSideNavigationElementEventMap>(type: K, listener: (this: HTMLModusSideNavigationElement, ev: ModusSideNavigationCustomEvent<HTMLModusSideNavigationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusSideNavigationElementEventMap>(type: K, listener: (this: HTMLModusSideNavigationElement, ev: ModusSideNavigationCustomEvent<HTMLModusSideNavigationElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusSideNavigationElement: {
         prototype: HTMLModusSideNavigationElement;
         new (): HTMLModusSideNavigationElement;
     };
+    interface HTMLModusSideNavigationItemElementEventMap {
+        "sideNavItemClicked": { id: string; selected: boolean };
+        "sideNavItemFocus": { id: string };
+        "_sideNavItemAdded": HTMLElement;
+        "_sideNavItemRemoved": HTMLElement;
+    }
     interface HTMLModusSideNavigationItemElement extends Components.ModusSideNavigationItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusSideNavigationItemElementEventMap>(type: K, listener: (this: HTMLModusSideNavigationItemElement, ev: ModusSideNavigationItemCustomEvent<HTMLModusSideNavigationItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusSideNavigationItemElementEventMap>(type: K, listener: (this: HTMLModusSideNavigationItemElement, ev: ModusSideNavigationItemCustomEvent<HTMLModusSideNavigationItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusSideNavigationItemElement: {
         prototype: HTMLModusSideNavigationItemElement;
         new (): HTMLModusSideNavigationItemElement;
     };
+    interface HTMLModusSliderElementEventMap {
+        "valueChange": string;
+        "valueInput": string;
+    }
     interface HTMLModusSliderElement extends Components.ModusSlider, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusSliderElementEventMap>(type: K, listener: (this: HTMLModusSliderElement, ev: ModusSliderCustomEvent<HTMLModusSliderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusSliderElementEventMap>(type: K, listener: (this: HTMLModusSliderElement, ev: ModusSliderCustomEvent<HTMLModusSliderElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusSliderElement: {
         prototype: HTMLModusSliderElement;
@@ -1944,13 +2276,44 @@ declare global {
         prototype: HTMLModusSpinnerElement;
         new (): HTMLModusSpinnerElement;
     };
+    interface HTMLModusSwitchElementEventMap {
+        "switchClick": boolean;
+    }
     interface HTMLModusSwitchElement extends Components.ModusSwitch, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusSwitchElementEventMap>(type: K, listener: (this: HTMLModusSwitchElement, ev: ModusSwitchCustomEvent<HTMLModusSwitchElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusSwitchElementEventMap>(type: K, listener: (this: HTMLModusSwitchElement, ev: ModusSwitchCustomEvent<HTMLModusSwitchElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusSwitchElement: {
         prototype: HTMLModusSwitchElement;
         new (): HTMLModusSwitchElement;
     };
+    interface HTMLModusTableElementEventMap {
+        "cellValueChange": ModusTableCellValueChange;
+        "cellLinkClick": ModusTableCellLink;
+        "columnOrderChange": ModusTableColumnOrderState;
+        "columnSizingChange": ModusTableColumnSizingState;
+        "columnVisibilityChange": ModusTableColumnVisibilityState;
+        "rowActionClick": ModusTableRowActionClick;
+        "rowExpanded": ModusTableExpandedState;
+        "rowSelectionChange": unknown;
+        "sortChange": ModusTableSortingState;
+        "paginationChange": ModusTablePaginationState;
+    }
     interface HTMLModusTableElement extends Components.ModusTable, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTableElementEventMap>(type: K, listener: (this: HTMLModusTableElement, ev: ModusTableCustomEvent<HTMLModusTableElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTableElementEventMap>(type: K, listener: (this: HTMLModusTableElement, ev: ModusTableCustomEvent<HTMLModusTableElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTableElement: {
         prototype: HTMLModusTableElement;
@@ -1989,7 +2352,18 @@ declare global {
         prototype: HTMLModusTableFillerColumnElement;
         new (): HTMLModusTableFillerColumnElement;
     };
+    interface HTMLModusTableRowActionsElementEventMap {
+        "overflowRowActions": TableRowActionsMenuEvent;
+    }
     interface HTMLModusTableRowActionsElement extends Components.ModusTableRowActions, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTableRowActionsElementEventMap>(type: K, listener: (this: HTMLModusTableRowActionsElement, ev: ModusTableRowActionsCustomEvent<HTMLModusTableRowActionsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTableRowActionsElementEventMap>(type: K, listener: (this: HTMLModusTableRowActionsElement, ev: ModusTableRowActionsCustomEvent<HTMLModusTableRowActionsElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTableRowActionsElement: {
         prototype: HTMLModusTableRowActionsElement;
@@ -2013,25 +2387,70 @@ declare global {
         prototype: HTMLModusTableToolbarElement;
         new (): HTMLModusTableToolbarElement;
     };
+    interface HTMLModusTabsElementEventMap {
+        "tabChange": string;
+    }
     interface HTMLModusTabsElement extends Components.ModusTabs, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTabsElementEventMap>(type: K, listener: (this: HTMLModusTabsElement, ev: ModusTabsCustomEvent<HTMLModusTabsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTabsElementEventMap>(type: K, listener: (this: HTMLModusTabsElement, ev: ModusTabsCustomEvent<HTMLModusTabsElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTabsElement: {
         prototype: HTMLModusTabsElement;
         new (): HTMLModusTabsElement;
     };
+    interface HTMLModusTextInputElementEventMap {
+        "valueChange": string;
+    }
     interface HTMLModusTextInputElement extends Components.ModusTextInput, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTextInputElementEventMap>(type: K, listener: (this: HTMLModusTextInputElement, ev: ModusTextInputCustomEvent<HTMLModusTextInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTextInputElementEventMap>(type: K, listener: (this: HTMLModusTextInputElement, ev: ModusTextInputCustomEvent<HTMLModusTextInputElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTextInputElement: {
         prototype: HTMLModusTextInputElement;
         new (): HTMLModusTextInputElement;
     };
+    interface HTMLModusTimePickerElementEventMap {
+        "timeInputBlur": ModusTimePickerEventDetails;
+        "valueChange": ModusTimePickerEventDetails;
+    }
     interface HTMLModusTimePickerElement extends Components.ModusTimePicker, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTimePickerElementEventMap>(type: K, listener: (this: HTMLModusTimePickerElement, ev: ModusTimePickerCustomEvent<HTMLModusTimePickerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTimePickerElementEventMap>(type: K, listener: (this: HTMLModusTimePickerElement, ev: ModusTimePickerCustomEvent<HTMLModusTimePickerElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTimePickerElement: {
         prototype: HTMLModusTimePickerElement;
         new (): HTMLModusTimePickerElement;
     };
+    interface HTMLModusToastElementEventMap {
+        "dismissClick": any;
+    }
     interface HTMLModusToastElement extends Components.ModusToast, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusToastElementEventMap>(type: K, listener: (this: HTMLModusToastElement, ev: ModusToastCustomEvent<HTMLModusToastElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusToastElementEventMap>(type: K, listener: (this: HTMLModusToastElement, ev: ModusToastCustomEvent<HTMLModusToastElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusToastElement: {
         prototype: HTMLModusToastElement;
@@ -2043,13 +2462,39 @@ declare global {
         prototype: HTMLModusTooltipElement;
         new (): HTMLModusTooltipElement;
     };
+    interface HTMLModusTreeViewElementEventMap {
+        "itemActionClick": any;
+    }
     interface HTMLModusTreeViewElement extends Components.ModusTreeView, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTreeViewElementEventMap>(type: K, listener: (this: HTMLModusTreeViewElement, ev: ModusTreeViewCustomEvent<HTMLModusTreeViewElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTreeViewElementEventMap>(type: K, listener: (this: HTMLModusTreeViewElement, ev: ModusTreeViewCustomEvent<HTMLModusTreeViewElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTreeViewElement: {
         prototype: HTMLModusTreeViewElement;
         new (): HTMLModusTreeViewElement;
     };
+    interface HTMLModusTreeViewItemElementEventMap {
+        "checkboxClick": boolean;
+        "itemClick": boolean;
+        "itemExpandToggle": boolean;
+        "itemAdded": HTMLElement;
+        "actionClick": any;
+    }
     interface HTMLModusTreeViewItemElement extends Components.ModusTreeViewItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusTreeViewItemElementEventMap>(type: K, listener: (this: HTMLModusTreeViewItemElement, ev: ModusTreeViewItemCustomEvent<HTMLModusTreeViewItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusTreeViewItemElementEventMap>(type: K, listener: (this: HTMLModusTreeViewItemElement, ev: ModusTreeViewItemCustomEvent<HTMLModusTreeViewItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusTreeViewItemElement: {
         prototype: HTMLModusTreeViewItemElement;
@@ -2366,6 +2811,10 @@ declare namespace LocalJSX {
           * (optional) The size of the button.
          */
         "size"?: 'small' | 'medium' | 'large';
+        /**
+          * (Optional) Button types
+         */
+        "type"?: 'button' | 'reset' | 'submit';
     }
     interface ModusCard {
         /**

--- a/stencil-workspace/src/components/modus-button/modus-button.spec.ts
+++ b/stencil-workspace/src/components/modus-button/modus-button.spec.ts
@@ -10,7 +10,7 @@ describe('modus-button', () => {
     expect(root).toEqualHtml(`
       <modus-button>
         <mock:shadow-root>
-          <button class="size-medium color-primary style-fill">
+          <button class="size-medium color-primary style-fill" type="button">
             <span class="label">
                <slot></slot>
             </span>
@@ -28,7 +28,7 @@ describe('modus-button', () => {
     expect(root).toEqualHtml(`
       <modus-button>
         <mock:shadow-root>
-          <button class="size-medium color-primary style-fill">
+          <button class="size-medium color-primary style-fill" type="button">
             <span class="label">
                 <slot></slot>
             </span>
@@ -46,16 +46,16 @@ describe('modus-button', () => {
     });
     expect(root).toEqualHtml(`
       <modus-button icon-only="add">
-            <mock:shadow-root>
-              <button class="color-primary icon-only size-medium style-fill">
-                <span class="icon">
-                  <svg class="icon-add" fill="currentColor" height="16" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M19 11h-6V5c0-.55-.45-1-1-1s-1 .45-1 1v6H5c-.55 0-1 .45-1 1s.45 1 1 1h6v6c0 .55.45 1 1 1s1-.45 1-1v-6h6c.55 0 1-.45 1-1s-.45-1-1-1"></path>
-                  </svg>
-                </span>
-              </button>
-            </mock:shadow-root>
-          </modus-button>
+        <mock:shadow-root>
+          <button class="color-primary icon-only size-medium style-fill" type="button">
+            <span class="icon">
+              <svg class="icon-add" fill="currentColor" height="16" viewBox="0 0 24 24" width="16" xmlns="http://www.w3.org/2000/svg">
+                <path d="M19 11h-6V5c0-.55-.45-1-1-1s-1 .45-1 1v6H5c-.55 0-1 .45-1 1s.45 1 1 1h6v6c0 .55.45 1 1 1s1-.45 1-1v-6h6c.55 0 1-.45 1-1s-.45-1-1-1"></path>
+              </svg>
+            </span>
+          </button>
+        </mock:shadow-root>
+      </modus-button>
     `);
   });
 

--- a/stencil-workspace/src/components/modus-button/modus-button.tsx
+++ b/stencil-workspace/src/components/modus-button/modus-button.tsx
@@ -36,6 +36,9 @@ export class ModusButton {
   /** (optional) Shows a caret icon right side of the button. */
   @Prop() showCaret: boolean;
 
+  /** (Optional) Button types */
+  @Prop() type: 'button' | 'reset' | 'submit' = 'button';
+
   /** (optional) An event that fires on button click. */
   @Event() buttonClick: EventEmitter;
 
@@ -127,7 +130,8 @@ export class ModusButton {
         onKeyUp={() => (this.pressed = false)}
         onMouseDown={() => (this.pressed = true)}
         onMouseUp={() => (this.pressed = false)}
-        ref={(el) => (this.buttonRef = el)}>
+        ref={(el) => (this.buttonRef = el)}
+        type={this.type}>
         {this.iconOnly ? this.renderIconOnly() : this.renderIconWithText()}
         {this.showCaret && <ModusIconMap size="24" icon="caret_down"></ModusIconMap>}
       </button>

--- a/stencil-workspace/src/components/modus-button/readme.md
+++ b/stencil-workspace/src/components/modus-button/readme.md
@@ -1,9 +1,6 @@
 # modus-button
 
-
-
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
@@ -18,14 +15,13 @@
 | `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                             | `undefined` |
 | `showCaret`   | `show-caret`   | (optional) Shows a caret icon right side of the button.                                    | `boolean`                                            | `undefined` |
 | `size`        | `size`         | (optional) The size of the button.                                                         | `"large" \| "medium" \| "small"`                     | `'medium'`  |
-
+| `type`        | `type`         | (Optional) Button types                                                                    | `"button" \| "reset" \| "submit"`                    | `'button'`  |
 
 ## Events
 
 | Event         | Description                                     | Type               |
 | ------------- | ----------------------------------------------- | ------------------ |
 | `buttonClick` | (optional) An event that fires on button click. | `CustomEvent<any>` |
-
 
 ## Methods
 
@@ -37,20 +33,18 @@ Focus the Button
 
 Type: `Promise<void>`
 
-
-
-
 ## Dependencies
 
 ### Used by
 
- - [modus-action-bar](../modus-action-bar)
- - [modus-alert](../modus-alert)
- - [modus-modal](../modus-modal)
- - [modus-table-columns-visibility](../modus-table/parts/panel/modus-table-columns-visibility)
- - [modus-table-row-actions](../modus-table/parts/row/actions/modus-table-row-actions)
+- [modus-action-bar](../modus-action-bar)
+- [modus-alert](../modus-alert)
+- [modus-modal](../modus-modal)
+- [modus-table-columns-visibility](../modus-table/parts/panel/modus-table-columns-visibility)
+- [modus-table-row-actions](../modus-table/parts/row/actions/modus-table-row-actions)
 
 ### Graph
+
 ```mermaid
 graph TD;
   modus-action-bar --> modus-button
@@ -61,6 +55,4 @@ graph TD;
   style modus-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
-
-
+---

--- a/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button/modus-button-storybook-docs.mdx
@@ -160,6 +160,7 @@ Users can choose to show a caret icon at the right side of the button using `sho
 | `rightIcon`   | `right-icon`   | (optional) Takes the icon name and shows the icon aligned to the right of the button text. | `string`                                         | `undefined` |
 | `showCaret`   | `show-caret`   | (optional) Shows a caret icon right side of the button.                                    | `boolean`                                        | `undefined` |
 | `size`        | `size`         | (optional) The size of the button.                                                         | `"large" ,"medium" , "small"`                    | `'medium'`  |
+| `type`        | `type`         | (optional) The type of the button.                                                         | `"button" , "reset" , "submit"`                  | `'button'`  |
 
 ### DOM Events
 


### PR DESCRIPTION
## Description

Add option to specify a button type. Defaults to `button`

References #<!-- issue number -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

npm run test completes without issues

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
