### PR TITLE
Toast: Add delay property 

### DIFF
--- a/stencil-workspace/src/components/modus-toast/modus-toast.e2e.ts
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.e2e.ts
@@ -62,4 +62,24 @@ describe('modus-toast', () => {
     await page.waitForChanges();
     expect(dismissClick).toHaveReceivedEvent();
   });
+
+  it('emits dismissClick event after 15000ms', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-toast></modus-toast>');
+    const dismissClick = await page.spyOnEvent('dismissClick');
+
+    await page.waitForTimeout(15000);
+    expect(dismissClick).toHaveReceivedEvent();
+  });
+
+  it('emits dismissClick event after 15000ms', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-toast delay="10000"></modus-toast>');
+    const dismissClick = await page.spyOnEvent('dismissClick');
+
+    await page.waitForTimeout(10000);
+    expect(dismissClick).toHaveReceivedEvent();
+  });
 });

--- a/stencil-workspace/src/components/modus-toast/modus-toast.tsx
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.tsx
@@ -19,6 +19,9 @@ export class ModusToast {
   /** (optional) Whether the toast has a dismiss button. */
   @Prop() dismissible: boolean;
 
+  /** (optional) Time taken to dismiss the toast */
+  @Prop() delay = 15000;
+
   /** (optional) Role taken by the toast.  Defaults to 'status'. */
   @Prop() role: 'alert' | 'log' | 'marquee' | 'status' | 'timer' = 'status';
 
@@ -30,6 +33,8 @@ export class ModusToast {
 
   /** An event that fires when the toast is dismissed */
   @Event() dismissClick: EventEmitter;
+
+  private timerId: NodeJS.Timeout;
 
   iconByType: Map<string, HTMLElement> = new Map([
     ['danger', <IconWarning color={'#C81922'} size={'18'} />],
@@ -52,6 +57,16 @@ export class ModusToast {
     ['tertiary', 'tertiary'],
     ['warning', 'warning'],
   ]);
+
+  componentDidLoad(): void {
+    this.timerId = setTimeout(() => {
+      this.dismissClick.emit();
+    }, this.delay);
+  }
+
+  disconnectedCallback(): void {
+    clearTimeout(this.timerId);
+  }
 
   render(): unknown {
     const icon = this.iconByType.get(this.type);

--- a/stencil-workspace/src/components/modus-toast/readme.md
+++ b/stencil-workspace/src/components/modus-toast/readme.md
@@ -10,6 +10,7 @@
 | Property      | Attribute     | Description                                                | Type                                                                                    | Default     |
 | ------------- | ------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------- |
 | `ariaLabel`   | `aria-label`  | (optional) The toast's aria-label.                         | `string`                                                                                | `undefined` |
+| `delay`       | `delay`       | (optional) Time taken to dismiss the toast                 | `number`                                                                                | `15000`     |
 | `dismissible` | `dismissible` | (optional) Whether the toast has a dismiss button.         | `boolean`                                                                               | `undefined` |
 | `role`        | `role`        | (optional) Role taken by the toast.  Defaults to 'status'. | `"alert" \| "log" \| "marquee" \| "status" \| "timer"`                                  | `'status'`  |
 | `showIcon`    | `show-icon`   | (optional) Whether to show the toasts' icon.               | `boolean`                                                                               | `true`      |

--- a/stencil-workspace/storybook/stories/components/modus-toast/modus-toast-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-toast/modus-toast-storybook-docs.mdx
@@ -63,6 +63,7 @@ import { Anchor } from '@storybook/addon-docs';
 | Name          | Description                      | Type      | Options                                                                   | Default Value | Required |
 | ------------- | -------------------------------- | --------- | ------------------------------------------------------------------------- | ------------- | -------- |
 | `aria-label`  | The toast's aria-label           | `string`  |                                                                           |               |
+| `delay`       | Time taken to dismiss the toast  | `number`  |                                                                           | 15000         |
 | `dismissible` | Whether the toast is dismissible | `boolean` |                                                                           | false         |
 | `role`        | Role taken by the toast          | `string`  | 'alert', 'log', 'marquee', 'status', 'timer'                              | 'status'      |
 | `show-icon`   | Whether to show the toast's      | `boolean` |                                                                           | false         |

--- a/stencil-workspace/storybook/stories/components/modus-toast/modus-toast.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-toast/modus-toast.stories.tsx
@@ -12,6 +12,13 @@ export default {
         type: { summary: 'string' },
       },
     },
+    delay:{
+      description:'Time taken to dismiss the toast',
+      table: {
+        defaultValue: { summary: 15000 },
+        type: { summary: 'number' },
+      },
+    },
     dismissible: {
       description: 'Whether the toast is dismissible, renders the close icon',
       table: {
@@ -74,10 +81,11 @@ export default {
   },
 };
 
-const Template = ({ ariaLabel, dismissible, showIcon, role, type }) =>
+const Template = ({ ariaLabel, dismissible, showIcon, role, type , delay }) =>
   html`
     <modus-toast
       aria-label=${ariaLabel}
+      delay=${delay}
       dismissible=${dismissible}
       show-icon=${showIcon}
       role=${role}
@@ -89,6 +97,7 @@ const Template = ({ ariaLabel, dismissible, showIcon, role, type }) =>
 export const Default = Template.bind({});
 Default.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,
@@ -98,6 +107,7 @@ Default.args = {
 export const Danger = Template.bind({});
 Danger.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,
@@ -107,6 +117,7 @@ Danger.args = {
 export const Dark = Template.bind({});
 Dark.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,
@@ -116,6 +127,7 @@ Dark.args = {
 export const Primary = Template.bind({});
 Primary.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,
@@ -125,6 +137,7 @@ Primary.args = {
 export const Secondary = Template.bind({});
 Secondary.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,
@@ -134,6 +147,7 @@ Secondary.args = {
 export const Success = Template.bind({});
 Success.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,
@@ -143,6 +157,7 @@ Success.args = {
 export const Warning = Template.bind({});
 Warning.args = {
   ariaLabel: '',
+  delay: 15000,
   dismissible: false,
   role: 'status',
   showIcon: true,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Added property `delay` which will determine the number of milli-seconds later the toast emits dismissClick to dismiss the toast
- Default value of delay is 15000ms

References 
Fixes #1762
<!-- issue number -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
