### PR TITLE
Docs: Fix some accessibility 'incomplete' (warnings) in Canvas demos

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
@@ -159,7 +159,7 @@ export default {
 };
 
 const defaultArgs = {
-  ariaLabel: 'Date Input',
+  ariaLabel: '',
   allowedCharsRegex: '[\\d\\/]',
   altFormats: '',
   autoFocusInput: true,

--- a/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-number-input/modus-number-input.stories.tsx
@@ -174,11 +174,11 @@ const Template = ({
 
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: 'Number Input',
+  ariaLabel: '',
   disabled: false,
   errorText: '',
   helperText: '',
-  label: '',
+  label: 'Number Input',
   maxValue: 100,
   minValue: 0,
   placeholder: '',

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
@@ -223,6 +223,7 @@ const Template = ({
   validText,
   value,
 }) => html`
+<form>
   <modus-text-input
     aria-label=${ariaLabel}
     autocomplete=${autocomplete}
@@ -245,11 +246,12 @@ const Template = ({
     type=${type}
     valid-text=${validText}
     value=${value}></modus-text-input>
+</form>
 `;
 
 export const Default = Template.bind({});
 Default.args = {
-  ariaLabel: 'Text Input',
+  ariaLabel: '',
   autocomplete: '',
   autoFocusInput: true,
   clearable: false,
@@ -259,8 +261,8 @@ Default.args = {
   includePasswordTextToggle: true,
   includeSearchIcon: false,
   inputmode: '',
-  label: '',
-  maxLength: 100,
+  label: 'Username',
+  maxLength: 20,
   minLength: 0,
   placeholder: '',
   readOnly: false,
@@ -269,5 +271,5 @@ Default.args = {
   textAlign: 'left',
   type: 'text',
   validText: '',
-  value: 'Hello, text input!',
+  value: '',
 };


### PR DESCRIPTION
## Description

There are accessibility warnings on a few components.

- https://modus-web-components.trimble.com/?path=/story/user-inputs-text-input--default
- https://modus-web-components.trimble.com/?path=/story/user-inputs-number-input--default
- https://modus-web-components.trimble.com/?path=/story/user-inputs-date-picker--default

This PR fixes them. Mainly by linking inputs to labels.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
