### PR TITLE
Input: Add primary-font to input elements designed to display text

### DIFF
--- a/stencil-workspace/src/components/modus-date-input/modus-date-input.scss
+++ b/stencil-workspace/src/components/modus-date-input/modus-date-input.scss
@@ -199,6 +199,7 @@
     background-position: right calc(0.375em + 0.1875rem) center;
     background-repeat: no-repeat;
     background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+    font-family: $primary-font;
     padding-right: calc(1.5em + 0.75rem);
   }
 }

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.scss
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.scss
@@ -36,6 +36,12 @@
     }
   }
 
+  .input-container {
+    input {
+      font-family: $primary-font;
+    }
+  }
+
   .calendar-container {
     background-color: $modus-date-picker-calendar-body-bg;
     border-radius: 4px;

--- a/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
+++ b/stencil-workspace/src/components/modus-number-input/modus-number-input.scss
@@ -41,6 +41,7 @@
       background-color: transparent;
       border: none;
       color: $modus-input-color;
+      font-family: $primary-font;
       outline: 0;
       padding: 0 $rem-8px;
       width: 100%;

--- a/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
+++ b/stencil-workspace/src/components/modus-text-input/modus-text-input.scss
@@ -56,6 +56,7 @@
       background-color: transparent;
       border: none;
       color: $modus-input-color;
+      font-family: $primary-font;
       font-size: $rem-12px;
       outline: none;
       padding: 0 $rem-8px;

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.scss
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.scss
@@ -64,6 +64,7 @@
       background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
       border: none;
       color: $modus-input-color;
+      font-family: $primary-font;
       font-size: $rem-12px;
       outline: none;
       padding: 0 $rem-8px;


### PR DESCRIPTION
## Description

Adds `font-family: $primary-font` to input elements that display some form of text.

References #2353

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added the following to `index.html`: 

```html
<modus-text-input
      label="Text Input (Search Icon)"
      placeholder="Placeholder"
      include-search-icon
      required></modus-text-input>
    <modus-number-input
      label="Number Input Demo 1"
      placeholder="Placeholder"
      required="true"></modus-number-input>
    <modus-date-picker
      helper-text="mmm dd, yyyy"
      label="Single date"
      allowed-chars-regex="[\d\/]"
      format="mmm dd, yyyy"
      value="2022-12-22"></modus-date-input>
      <modus-time-picker
        label="Time"
        ampm="true"
        value="23:39"
        placeholder="12:00 AM"
        helper-text="hh:mm AM/PM"></modus-time-picker>
```

Also put "Times New Roman" as the first element in `$primary-font` (just as a visual indicator that my changes are, in fact, effective and the inspector isn't mistaken)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
