### PR TITLE
Navbar: Add `aria-label` to Search and Help buttons

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
@@ -401,6 +401,7 @@ export class ModusNavbar {
                       position="bottom">
                       <span
                         class="navbar-button-icon"
+                        aria-label="Search"
                         role="button"
                         onKeyDown={(event) => this.searchMenuKeydownHandler(event)}
                         tabIndex={0}
@@ -446,7 +447,7 @@ export class ModusNavbar {
                 {this.showHelp && (
                   <div class="navbar-button" data-test-id="help-menu">
                     <modus-tooltip text={this.helpTooltip?.text} aria-label={this.helpTooltip?.ariaLabel} position="bottom">
-                      <span class="navbar-button-icon" role="button" tabIndex={0}>
+                      <span class="navbar-button-icon" role="button" aria-label="Help" tabIndex={0}>
                         <IconHelp size="24" onClick={(event) => this.helpMenuClickHandler(event)} />
                       </span>
                     </modus-tooltip>


### PR DESCRIPTION
## Description

Fixes an accessibility issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Locally with Edge v122 on Windows 11 Pro
- https://deploy-preview-2307--moduswebcomponents.netlify.app/?path=/story/components-navbar--default&args=showHelp:true;showProfile:false;showSearch:true

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
