### PR TITLE
Dropdown: Fix issue where enter, escape, and space key are not having desired output

### DIFF
--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.e2e.ts
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.e2e.ts
@@ -129,4 +129,115 @@ describe('modus-dropdown', () => {
     await page.waitForChanges();
     expect(dropdownClose).toHaveReceivedEvent();
   });
+
+  it('should close dropdown when Enter is pressed outside the toggle element', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+      <div id="not-dropdown">
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.focus();
+    await page.keyboard.press('Enter');
+    expect(dropdown.find('.dropdown-list.visible')).toBeTruthy();
+
+    const notDropdownComponent = await page.find('#not-dropdown');
+    await notDropdownComponent.focus();
+    await page.keyboard.press('Enter');
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
+  it('should close dropdown when Space is pressed outside the toggle element', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+      <div id="not-dropdown">
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.focus();
+    await page.keyboard.press(' ');
+    expect(dropdown.find('.dropdown-list.visible')).toBeTruthy();
+
+    const notDropdownComponent = await page.find('#not-dropdown');
+    await notDropdownComponent.focus();
+    await page.keyboard.press(' ');
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
+  it('should toggle visibility when Enter is pressed on the toggle element', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.focus();
+    await page.keyboard.press('Enter');
+    expect(dropdown.find('.dropdown-list.visible')).toBeTruthy();
+
+    await page.keyboard.press('Enter');
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
+  it('should toggle visibility when Space is pressed on the toggle element', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.focus();
+    await page.keyboard.press(' ');
+    expect(dropdown.find('.dropdown-list.visible')).toBeTruthy();
+
+    await page.keyboard.press(' ');
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
+  it('should close dropdown when Escape is pressed', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.focus();
+    await page.keyboard.press(' ');
+    expect(dropdown.find('.dropdown-list.visible')).toBeTruthy();
+
+    await page.keyboard.press('Escape');
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
 });

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.spec.ts
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.spec.ts
@@ -2,7 +2,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { ModusDropdown } from './modus-dropdown';
 
 describe('modus-dropdown', () => {
-  let component: ModusDropdown;
   it('renders', async () => {
     const { root } = await newSpecPage({
       components: [ModusDropdown],
@@ -48,51 +47,5 @@ describe('modus-dropdown', () => {
     expect(() => {
       modusDropdown.componentDidRender();
     }).toThrowError('matching element not found for toggle-element-id');
-  });
-
-  beforeEach(() => {
-    component = new ModusDropdown();
-    component.toggleElementId = 'testId';
-    document.body.innerHTML = `<div id="${component.toggleElementId}"></div>`;
-  });
-
-  it('should toggle visibility when Enter is pressed on the toggle element', () => {
-    const event = new KeyboardEvent('keydown', { key: 'Enter' });
-    Object.defineProperty(event, 'target', { value: document.getElementById(component.toggleElementId), writable: false });
-    component.handleDropdownKeyDown(event);
-    expect(component.visible).toBe(true);
-    component.handleDropdownKeyDown(event);
-    expect(component.visible).toBe(false);
-  });
-
-  it('should close dropdown when Enter is pressed outside the toggle element', () => {
-    const event = new KeyboardEvent('keydown', { key: 'Enter' });
-    Object.defineProperty(event, 'target', { value: document.body, writable: false });
-    component.visible = true;
-    component.handleDropdownKeyDown(event);
-    expect(component.visible).toBe(false);
-  });
-  it('should toggle visibility when Space is pressed on the toggle element', () => {
-    const event = new KeyboardEvent('keydown', { key: ' ' });
-    Object.defineProperty(event, 'target', { value: document.getElementById(component.toggleElementId), writable: false });
-    component.handleDropdownKeyDown(event);
-    expect(component.visible).toBe(true);
-    component.handleDropdownKeyDown(event);
-    expect(component.visible).toBe(false);
-  });
-
-  it('should close dropdown when Space is pressed outside the toggle element', () => {
-    const event = new KeyboardEvent('keydown', { key: ' ' });
-    Object.defineProperty(event, 'target', { value: document.body, writable: false });
-    component.visible = true;
-    component.handleDropdownKeyDown(event);
-    expect(component.visible).toBe(false);
-  });
-  it('should close dropdown when Escape is pressed', () => {
-    const event = new KeyboardEvent('keydown', { key: 'Escape' });
-    Object.defineProperty(event, 'target', { value: document.getElementById(component.toggleElementId), writable: false });
-    component.visible = true;
-    component.documentKeyDownHandler(event);
-    expect(component.visible).toBe(false);
   });
 });

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
@@ -104,22 +104,6 @@ export class ModusDropdown {
     }
   }
 
-  handleDropdownKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Enter' || event.key === ' ') {
-      if ((event.target as HTMLElement)?.closest(`#${this.toggleElementId}`)) {
-        this.visible = !this.visible;
-      } else {
-        this.visible = false;
-      }
-
-      if (!this.visible) {
-        this.dropdownClose.emit();
-      } else {
-        this.dropdownToggleClicked = true;
-      }
-    }
-  }
-
   render(): unknown {
     const listContainerClass = `dropdown-list ${this.visible ? 'visible' : 'hidden'} ${
       this.showDropdownListBorder ? 'list-border' : ''

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
@@ -128,13 +128,7 @@ export class ModusDropdown {
     const width = `${this.toggleElement?.offsetWidth ? this.toggleElement?.offsetWidth : 0}px`;
 
     return (
-      <div
-        aria-label={this.ariaLabel}
-        class="dropdown"
-        onClick={(event) => this.handleDropdownClick(event)}
-        onKeyDown={(event) => {
-          this.handleDropdownKeyDown(event);
-        }}>
+      <div aria-label={this.ariaLabel} class="dropdown" onClick={(event) => this.handleDropdownClick(event)}>
         <slot name="dropdownToggle" />
         <div
           class={listContainerClass}


### PR DESCRIPTION
## Description

* Delete excessive calls to methods that react to input
* Update tests to better reflect a user journey, replacing existing unit tests with more black-box e2e tests.

References #2392

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

E2E tests, manually using the following code in `index.html`:

```
    <modus-dropdown toggle-element-id="toggleElement">
      <modus-button id="toggleElement" slot="dropdownToggle" show-caret="true">Dropdown</modus-button>
      <modus-list slot="dropdownList">
        <modus-list-item size="condensed" borderless>Item 1</modus-list-item>
        <modus-list-item size="condensed" borderless>Item 2</modus-list-item>
        <modus-list-item size="condensed" borderless>Item 3</modus-list-item>
      </modus-list>
    </modus-dropdown>
    <modus-text-input></modus-text-input>
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
