### PR TITLE
Docs: Add link to Netlify from front page

### DIFF
--- a/stencil-workspace/storybook/stories/introduction/welcome.stories.mdx
+++ b/stencil-workspace/storybook/stories/introduction/welcome.stories.mdx
@@ -53,3 +53,5 @@ Each component has a Docs page which contains component documentation - how to u
 </a>
 
 Thanks to all of [our contributors](https://github.com/trimble-oss/modus-web-components/graphs/contributors)!
+
+[This site is powered by Netlify](https://www.netlify.com/)


### PR DESCRIPTION
## Description

Add link to Netlify from front page

Fixes: #308

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- Locally
- https://deploy-preview-2348--moduswebcomponents.netlify.app/ (bottom of page)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
