### PR TITLE
Dropdown: Fix disabled behavior on dropdown element

### DIFF
--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.e2e.ts
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.e2e.ts
@@ -199,6 +199,46 @@ describe('modus-dropdown', () => {
     expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
   });
 
+  it('should toggle visibility when clicked', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.focus();
+    await dropdown.click();
+    await page.waitForChanges();
+    expect(dropdown.find('.dropdown-list.visible')).toBeTruthy();
+
+    await dropdown.click();
+    await page.waitForChanges();
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
+  it('should not toggle visibility dropdown is disabled and clicked', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown disabled toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+
+    const dropdown = await page.find('modus-dropdown');
+    await dropdown.click();
+    expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
   it('should toggle visibility when Space is pressed on the toggle element', async () => {
     const page = await newE2EPage();
 
@@ -239,5 +279,21 @@ describe('modus-dropdown', () => {
 
     await page.keyboard.press('Escape');
     expect(dropdown.find('.dropdown-list.hidden')).toBeTruthy();
+  });
+
+  it('does not set the toggle element to disabled when "disabled" is not in as an attribute', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <modus-dropdown toggle-element-id='toggle-id'>
+        <modus-button id='toggle-id' slot='dropdownToggle'>Dropdown</modus-button>
+        <modus-list slot='dropdownList'>
+          <modus-list-item>Item 1</modus-list-item>
+        </modus-list>
+      </modus-dropdown>
+    `);
+
+    const button = await page.find('#toggle-id');
+    expect(button.getAttribute('disabled')).toBeNull();
   });
 });

--- a/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-dropdown/modus-dropdown.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Component, Prop, h, Event, EventEmitter, State, Element, Listen } from '@stencil/core';
+import { Component, Prop, h, Event, EventEmitter, State, Element, Listen, Watch } from '@stencil/core';
 
 @Component({
   tag: 'modus-dropdown',
@@ -55,6 +55,9 @@ export class ModusDropdown {
     if (!this.toggleElement) {
       throw Error('matching element not found for toggle-element-id');
     }
+    if (this.disabled) {
+      this.toggleElement.setAttribute('disabled', String(this.disabled));
+    }
   }
 
   @Listen('click', { target: 'document' })
@@ -73,6 +76,9 @@ export class ModusDropdown {
   @Listen('keydown', { target: 'document' })
   documentKeyDownHandler(event: KeyboardEvent): void {
     if (event.key === 'Enter' || event.key === ' ') {
+      if (this.disabled) {
+        return;
+      }
       if (this.dropdownToggleClicked || (event.target as HTMLElement).closest(`#${this.toggleElementId}`)) {
         this.dropdownToggleClicked = false;
         return;
@@ -86,11 +92,19 @@ export class ModusDropdown {
     }
   }
 
+  @Watch('disabled')
+  onDisabledChange(newValue: boolean) {
+    this.toggleElement.setAttribute('disabled', String(newValue));
+  }
+
   hideDropdown(): void {
     this.visible = false;
     this.dropdownClose.emit();
   }
   handleDropdownClick(event: MouseEvent): void {
+    if (this.disabled) {
+      return;
+    }
     if ((event.target as HTMLElement).closest(`#${this.toggleElementId}`)) {
       this.visible = !this.visible;
     } else {


### PR DESCRIPTION
## Description
Fix disabled behavior on dropdown element.  Adds `disabled` to toggle element and prevents actions when disabled.

References #2419

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Manual using existing Storybook implementation, e2e tests

https://deploy-preview-2456--moduswebcomponents.netlify.app/?path=/story/components-dropdown--default&args=disabled:true

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
