### PR TITLE
Tabs: Fix issue where selecting a tab in a set with no active tab errors out

### DIFF
--- a/stencil-workspace/src/components/modus-tabs/modus-tabs.e2e.ts
+++ b/stencil-workspace/src/components/modus-tabs/modus-tabs.e2e.ts
@@ -56,4 +56,23 @@ describe('modus-tabs', () => {
     await page.waitForChanges();
     expect(tabChange).toHaveReceivedEvent();
   });
+
+  it('emits pageChange on page click when no tabs are active before click', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-tabs></modus-tabs>');
+    const tabChange = await page.spyOnEvent('tabChange');
+
+    const modusTabs = await page.find('modus-tabs');
+    modusTabs.setProperty('tabs', [
+      { id: 0, label: 'Tab1' },
+      { id: 1, label: 'Tab2' },
+    ]);
+    await page.waitForChanges();
+    const element = await page.find('modus-tabs >>> div[id="0"] + div');
+
+    await element.click();
+    await page.waitForChanges();
+    expect(tabChange).toHaveReceivedEvent();
+  });
 });

--- a/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
+++ b/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
@@ -44,7 +44,7 @@ export class ModusTabs {
   handleTabChange(id: string): void {
     const activeTab = this.tabs.find((tab) => tab.active);
 
-    if (activeTab != undefined && activeTab.id === id) {
+    if (activeTab?.id === id) {
       return;
     }
 

--- a/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
+++ b/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
@@ -42,7 +42,9 @@ export class ModusTabs {
   }
 
   handleTabChange(id: string): void {
-    if (id === this.tabs.find((tab) => tab.active).id) {
+    const activeTab = this.tabs.find((tab) => tab.active);
+
+    if (activeTab != undefined && activeTab.id) {
       return;
     }
 

--- a/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
+++ b/stencil-workspace/src/components/modus-tabs/modus-tabs.tsx
@@ -44,7 +44,7 @@ export class ModusTabs {
   handleTabChange(id: string): void {
     const activeTab = this.tabs.find((tab) => tab.active);
 
-    if (activeTab != undefined && activeTab.id) {
+    if (activeTab != undefined && activeTab.id === id) {
       return;
     }
 


### PR DESCRIPTION

## Description

Fix issue where selecting a tab in a set with no active tab errors out.

References #2197

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added E2E test, manually tested using provided HTML (thank you, reporter)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
