### PR TITLE
Button: Make `aria-disabled` buttons look disabled (CSS fix)

### DIFF
--- a/stencil-workspace/src/components/modus-button/modus-button.scss
+++ b/stencil-workspace/src/components/modus-button/modus-button.scss
@@ -38,7 +38,8 @@ button {
     cursor: pointer;
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled='true'] {
     background-color: $modus-btn-disabled-bg;
     color: $modus-btn-disabled-color;
     cursor: default;


### PR DESCRIPTION
## Description

Follow up fix for: #2244

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Locally: http://localhost:6006/?path=/story/components-button--default&args=ariaDisabled:true

- Deploy Preview: https://deploy-preview-2269--moduswebcomponents.netlify.app/?path=/story/components-button--default&args=ariaDisabled:true

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
