### PR TITLE
Docs: badges (counter) Canvas demo to use numbers (not text)

### DIFF
--- a/stencil-workspace/storybook/stories/components/modus-badge/modus-badge.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-badge/modus-badge.stories.tsx
@@ -92,7 +92,7 @@ export const Counter = ({ ariaLabel, color, size, type }) =>
       color=${color}
       size=${size}
       type=${type}>
-      Counter
+      12
     </modus-badge>
   `;
 Counter.args = {


### PR DESCRIPTION
## Description

Minor docs change: Badges (counter) Canvas demo to use numbers (not text) as intended.

Fixes: #2422

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

https://deploy-preview-2423--moduswebcomponents.netlify.app/?path=/story/components-badge--counter

![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/65a54cd8-c8b8-4ddf-aa0a-02ff281b63af)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
