### PR TITLE
Navbar: Remove modus navbar main menu border

### DIFF
--- a/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
+++ b/stencil-workspace/src/components/modus-navbar/main-menu/modus-navbar-main-menu.scss
@@ -4,8 +4,8 @@
   @include custom-navbar-menu;
 
   background-color: $menu-background-color;
+  border: unset;
   border-radius: 0 0 $rem_2px $rem_2px;
-  border-top: none;
   box-sizing: border-box;
   clip-path: inset(0 -10px -10px -10px);
   cursor: default;


### PR DESCRIPTION
## Description

This PR removes the border rendered by the `custom-navbar-menu` mixin (used by all navbar menus). The border is overridden using ` border: unset` within the `.main-menu` class level styling.

When testing this from the `index.html` file I noticed a margin and padding being applied that caused abnormal rendering issues. I added inline styling to the `body` element to set these values to 0.

I ran the following commands which caused several other minor updates.
`npm run lint`
`npm run prettier`

Fixes #2572

[Issue 2572](https://github.com/trimble-oss/modus-web-components/issues/2572)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Manual testing, no additional testing required for this small of a styling change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
