### PR TITLE
Accordion: Add icon property to accordion

### DIFF
--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.e2e.ts
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.e2e.ts
@@ -106,4 +106,19 @@ describe('modus-accordion-item', () => {
     await page.waitForChanges();
     expect(opened).not.toHaveReceivedEvent();
   });
+  it('renders changes to the icon prop', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-accordion-item></modus-accordion-item>');
+    await page.waitForChanges();
+
+    const component = await page.find('modus-accordion-item');
+    const element = await page.find('modus-accordion-item >>> .header');
+    expect(element).not.toHaveClass('icon');
+
+    component.setProperty('icon', 'add');
+    await page.waitForChanges();
+    const icon = await page.find('modus-accordion-item >>> .icon-add');
+    expect(icon).toBeTruthy();
+  });
 });

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.scss
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.scss
@@ -17,6 +17,12 @@
     font-weight: $font-weight-semi-bold;
     height: 48px;
 
+    .icon {
+      margin-left: 8px;
+      margin-right: 0;
+      margin-top: 4px;
+    }
+
     &.disabled {
       cursor: auto;
       opacity: 0.4;

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
@@ -2,6 +2,8 @@
 import { Component, Event, EventEmitter, Prop, h } from '@stencil/core';
 import { IconExpandMore } from '../../icons/generated-icons/IconExpandMore';
 import { generateElementId } from '../../utils/utils';
+import { ModusIconMap } from '../../icons/ModusIconMap';
+import { JSX } from '@stencil/core/internal';
 
 @Component({
   tag: 'modus-accordion-item',
@@ -17,6 +19,9 @@ export class ModusAccordionItem {
 
   /** (required) The text to render in the header. */
   @Prop() headerText: string;
+
+  /** (optional) Takes the icon name and renders the icon. */
+  @Prop() icon: string;
 
   /** (optional) The size of accordion item. */
   @Prop() size: 'condensed' | 'standard' = 'standard';
@@ -107,6 +112,14 @@ export class ModusAccordionItem {
     element.offsetHeight; // eslint-disable-line no-unused-expressions
   };
 
+  renderIcon(): JSX.Element {
+    return (
+      <span class="icon">
+        <ModusIconMap icon={this.icon}></ModusIconMap>
+      </span>
+    );
+  }
+
   render(): unknown {
     const sizeClass = `${this.classBySize.get(this.size)}`;
     const disabledClass = `${this.disabled ? 'disabled' : ''}`;
@@ -127,6 +140,7 @@ export class ModusAccordionItem {
           onClick={() => this.handleHeaderClick()}
           onKeyDown={(event) => this.handleKeydown(event)}
           tabIndex={this.disabled ? -1 : 0}>
+          {this.icon ? this.renderIcon() : null}
           <span class="title">{this.headerText}</span>
           {
             <div

--- a/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
+++ b/stencil-workspace/src/components/modus-accordion-item/modus-accordion-item.tsx
@@ -20,7 +20,7 @@ export class ModusAccordionItem {
   /** (required) The text to render in the header. */
   @Prop() headerText: string;
 
-  /** (optional) Takes the icon name and renders the icon. */
+  /** (optional) The icon to display before the header text. */
   @Prop() icon: string;
 
   /** (optional) The size of accordion item. */

--- a/stencil-workspace/src/components/modus-accordion-item/readme.md
+++ b/stencil-workspace/src/components/modus-accordion-item/readme.md
@@ -12,6 +12,7 @@
 | `disabled`   | `disabled`    | (optional) Disables the accordion item, locks expand/collapse. | `boolean`                   | `undefined`  |
 | `expanded`   | `expanded`    | (optional) Whether the accordion item is expanded.             | `boolean`                   | `undefined`  |
 | `headerText` | `header-text` | (required) The text to render in the header.                   | `string`                    | `undefined`  |
+| `icon`       | `icon`        | (optional) Takes the icon name and renders the icon.           | `string`                    | `undefined`  |
 | `size`       | `size`        | (optional) The size of accordion item.                         | `"condensed" \| "standard"` | `'standard'` |
 
 

--- a/stencil-workspace/src/components/modus-accordion-item/readme.md
+++ b/stencil-workspace/src/components/modus-accordion-item/readme.md
@@ -12,7 +12,7 @@
 | `disabled`   | `disabled`    | (optional) Disables the accordion item, locks expand/collapse. | `boolean`                   | `undefined`  |
 | `expanded`   | `expanded`    | (optional) Whether the accordion item is expanded.             | `boolean`                   | `undefined`  |
 | `headerText` | `header-text` | (required) The text to render in the header.                   | `string`                    | `undefined`  |
-| `icon`       | `icon`        | (optional) Takes the icon name and renders the icon.           | `string`                    | `undefined`  |
+| `icon`       | `icon`        | (optional) The icon to display before the header text.         | `string`                    | `undefined`  |
 | `size`       | `size`        | (optional) The size of accordion item.                         | `"condensed" \| "standard"` | `'standard'` |
 
 

--- a/stencil-workspace/storybook/stories/components/modus-accordion/modus-accordion-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-accordion/modus-accordion-storybook-docs.mdx
@@ -30,6 +30,16 @@ The `<modus-accordion-item>` utilizes the slot element, allowing you to render y
   </modus-accordion-item>
 </modus-accordion>
 
+### With Icon
+
+<modus-accordion>
+  <modus-accordion-item header-text="Item 1" icon="notifications">Content</modus-accordion-item>
+  <modus-accordion-item header-text="Item 2" icon="notifications">Content</modus-accordion-item>
+  <modus-accordion-item disabled  header-text="Item 3" icon="notifications">
+    Content
+  </modus-accordion-item>
+</modus-accordion>
+
 ```html
 <modus-accordion>
   <modus-accordion-item header-text="Item 1">Content</modus-accordion-item>
@@ -42,6 +52,13 @@ The `<modus-accordion-item>` utilizes the slot element, allowing you to render y
   <modus-accordion-item header-text="Item 2" size="condensed">Content</modus-accordion-item>
   <modus-accordion-item disabled expanded header-text="Item 3" size="condensed">Content</modus-accordion-item>
 </modus-accordion>
+
+<modus-accordion-item header-text="Item 1" icon="notifications">Content</modus-accordion-item>
+  <modus-accordion-item header-text="Item 2" icon="notifications">Content</modus-accordion-item>
+  <modus-accordion-item disabled  header-text="Item 3" icon="notifications">
+    Content
+  </modus-accordion-item>
+</modus-accordion>
 ```
 
 ### Properties
@@ -53,7 +70,7 @@ The `<modus-accordion-item>` utilizes the slot element, allowing you to render y
 | `expanded`    | The expanded state of the accordion item        | `boolean` |                         |               |          |
 | `header-text` | The text to render in the accordion item header | `string`  |                         |               |          |
 | `size`        | The size of the accordion item                  | `string`  | 'condensed', 'standard' | 'standard'    |          |
-
+| `icon`        | Takes the icon name and renders the icon        | `string`  |                         |               |          |
 ### DOM Events
 
 | Name     | Description                      | Emits |

--- a/stencil-workspace/storybook/stories/components/modus-accordion/modus-accordion.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-accordion/modus-accordion.stories.tsx
@@ -4,12 +4,21 @@ import { html } from 'lit-html';
 
 export default {
   title: 'Components/Accordion',
+  argTypes: {
+    icon:{
+      name: 'icon',
+      description: 'The icon to display before the header text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    },
   parameters: {
+    controls: {
+      expanded: true ,sort:"alpha"
+    },
     docs: {
       page: docs,
-    },
-    controls: {
-      disabled: true,
     },
     options: {
       isToolshown: true,
@@ -17,13 +26,22 @@ export default {
   },
 };
 
-const Template = () => html`
+const Template = ({icon}) => html`
   <modus-accordion>
-    <modus-accordion-item header-text="Item 1">Content</modus-accordion-item>
-    <modus-accordion-item header-text="Item 2">Content</modus-accordion-item>
-    <modus-accordion-item disabled header-text="Item 3">
+    <modus-accordion-item header-text="Item 1" icon=${icon}>Content</modus-accordion-item>
+    <modus-accordion-item header-text="Item 2" icon=${icon}>Content</modus-accordion-item>
+    <modus-accordion-item disabled header-text="Item 3" icon=${icon}>
       Content
     </modus-accordion-item>
   </modus-accordion>
 `;
+const DefaultTemplateArgs={
+  icon: '',
+};
+const WithIconTemplateArgs={
+  icon: 'notifications',
+};
 export const Default = Template.bind({});
+Default.args = DefaultTemplateArgs;
+export const WithIcon = Template.bind({});
+WithIcon.args = WithIconTemplateArgs;


### PR DESCRIPTION
## Description

- Added a property `icon` to accordion which can accept any modus icon
- Added a test case to check icon property being set or not set.

Fixes: #2258
 
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

https://deploy-preview-2261--moduswebcomponents.netlify.app/?path=/story/components-accordion--default&args=icon:heart

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
