### PR TITLE
Button-Group: Add `role="group"`

### DIFF
--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.e2e.ts
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.e2e.ts
@@ -4,7 +4,7 @@ describe('modus-button-group', () => {
   it('renders', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<modus-button-group></modus-button-group>');
+    await page.setContent('<modus-button-group role="group"></modus-button-group>');
     const element = await page.find('modus-button-group');
     expect(element).toHaveClass('hydrated');
   });
@@ -13,7 +13,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group>
+      <modus-button-group role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
       </modus-button-group>

--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.e2e.ts
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.e2e.ts
@@ -27,7 +27,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group>
+      <modus-button-group role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
       </modus-button-group>
@@ -48,7 +48,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group>
+      <modus-button-group role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
       </modus-button-group>
@@ -84,7 +84,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group selection-type="single">
+      <modus-button-group selection-type="single" role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
         <modus-button>Button 3</modus-button>
@@ -137,7 +137,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group selection-type="multiple">
+      <modus-button-group selection-type="multiple" role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
         <modus-button>Button 3</modus-button>
@@ -189,7 +189,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group disabled>
+      <modus-button-group disabled role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
       </modus-button-group>
@@ -198,7 +198,7 @@ describe('modus-button-group', () => {
 
     const buttons = await page.findAll('modus-button');
 
-    for (let button of buttons) {
+    for (const button of buttons) {
       const buttonDisabled = await button.getProperty('disabled');
       expect(buttonDisabled).toBe(true);
     }
@@ -208,7 +208,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group button-style="solid">
+      <modus-button-group button-style="solid" role="group">
         <modus-button>Button 1</modus-button>
         <modus-button>Button 2</modus-button>
       </modus-button-group>
@@ -235,7 +235,7 @@ describe('modus-button-group', () => {
     const page = await newE2EPage();
 
     await page.setContent(`
-      <modus-button-group aria-label="Group Label" aria-disabled="true">
+      <modus-button-group aria-label="Group Label" aria-disabled="true" role="group">
         <modus-button>Button 1</modus-button>
       </modus-button-group>
     `);

--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.spec.ts
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.spec.ts
@@ -8,7 +8,7 @@ describe('modus-button-group', () => {
       html: '<modus-button-group></modus-button-group>',
     });
     expect(root).toEqualHtml(`
-    <modus-button-group>
+    <modus-button-group role="group">
       <mock:shadow-root>
         <slot></slot>
       </mock:shadow-root>
@@ -28,7 +28,7 @@ describe('modus-button-group', () => {
         `,
     });
     expect(root).toEqualHtml(`
-    <modus-button-group>
+    <modus-button-group role="group">
       <mock:shadow-root>
         <slot></slot>
       </mock:shadow-root>

--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
@@ -136,7 +136,8 @@ export class ModusButtonGroup {
     return (
       <Host
         aria-label={this.ariaLabel}
-        aria-disabled={this.ariaDisabled ? this.ariaDisabled : this.disabled ? 'true' : undefined}>
+        aria-disabled={this.ariaDisabled ? this.ariaDisabled : this.disabled ? 'true' : undefined}
+        role="group">
         <slot />
       </Host>
     );

--- a/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group-storybook-docs.mdx
@@ -103,7 +103,8 @@ interface ModusButtonGroupButtonClickEvent {
 | `buttonClick`     | An event that fires on button click.                                                                                          | `CustomEvent<ModusButtonGroupButtonClickEvent>` |
 | `selectionChange` | An event that fires when selection type is `single` or `multiple` on button click that provides the list of selected buttons. | `CustomEvent<HTMLModusButtonElement[]>`         |
 
-
 ### Accessibility
-- ButtonGroup gets an aria-label provided by the aria-label property input.
-- ButtonGroup gets an aria-disabled set to whether ButtonGroup is disabled.
+
+- ButtonGroup gets an `aria-label` provided by the `aria-label` property input.
+- ButtonGroup gets an `aria-disabled` set to whether ButtonGroup is disabled.
+- ButtonGroup gets `role="group"` set.


### PR DESCRIPTION
## Description

Fix accessibility issue if a user adds an `aria-label` since no role was defined.

Fixes this issue:
![image](https://github.com/trimble-oss/modus-web-components/assets/1212885/c8ee74a5-ec41-4ce7-9f13-06cf4fd42235)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Local (storybook)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
