### PR TITLE
Switch: Make disabled switches not focusable

### DIFF
--- a/stencil-workspace/src/components/modus-switch/modus-switch.spec.tsx
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.spec.tsx
@@ -20,4 +20,23 @@ describe('modus-switch', () => {
       </modus-switch>
     `);
   });
+
+  it('sets tabindex to -1 when disabled', async () => {
+    const page = await newSpecPage({
+      components: [ModusSwitch],
+      html: '<modus-switch disabled></modus-switch>',
+    });
+    expect(page.root).toEqualHtml(`
+      <modus-switch disabled>
+        <mock:shadow-root>
+          <div class="disabled medium modus-switch" tabindex="-1">
+            <div class="switch">
+              <span class="slider"></span>
+            </div>
+            <input role="switch" aria-disabled="true" disabled type="checkbox">
+          </div>
+        </mock:shadow-root>
+      </modus-switch>
+    `);
+  });
 });

--- a/stencil-workspace/src/components/modus-switch/modus-switch.tsx
+++ b/stencil-workspace/src/components/modus-switch/modus-switch.tsx
@@ -64,7 +64,7 @@ export class ModusSwitch {
     const switchClassName = `switch ${this.checked ? 'checked' : ''}`;
 
     return (
-      <div class={containerClassName} onClick={() => this.handleSwitchClick()} tabIndex={0}>
+      <div class={containerClassName} onClick={() => this.handleSwitchClick()} tabIndex={this.disabled ? -1 : 0}>
         <div class={switchClassName}>
           <span class={`slider`}></span>
         </div>


### PR DESCRIPTION
## Description

Make disabled switches not focusable by making `tabindex` dependent on `disabled`.

References #2270

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added a unit test to verify `tabindex` is -1 when `disabled` attribute is added.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
