### PR TITLE
Table: Manual Pagination `currentPagesize` not working on initial load fix

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.core.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.core.tsx
@@ -46,6 +46,7 @@ export interface TableCoreOptions {
   preSelectedRows?: RowSelectionState;
   defaultSort?: ModusTableColumnSort;
   wrapText?: boolean;
+  currentPageSize: number;
 
   getRowId(originalRow: unknown, index: number, parent?: Row<unknown>): string;
   setExpanded: (updater: Updater<ExpandedState>) => void;
@@ -79,6 +80,7 @@ export default class ModusTableCore {
       manualSorting,
       sortingState,
       defaultSort,
+      currentPageSize,
       getRowId,
       setExpanded,
       setSorting,
@@ -106,7 +108,7 @@ export default class ModusTableCore {
         rowSelection: preSelectedRows,
         pagination: {
           pageIndex: 0,
-          pageSize: pagination ? pageSizeList[0] : data?.length,
+          pageSize: pagination ? (currentPageSize ? currentPageSize : pageSizeList[0]) : data?.length,
         },
       },
       enableRowSelection: rowSelection,

--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -593,6 +593,7 @@ export class ModusTable {
       toolbarOptions: this.toolbarOptions,
       preSelectedRows: this.getPreselectedRowState(),
       defaultSort: this.defaultSort,
+      currentPageSize: this.manualPaginationOptions?.currentPageSize,
 
       ...(this.manualPaginationOptions && {
         manualPagination: true,


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixed the manual pagination - `currentpageSize` prop not working on initial load
- Page view select will be empty on user defined page size. 

References 
Fix #2395 <!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
