### PR TITLE
Add "textarea" type to text input

### DIFF
--- a/angular-workspace/ng14/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/ng14/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1469,7 +1469,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
 @Component({
@@ -1477,7 +1477,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/angular-workspace/ng15/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/ng15/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1469,7 +1469,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
 @Component({
@@ -1477,7 +1477,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/angular-workspace/ng16/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/ng16/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1469,7 +1469,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
 @Component({
@@ -1477,7 +1477,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/angular-workspace/ng17/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
+++ b/angular-workspace/ng17/projects/trimble-oss/modus-angular-components/src/lib/stencil-generated/components.ts
@@ -1469,7 +1469,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
 
 
 @ProxyCmp({
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
   methods: ['focusInput']
 })
 @Component({
@@ -1477,7 +1477,7 @@ export declare interface ModusTabs extends Components.ModusTabs {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'size', 'textAlign', 'type', 'validText', 'value'],
+  inputs: ['ariaLabel', 'autoFocusInput', 'autocomplete', 'clearable', 'disabled', 'errorText', 'helperText', 'includePasswordTextToggle', 'includeSearchIcon', 'inputmode', 'label', 'maxLength', 'minLength', 'placeholder', 'readOnly', 'required', 'rows', 'size', 'textAlign', 'type', 'validText', 'value'],
 })
 export class ModusTextInput {
   protected el: HTMLElement;

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1373,6 +1373,10 @@ export namespace Components {
          */
         "required": boolean;
         /**
+          * (optional) Number of rows on textarea for multiline input
+         */
+        "rows": number;
+        /**
           * (optional) The input's size.
          */
         "size": 'medium' | 'large';
@@ -1383,7 +1387,7 @@ export namespace Components {
         /**
           * (optional) The input's type.
          */
-        "type": 'email' | 'password' | 'search' | 'text' | 'tel' | 'url';
+        "type": 'email' | 'password' | 'search' | 'text' | 'textarea' | 'tel' | 'url';
         /**
           * (optional) The input's valid state text.
          */
@@ -4103,6 +4107,10 @@ declare namespace LocalJSX {
          */
         "required"?: boolean;
         /**
+          * (optional) Number of rows on textarea for multiline input
+         */
+        "rows"?: number;
+        /**
           * (optional) The input's size.
          */
         "size"?: 'medium' | 'large';
@@ -4113,7 +4121,7 @@ declare namespace LocalJSX {
         /**
           * (optional) The input's type.
          */
-        "type"?: 'email' | 'password' | 'search' | 'text' | 'tel' | 'url';
+        "type"?: 'email' | 'password' | 'search' | 'text' | 'textarea' | 'tel' | 'url';
         /**
           * (optional) The input's valid state text.
          */

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -52,7 +52,8 @@
       }
     }
 
-    input {
+    input,
+    textarea {
       background-color: transparent;
       border: none;
       color: $modus-input-color;

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
@@ -116,4 +116,40 @@ describe('modus-text-input', () => {
     const modusTextInput = new ModusTextInput();
     expect(modusTextInput.minLength).toBeFalsy();
   });
+
+  it('should default to input type', async () => {
+    const modusTextInput = new ModusTextInput();
+    expect(modusTextInput.type).toBe('text');
+    expect(modusTextInput.inputAttributeName).toBe('input');
+  });
+
+  it('should add a "textarea" tag when type is "textarea"', () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.type = 'textarea';
+    expect(modusTextInput.inputAttributeName).toBe('textarea');
+  });
+
+  it('should default to not including the "rows" attribute', async () => {
+    const modusTextInput = new ModusTextInput();
+    expect(modusTextInput.numRows).toBe(null);
+  });
+
+  it('should default "rows" to 5 when big', async () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.type = 'textarea';
+    expect(modusTextInput.numRows).toBe(5);
+  });
+
+  it('should default to not including the "style" attribute on the input container', async () => {
+    const modusTextInput = new ModusTextInput();
+    expect(modusTextInput.inputContainerStyle).toBe(null);
+  });
+
+  it('should return a correct size when "type" is textarea', async () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.type = 'textarea';
+    expect(modusTextInput.inputContainerStyle.height).toBe('6rem');
+    modusTextInput.rows = 2;
+    expect(modusTextInput.inputContainerStyle.height).toBe('3rem');
+  });
 });

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -60,6 +60,9 @@ export class ModusTextInput {
   /** (optional) Whether the input is required. */
   @Prop() required: boolean;
 
+  /** (optional) Number of rows on textarea for multiline input */
+  @Prop() rows = 5;
+
   /** (optional) The input's size. */
   @Prop() size: 'medium' | 'large' = 'medium';
 
@@ -67,7 +70,7 @@ export class ModusTextInput {
   @Prop() textAlign: 'left' | 'right' = 'left';
 
   /** (optional) The input's type. */
-  @Prop() type: 'email' | 'password' | 'search' | 'text' | 'tel' | 'url' = 'text';
+  @Prop() type: 'email' | 'password' | 'search' | 'text' | 'textarea' | 'tel' | 'url' = 'text';
 
   /** (optional) The input's valid state text. */
   @Prop() validText: string;
@@ -139,6 +142,26 @@ export class ModusTextInput {
     }
   }
 
+  get inputAttributeName(): 'input' | 'textarea' {
+    return this.type === 'textarea' ? 'textarea' : 'input';
+  }
+
+  get containerHeight(): number {
+    if (this.type !== 'textarea') {
+      return 2;
+    } else {
+      return this.rows + 1;
+    }
+  }
+
+  get numRows(): number {
+    return this.type === 'textarea' ? this.rows : null;
+  }
+
+  get inputContainerStyle() {
+    return this.type === 'textarea' ? { height: this.containerHeight + 'rem' } : null;
+  }
+
   render(): unknown {
     const iconSize = this.size === 'large' ? '24' : '16';
     const isPassword = this.type === 'password';
@@ -181,10 +204,11 @@ export class ModusTextInput {
           class={`input-container ${this.errorText ? 'error' : this.validText ? 'valid' : ''} ${this.classBySize.get(
             this.size
           )}`}
+          style={this.inputContainerStyle}
           onClick={() => this.textInput.focus()}
           part="input-container">
           {this.includeSearchIcon ? <IconSearch size={iconSize} /> : null}
-          <input
+          <this.inputAttributeName
             id={this.inputId}
             aria-invalid={!!this.errorText}
             aria-label={this.ariaLabel}
@@ -199,6 +223,7 @@ export class ModusTextInput {
             placeholder={this.placeholder}
             readonly={this.readOnly}
             ref={(el) => (this.textInput = el as HTMLInputElement)}
+            rows={this.numRows}
             tabIndex={0}
             type={this.type}
             value={this.value}

--- a/stencil-workspace/src/components/modus-text-input/readme.md
+++ b/stencil-workspace/src/components/modus-text-input/readme.md
@@ -25,9 +25,10 @@
 | `placeholder`               | `placeholder`                  | (optional) The input's placeholder text.                      | `string`                                                                    | `undefined` |
 | `readOnly`                  | `read-only`                    | (optional) Whether the input's content is read-only           | `boolean`                                                                   | `undefined` |
 | `required`                  | `required`                     | (optional) Whether the input is required.                     | `boolean`                                                                   | `undefined` |
+| `rows`                      | `rows`                         | (optional) Number of rows for textarea. Defaults to 5.        | `number`                                                                    | `undefined` |
 | `size`                      | `size`                         | (optional) The input's size.                                  | `"large" \| "medium"`                                                       | `'medium'`  |
 | `textAlign`                 | `text-align`                   | (optional) The input's text alignment.                        | `"left" \| "right"`                                                         | `'left'`    |
-| `type`                      | `type`                         | (optional) The input's type.                                  | `"email" \| "password" \| "search" \| "tel" \| "text" \| "url"`             | `'text'`    |
+| `type`                      | `type`                         | (optional) The input's type.                                  | `"email" \| "password" \| "search" \| "tel" \| "text" \| "textarea" \| "url"`             | `'text'`    |
 | `validText`                 | `valid-text`                   | (optional) The input's valid state text.                      | `string`                                                                    | `undefined` |
 | `value`                     | `value`                        | (optional) The input's value.                                 | `string`                                                                    | `undefined` |
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

References #2327 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

In addition to the unit tests added, in the `input.html` file, I added the following code:
```
    <modus-text-input label="standard input"></modus-text-input>
    <modus-text-input label="textarea input" type="textarea"></modus-text-input>
    <modus-text-input label="textarea input with 3 rows" type="textarea" rows="3"></modus-text-input>
```

Result is below:

![image](https://github.com/trimble-oss/modus-web-components/assets/5069856/fd76956f-3860-427f-97ff-cb47b973fb68)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
