### PR TITLE
Set: `forceConsistentCasingInFileNames` rule to true (tsconfig)

### DIFF
--- a/stencil-workspace/tsconfig.json
+++ b/stencil-workspace/tsconfig.json
@@ -4,6 +4,7 @@
     "allowUnreachableCode": false,
     "declaration": false,
     "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
     "lib": [
       "dom",
       "es2017"


### PR DESCRIPTION
## Description

Set: `forceConsistentCasingInFileNames` rule to true (tsconfig)

This is recommended by Typescript:
https://www.typescriptlang.org/tsconfig/#forceConsistentCasingInFileNames

I've had this option set locally for several months without any problems.

I discovered this by using WebHint VS Code extension which also recommend using it. https://webhint.io/docs/user-guide/hints/hint-typescript-config/consistent-casing/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

I've used this setting locally for a few months with no issues building or running lints/tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
