### PR TITLE
Dropdown: Remove unnecessary `role="listbox"`

### DIFF
--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.spec.ts
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.spec.ts
@@ -14,7 +14,7 @@ describe('modus-dropdown', () => {
     expect(root).toEqualHtml(`
       <modus-dropdown toggle-element-id='toggle-id'>
         <mock:shadow-root>
-          <div class="dropdown" role="listbox">
+          <div class="dropdown">
             <slot name='dropdownToggle'></slot>
             <div class='bottom dropdown-list hidden list-border' style='left: unset; min-width: 0px;'>
               <slot name='dropdownList'></slot>

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
@@ -1,4 +1,4 @@
-// eslint-disable-next-line
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Component, Prop, h, Event, EventEmitter, State, Element, Listen } from '@stencil/core';
 
 @Component({
@@ -131,7 +131,6 @@ export class ModusDropdown {
       <div
         aria-label={this.ariaLabel}
         class="dropdown"
-        role="listbox"
         onClick={(event) => this.handleDropdownClick(event)}
         onKeyDown={(event) => {
           this.handleDropdownKeyDown(event);

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown-storybook-docs.mdx
@@ -40,7 +40,7 @@
 | Property                 | Attribute                   | Description                                                                                      | Type                                                                | Default     |
 | ------------------------ | --------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- | ----------- |
 | `animateList`            | `animate-list`              | Whether to apply list opening animation.                                                         | `boolean`                                                           | `false`     |
-| `ariaLabel`              | `aria-label`                | (optional) The dropdown's aria-label.                                                            | `string`                                                            | `undefined` |
+| `ariaLabel`              | `aria-label`                | (optional) The dropdown's `aria-label`.  (Not recommended)                                       | `string`                                                            | `undefined` |
 | `customPlacement`        | --                          | (optional) Determines custom dropdown placement offset.                                          | `{ top?: number; right?: number; bottom?: number; left?: number; }` | `undefined` |
 | `disabled`               | `disabled`                  | (optional) Disables the dropdown.                                                                | `boolean`                                                           | `undefined` |
 | `placement`              | `placement`                 | (optional) The placement of the dropdown in related to the toggleElement.                        | `"bottom", "left", "right", "top"`                                  | `'bottom'`  |
@@ -55,5 +55,4 @@
 
 ### Accessibility
 
-- Dropdown has `role` of `listbox`.
 - When the Dropdown Toggle has focus, <kbd>Enter</kbd> toggles the dropdown.

--- a/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-dropdown/modus-dropdown.stories.tsx
@@ -21,7 +21,7 @@ export default {
 };
 
 const Template = () => html`
-  <modus-dropdown toggle-element-id="toggleElement" aria-label="Dropdown">
+  <modus-dropdown toggle-element-id="toggleElement">
   <modus-button id="toggleElement" slot="dropdownToggle" show-caret="true">Dropdown</modus-button>
   <modus-list slot="dropdownList">
     <modus-list-item size="condensed" borderless>Item 1</modus-list-item>


### PR DESCRIPTION
## Description

Fixes: #1195

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-2279--moduswebcomponents.netlify.app/?path=/story/components-dropdown--default

![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/4e3e2af3-1298-4482-a5bb-9f5129ebde6e)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
