### PR TITLE
Tooltip: fix issue with tooltip creating a new line when multiple buttons are in a row

### DIFF
--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
@@ -14,7 +14,7 @@
 }
 
 .tooltip[data-show]:not(.hide) {
-  display: block;
+  display: inline-block;
 }
 
 #arrow,


### PR DESCRIPTION


## Description

Behavior was because of how `modus-tooltip` is implemented (i.e. as a `div`).  Using `inline-block` prevents this behavior.

References  #2438

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Manually verify in both Chrome and Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
