### PR TITLE
Input: Add `autocapitalize`, `autocorrect`, `enterkeyhint`, and `spellcheck `properties

### DIFF
--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -1313,9 +1313,17 @@ export namespace Components {
          */
         "autoFocusInput": boolean;
         /**
+          * (optional) Capitalization behavior when using a non-traditional keyboard (e.g. microphone, touch screen)
+         */
+        "autocapitalize": boolean | 'none' | 'off' | 'sentences' | 'on' | 'words' | 'characters';
+        /**
           * (optional) Sets autocomplete on the input.
          */
         "autocomplete": string | null;
+        /**
+          * (optional) Whether to activate automatic correction while the user is editing this field in Safari.
+         */
+        "autocorrect": boolean | 'off' | 'on';
         /**
           * (optional) Whether the input has a clear button.
          */
@@ -1324,6 +1332,10 @@ export namespace Components {
           * (optional) Whether the input is disabled.
          */
         "disabled": boolean;
+        /**
+          * (optional) Which action label to present for the enter key on virtual keyboards.
+         */
+        "enterkeyhint": 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
         /**
           * (optional) The input's error state text.
          */
@@ -1376,6 +1388,10 @@ export namespace Components {
           * (optional) The input's size.
          */
         "size": 'medium' | 'large';
+        /**
+          * (optional) Whether to enable spell checking.
+         */
+        "spellcheck": boolean;
         /**
           * (optional) The input's text alignment.
          */
@@ -4043,9 +4059,17 @@ declare namespace LocalJSX {
          */
         "autoFocusInput"?: boolean;
         /**
+          * (optional) Capitalization behavior when using a non-traditional keyboard (e.g. microphone, touch screen)
+         */
+        "autocapitalize"?: boolean | 'none' | 'off' | 'sentences' | 'on' | 'words' | 'characters';
+        /**
           * (optional) Sets autocomplete on the input.
          */
         "autocomplete"?: string | null;
+        /**
+          * (optional) Whether to activate automatic correction while the user is editing this field in Safari.
+         */
+        "autocorrect"?: boolean | 'off' | 'on';
         /**
           * (optional) Whether the input has a clear button.
          */
@@ -4054,6 +4078,10 @@ declare namespace LocalJSX {
           * (optional) Whether the input is disabled.
          */
         "disabled"?: boolean;
+        /**
+          * (optional) Which action label to present for the enter key on virtual keyboards.
+         */
+        "enterkeyhint"?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
         /**
           * (optional) The input's error state text.
          */
@@ -4106,6 +4134,10 @@ declare namespace LocalJSX {
           * (optional) The input's size.
          */
         "size"?: 'medium' | 'large';
+        /**
+          * (optional) Whether to enable spell checking.
+         */
+        "spellcheck"?: boolean;
         /**
           * (optional) The input's text alignment.
          */

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.spec.tsx
@@ -38,6 +38,102 @@ describe('modus-text-input', () => {
     `);
   });
 
+  it('renders autocapitalize', async () => {
+    const page = await newSpecPage({
+      components: [ModusTextInput],
+      html: '<modus-text-input autocapitalize="words"></modus-text-input>',
+    });
+    expect(page.root).toEqualHtml(`
+      <modus-text-input autocapitalize="words">
+        <mock:shadow-root>
+            <div class="modus-text-input">
+                <div class="input-container medium" part="input-container">
+                <input class="text-align-left" id="mwc_id_2_text_input" tabindex="0" autocapitalize="words" type="text">
+                </div>
+            </div>
+        </mock:shadow-root>
+      </modus-text-input>
+    `);
+  });
+
+  it('renders autocorrect', async () => {
+    const page = await newSpecPage({
+      components: [ModusTextInput],
+      html: '<modus-text-input autocorrect="on"></modus-text-input>',
+    });
+    expect(page.root).toEqualHtml(`
+      <modus-text-input autocorrect="on">
+        <mock:shadow-root>
+            <div class="modus-text-input">
+                <div class="input-container medium" part="input-container">
+                <input class="text-align-left" id="mwc_id_3_text_input" tabindex="0" autocorrect="on" type="text">
+                </div>
+            </div>
+        </mock:shadow-root>
+      </modus-text-input>
+    `);
+  });
+
+  it('renders enterkeyhint', async () => {
+    const page = await newSpecPage({
+      components: [ModusTextInput],
+      html: '<modus-text-input enterkeyhint="done"></modus-text-input>',
+    });
+    expect(page.root).toEqualHtml(`
+      <modus-text-input enterkeyhint="done">
+        <mock:shadow-root>
+            <div class="modus-text-input">
+                <div class="input-container medium" part="input-container">
+                <input class="text-align-left" id="mwc_id_4_text_input" tabindex="0" enterkeyhint="done" type="text">
+                </div>
+            </div>
+        </mock:shadow-root>
+      </modus-text-input>
+    `);
+  });
+
+  it('renders spellcheck', async () => {
+    const page = await newSpecPage({
+      components: [ModusTextInput],
+      html: '<modus-text-input spellcheck></modus-text-input>',
+    });
+    expect(page.root).toEqualHtml(`
+      <modus-text-input spellcheck>
+        <mock:shadow-root>
+            <div class="modus-text-input">
+                <div class="input-container medium" part="input-container">
+                <input class="text-align-left" id="mwc_id_5_text_input" tabindex="0" spellcheck type="text">
+                </div>
+            </div>
+        </mock:shadow-root>
+      </modus-text-input>
+    `);
+  });
+
+  it('should set autocapitalize on the input to "on" when "true" is passed in', async () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.autocapitalize = true;
+    expect(modusTextInput.inputAutocapitalize).toEqual('on');
+  });
+
+  it('should set autocapitalize on the input to "off" when "false" is passed in', async () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.autocapitalize = false;
+    expect(modusTextInput.inputAutocapitalize).toEqual('off');
+  });
+
+  it('should set autocorrect on the input to "on" when "true" is passed in', async () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.autocorrect = true;
+    expect(modusTextInput.inputAutocorrect).toEqual('on');
+  });
+
+  it('should set autocorrect on the input to "off" when "false" is passed in', async () => {
+    const modusTextInput = new ModusTextInput();
+    modusTextInput.autocorrect = false;
+    expect(modusTextInput.inputAutocorrect).toEqual('off');
+  });
+
   it('should get the correct class by size', async () => {
     const modusTextInput = new ModusTextInput();
     let className = modusTextInput.classBySize.get(modusTextInput.size);

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.tsx
@@ -15,6 +15,12 @@ export class ModusTextInput {
   /** (optional) The input's aria-label. */
   @Prop() ariaLabel: string | null;
 
+  /** (optional) Capitalization behavior when using a non-traditional keyboard (e.g. microphone, touch screen) */
+  @Prop() autocapitalize: boolean | 'none' | 'off' | 'sentences' | 'on' | 'words' | 'characters';
+
+  /** (optional) Whether to activate automatic correction while the user is editing this field in Safari. */
+  @Prop() autocorrect: boolean | 'off' | 'on';
+
   /** (optional) Sets autocomplete on the input. */
   @Prop() autocomplete: string | null;
 
@@ -26,6 +32,9 @@ export class ModusTextInput {
 
   /** (optional) Whether the input is disabled. */
   @Prop() disabled: boolean;
+
+  /** (optional) Which action label to present for the enter key on virtual keyboards. */
+  @Prop() enterkeyhint: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
 
   /** (optional) The input's error state text. */
   @Prop() errorText: string;
@@ -62,6 +71,9 @@ export class ModusTextInput {
 
   /** (optional) The input's size. */
   @Prop() size: 'medium' | 'large' = 'medium';
+
+  /** (optional) Whether to enable spell checking. */
+  @Prop() spellcheck: boolean;
 
   /** (optional) The input's text alignment. */
   @Prop() textAlign: 'left' | 'right' = 'left';
@@ -139,6 +151,24 @@ export class ModusTextInput {
     }
   }
 
+  get inputAutocapitalize() {
+    if (this.autocapitalize === true) {
+      return 'on';
+    } else if (this.autocapitalize === false) {
+      return 'off';
+    }
+    return this.autocapitalize;
+  }
+
+  get inputAutocorrect() {
+    if (this.autocorrect === true) {
+      return 'on';
+    } else if (this.autocorrect === false) {
+      return 'off';
+    }
+    return this.autocorrect;
+  }
+
   render(): unknown {
     const iconSize = this.size === 'large' ? '24' : '16';
     const isPassword = this.type === 'password';
@@ -189,9 +219,12 @@ export class ModusTextInput {
             aria-invalid={!!this.errorText}
             aria-label={this.ariaLabel}
             aria-required={this.required?.toString()}
+            autoCapitalize={this.inputAutocapitalize}
             autocomplete={this.autocomplete}
+            autocorrect={this.autocorrect as string}
             class={buildTextInputClassNames()}
             disabled={this.disabled}
+            enterkeyhint={this.enterkeyhint}
             inputmode={this.inputmode}
             maxlength={this.maxLength}
             minlength={this.minLength}
@@ -199,6 +232,7 @@ export class ModusTextInput {
             placeholder={this.placeholder}
             readonly={this.readOnly}
             ref={(el) => (this.textInput = el as HTMLInputElement)}
+            spellcheck={this.spellcheck}
             tabIndex={0}
             type={this.type}
             value={this.value}

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -66,33 +66,53 @@ This component is compatible with Angular reactive forms. This can be achieved t
   label="Text Input (Password)"
   placeholder="Password"
   type="password"></modus-text-input>
+<modus-text-input
+  label="Text Input (Autocapitalize)"
+  placeholder="Use voice input"
+  autocapitalize="on"></modus-text-input>
+<modus-text-input
+  label="Text Input (Autocorrect)"
+  placeholder="Make mistakes while typing"
+  autocorrect="on"></modus-text-input>
+<modus-text-input
+  label="Text Input (Enter key hint)"
+  placeholder="Try this on a virtual keyboard"
+  enterkeyhint="send"></modus-text-input>
+<modus-text-input
+  label="Text Input (Spellcheck)"
+  placeholder="Make big mistakes while typing"
+  spellcheck></modus-text-input>
 ```
 
 ### Properties
 
-| Property                    | Attribute                      | Description                                                   | Type                                                                        | Default     |
-| --------------------------- | ------------------------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------- |
-| `ariaLabel`                 | `aria-label`                   | (optional) The input's aria-label.                            | `string`                                                                    | `undefined` |
-| `autoFocusInput`            | `auto-focus-input`             | (optional) Sets autofocus on the input.                       | `boolean`                                                                   | `undefined` |
-| `autocomplete`              | `autocomplete`                 | (optional) Sets autocomplete on the input.                    | `string`                                                                    | `undefined` |
-| `clearable`                 | `clearable`                    | (optional) Whether the input has a clear button.              | `boolean`                                                                   | `false`     |
-| `disabled`                  | `disabled`                     | (optional) Whether the input is disabled.                     | `boolean`                                                                   | `undefined` |
-| `errorText`                 | `error-text`                   | (optional) The input's error state text.                      | `string`                                                                    | `undefined` |
-| `helperText`                | `helper-text`                  | (optional) The input's helper text displayed below the input. | `string`                                                                    | `undefined` |
-| `includePasswordTextToggle` | `include-password-text-toggle` | (optional) Whether the password text toggle icon is included. | `boolean`                                                                   | `true`      |
-| `includeSearchIcon`         | `include-search-icon`          | (optional) Whether the search icon is included.               | `boolean`                                                                   | `undefined` |
-| `inputmode`                 | `inputmode`                    | (optional) The input's inputmode.                             | `"decimal", "email",  "numeric", "search", "tel", "text", "url"` | `undefined` |
-| `label`                     | `label`                        | (optional) The input's label.                                 | `string`                                                                    | `undefined` |
-| `maxLength`                 | `max-length`                   | (optional) The input's maximum length.                        | `number`                                                                    | `undefined` |
-| `minLength`                 | `min-length`                   | (optional) The input's minimum length.                        | `number`                                                                    | `undefined` |
-| `placeholder`               | `placeholder`                  | (optional) The input's placeholder text.                      | `string`                                                                    | `undefined` |
-| `readOnly`                  | `read-only`                    | (optional) Whether the input's content is read-only           | `boolean`                                                                   | `undefined` |
-| `required`                  | `required`                     | (optional) Whether the input is required.                     | `boolean`                                                                   | `undefined` |
-| `size`                      | `size`                         | (optional) The input's size.                                  | `"large", "medium"`                                                       | `'medium'`  |
-| `textAlign`                 | `text-align`                   | (optional) The input's text alignment.                  | `"left", "right"`                                                         | `'left'`    |
-| `type`                      | `type`                         | (optional) The input's type.                                  | `"password", "text"`                                                      | `'text'`    |
-| `validText`                 | `valid-text`                   | (optional) The input's valid state text.                      | `string`                                                                    | `undefined` |
-| `value`                     | `value`                        | (optional) The input's value.                                 |
+| Property                    | Attribute                      | Description                                                                                                    | Type                                                                        | Default     |
+| --------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ----------- |
+| `ariaLabel`                 | `aria-label`                   | (optional) The input's aria-label.                                                                             | `string`                                                                    | `undefined` |
+| `autoFocusInput`            | `auto-focus-input`             | (optional) Sets autofocus on the input.                                                                        | `boolean`                                                                   | `undefined` |
+| `autocapitalize`            | `autocapitalize`               | (optional) Capitalization behavior when using a non-traditional keyboard (e.g. microphone, touch screen).      | `boolean, "none", "off", "sentences", "on", "words", "characters"`          | `undefined` |
+| `autocorrect `              | `autocorrect`                  | (optional) (optional) Whether to activate automatic correction while the user is editing this field in Safari. | `boolean, "off", "on"`                                                      | `undefined` |
+| `autocomplete`              | `autocomplete`                 | (optional) Sets autocomplete on the input.                                                                     | `string`                                                                    | `undefined` |
+| `clearable`                 | `clearable`                    | (optional) Whether the input has a clear button.                                                               | `boolean`                                                                   | `false`     |
+| `disabled`                  | `disabled`                     | (optional) Whether the input is disabled.                                                                      | `boolean`                                                                   | `undefined` |
+| `enterkeyhint`              | `enterkeyhint`                 | (optional) Which action label to present for the enter key on virtual keyboards.                               | `"enter", "done", "go", "next", "previous", "search", "send"`                 | `undefined` |
+| `errorText`                 | `error-text`                   | (optional) The input's error state text.                                                                       | `string`                                                                    | `undefined` |
+| `helperText`                | `helper-text`                  | (optional) The input's helper text displayed below the input.                                                  | `string`                                                                    | `undefined` |
+| `includePasswordTextToggle` | `include-password-text-toggle` | (optional) Whether the password text toggle icon is included.                                                  | `boolean`                                                                   | `true`      |
+| `includeSearchIcon`         | `include-search-icon`          | (optional) Whether the search icon is included.                                                                | `boolean`                                                                   | `undefined` |
+| `inputmode`                 | `inputmode`                    | (optional) The input's inputmode.                                                                              | `"decimal", "email",  "numeric", "search", "tel", "text", "url"`            | `undefined` |
+| `label`                     | `label`                        | (optional) The input's label.                                                                                  | `string`                                                                    | `undefined` |
+| `maxLength`                 | `max-length`                   | (optional) The input's maximum length.                                                                         | `number`                                                                    | `undefined` |
+| `minLength`                 | `min-length`                   | (optional) The input's minimum length.                                                                         | `number`                                                                    | `undefined` |
+| `placeholder`               | `placeholder`                  | (optional) The input's placeholder text.                                                                       | `string`                                                                    | `undefined` |
+| `readOnly`                  | `read-only`                    | (optional) Whether the input's content is read-only                                                            | `boolean`                                                                   | `undefined` |
+| `required`                  | `required`                     | (optional) Whether the input is required.                                                                      | `boolean`                                                                   | `undefined` |
+| `size`                      | `size`                         | (optional) The input's size.                                                                                   | `"large", "medium"`                                                         | `'medium'`  |
+| `spellcheck`                | `spellcheck`                   | (optional) Whether to enable spell checking.                                                                   | `boolean`                                                                   | `false`     |
+| `textAlign`                 | `text-align`                   | (optional) The input's text alignment.                                                                         | `"left", "right"`                                                           | `'left'`    |
+| `type`                      | `type`                         | (optional) The input's type.                                                                                   | `"password", "text"`                                                        | `'text'`    |
+| `validText`                 | `valid-text`                   | (optional) The input's valid state text.                                                                       | `string`                                                                    | `undefined` |
+| `value`                     | `value`                        | (optional) The input's value.                                                                                  |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input-storybook-docs.mdx
@@ -66,22 +66,6 @@ This component is compatible with Angular reactive forms. This can be achieved t
   label="Text Input (Password)"
   placeholder="Password"
   type="password"></modus-text-input>
-<modus-text-input
-  label="Text Input (Autocapitalize)"
-  placeholder="Use voice input"
-  autocapitalize="on"></modus-text-input>
-<modus-text-input
-  label="Text Input (Autocorrect)"
-  placeholder="Make mistakes while typing"
-  autocorrect="on"></modus-text-input>
-<modus-text-input
-  label="Text Input (Enter key hint)"
-  placeholder="Try this on a virtual keyboard"
-  enterkeyhint="send"></modus-text-input>
-<modus-text-input
-  label="Text Input (Spellcheck)"
-  placeholder="Make big mistakes while typing"
-  spellcheck></modus-text-input>
 ```
 
 ### Properties

--- a/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-text-input/modus-text-input.stories.tsx
@@ -12,11 +12,43 @@ export default {
         type: { summary: 'string' },
       },
     },
+    autocapitalize: {
+      name: 'autocapitalize',
+      control: {
+        options: [
+          'none',
+          'off',
+          'sentences',
+          'on',
+          'words',
+          'characters'
+        ],
+        type: 'select',
+      },
+      description: "Capitalization behavior when using a non-traditional keyboard (e.g. microphone, touch screen)",
+      table: {
+        type: { summary: `boolean | 'none' | 'off' | 'sentences' | 'on' | 'words' | 'characters'` },
+      },
+    },
     autocomplete: {
       name: 'autocomplete',
       description: "The text input's autocomplete",
       table: {
         type: { summary: 'string' },
+      },
+    },
+    autocorrect: {
+      name: 'autocorrect',
+      control: {
+        options: [
+          'off',
+          'on'
+        ],
+        type: 'select',
+      },
+      description: "Whether to activate automatic correction while the user is editing this field in Safari",
+      table: {
+        type: { summary: `boolean | 'off' | 'on'` },
       },
     },
     autoFocusInput: {
@@ -38,6 +70,24 @@ export default {
       table: {
         defaultValue: { summary: false },
         type: { summary: 'boolean' },
+      },
+    },
+    enterkeyhint: {
+      control: {
+        options: [
+          'enter',
+          'done',
+          'go',
+          'next',
+          'previous',
+          'search',
+          'send'
+        ],
+        type: 'select',
+      },
+      description: 'Which action label to present for the enter key on virtual keyboards',
+      table: {
+        type: { summary: `'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'` },
       },
     },
     errorText: {
@@ -143,6 +193,16 @@ export default {
         type: { summary: "'medium' | 'large'" },
       },
     },
+    spellcheck: {
+      control: {
+        type: 'boolean'
+      },
+      name: 'spellcheck',
+      description: "Whether to enable spell checking.",
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
     textAlign: {
       name: 'text-align',
       control: {
@@ -202,10 +262,13 @@ export default {
 
 const Template = ({
   ariaLabel,
+  autocapitalize,
   autocomplete,
+  autocorrect,
   autoFocusInput,
   clearable,
   disabled,
+  enterkeyhint,
   errorText,
   helperText,
   includePasswordTextToggle,
@@ -218,6 +281,7 @@ const Template = ({
   readOnly,
   required,
   size,
+  spellcheck,
   textAlign,
   type,
   validText,
@@ -226,10 +290,13 @@ const Template = ({
 <form>
   <modus-text-input
     aria-label=${ariaLabel}
+    autocapitalize=${autocapitalize}
     autocomplete=${autocomplete}
+    autocorrect=${autocorrect}
     auto-focus-input=${autoFocusInput}
     clearable=${clearable}
     ?disabled=${disabled}
+    enterkeyhint=${enterkeyhint}
     error-text=${errorText}
     helper-text=${helperText}
     include-password-text-toggle=${includePasswordTextToggle}
@@ -242,6 +309,7 @@ const Template = ({
     read-only=${readOnly}
     ?required=${required}
     size=${size}
+    ?spellcheck=${spellcheck}
     text-align=${textAlign}
     type=${type}
     valid-text=${validText}
@@ -252,10 +320,13 @@ const Template = ({
 export const Default = Template.bind({});
 Default.args = {
   ariaLabel: '',
+  autocapitalize: undefined,
   autocomplete: '',
+  autocorrect: null,
   autoFocusInput: true,
   clearable: false,
   disabled: false,
+  enterkeyhint: undefined,
   errorText: '',
   helperText: '',
   includePasswordTextToggle: true,
@@ -268,6 +339,7 @@ Default.args = {
   readOnly: false,
   required: false,
   size: 'medium',
+  spellcheck: false,
   textAlign: 'left',
   type: 'text',
   validText: '',


### PR DESCRIPTION
## Description

Add autocapitalize, autocorrect, enterkeyhint, and spellcheck properties to input

References #2347

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added unit tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
