### PR TITLE
Toast: Dismiss Button Style Improvement

### DIFF
--- a/stencil-workspace/src/components/modus-toast/modus-toast.scss
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.scss
@@ -32,10 +32,11 @@
     background-color: transparent;
     border: 0;
     margin-left: auto;
+    margin-top: 2px;
 
     .icon-close {
-      height: 24px;
-      width: 24px;
+      height: 18px;
+      width: 18px;
     }
 
     &:hover svg {

--- a/stencil-workspace/src/components/modus-toast/modus-toast.tsx
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.tsx
@@ -5,7 +5,7 @@ import { IconWarning } from '../../icons/svgs/icon-warning';
 import { IconInfo } from '../../icons/svgs/icon-info';
 import { IconHelp } from '../../icons/svgs/icon-help';
 import { IconCheckCircle } from '../../icons/svgs/icon-check-circle';
-import { IconClose } from '../../icons/svgs/icon-close';
+import { IconClose } from '../../icons/generated-icons/IconClose';
 
 @Component({
   tag: 'modus-toast',
@@ -64,7 +64,7 @@ export class ModusToast {
           <slot />
         </span>
         {this.dismissible && (
-          <button class={'close'} onClick={() => this.dismissClick.emit()} aria-label="Dismiss">
+          <button type="button" class={'close'} onClick={() => this.dismissClick.emit()} aria-label="Dismiss">
             <IconClose size={'18'} />
           </button>
         )}


### PR DESCRIPTION
## Description

- Smaller icon (from 24px to 18px) - now same size as Alert close/dismiss button
- Adds `type="button"` (Fixes this issue: https://webhint.io/docs/user-guide/hints/hint-button-type/)
- Use actual Modus Close icon.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-2472--moduswebcomponents.netlify.app/?path=/story/components-toast--default&args=dismissible:true

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
