### PR TITLE
Tooltip:focus tooltipped item when tooltip is active, allow tooltip to be dismissed on escape

### DIFF
--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.e2e.ts
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.e2e.ts
@@ -78,4 +78,81 @@ describe('modus-tooltip', () => {
     await new Promise((r) => setTimeout(r, 500));
     expect(tooltip.getAttribute('data-show')).toBeNull();
   });
+
+  it('preserves tabindex on hide', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-tooltip text="Tooltip text">
+        <modus-button tabindex="3" id="tooltip-button">Button</modus-button>
+      </modus-tooltip>
+      <modus-button id="not-tooltip-button">Other button</modus-button>
+      `);
+
+    const tooltip = await page.find('modus-tooltip');
+    const button = await tooltip.find('#tooltip-button');
+    await page.hover('#tooltip-button');
+    await page.waitForChanges();
+    expect(button.getAttribute('tabindex')).toEqual('3');
+
+    await page.hover('#not-tooltip-button');
+    await page.waitForChanges();
+    expect(button.getAttribute('tabindex')).toEqual('3');
+  });
+
+  it('preserves lack of tabindex on hide', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-tooltip text="Tooltip text">
+        <modus-button id="tooltip-button">Button</modus-button>
+      </modus-tooltip>
+      <modus-button id="not-tooltip-button">Other button</modus-button>
+      `);
+
+    const tooltip = await page.find('modus-tooltip');
+    const button = await tooltip.find('#tooltip-button');
+    await page.hover('#tooltip-button');
+    await page.waitForChanges();
+    expect(button.getAttribute('tabindex')).toEqual('-1');
+
+    await page.hover('#not-tooltip-button');
+    await page.waitForChanges();
+    expect(button.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('focuses the tooltipped element on show', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-tooltip text="Tooltip text">
+        <modus-button id="tooltip-button">Button</modus-button>
+      </modus-tooltip>
+      `);
+
+    await page.hover('#tooltip-button');
+    await page.waitForChanges();
+    const activeElementId = await page.evaluate(() => document.activeElement!.id);
+    expect(activeElementId).toEqual('tooltip-button');
+  });
+
+  it('hides the tooltip on "escape" key', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-tooltip text="Tooltip text">
+        <modus-button tabindex="3" id="tooltip-button">Button</modus-button>
+      </modus-tooltip>
+      `);
+
+    const tooltip = await page.find('modus-tooltip >>> .tooltip');
+    await page.hover('#tooltip-button');
+
+    await page.waitForChanges();
+    expect(tooltip).toHaveAttribute('data-show');
+
+    page.keyboard.press('Escape');
+    await page.waitForChanges();
+    expect(tooltip).not.toHaveAttribute('data-show');
+  });
 });


### PR DESCRIPTION
## Description

Focus tooltipped item when tooltip is active, allow tooltip to be dismissed on escape

References  #2177

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

End to end tests, manual test using the following html:

```
    <modus-tooltip text="Tooltip text..." position="right">
      <modus-button tabindex="3">Button</modus-button>
      <modus-button>Button2</modus-button>
    </modus-tooltip>
```

Also tried without `tabindex` on first button.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
