### PR TITLE
Textarea: Input Style Fixes

### DIFF
--- a/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.scss
+++ b/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.scss
@@ -1,11 +1,5 @@
 @import './modus-textarea-input.vars';
 
-textarea {
-  font-family: $primary-font;
-  height: 4rem;
-  resize: none;
-}
-
 .modus-textarea-input {
   border-radius: 4px;
   display: inline-flex;
@@ -16,16 +10,18 @@ textarea {
   label {
     color: $modus-input-label-color;
     font-size: $rem-12px;
+    font-weight: 700;
     margin-bottom: $rem-4px;
 
     span {
-      color: $modus-input-bottom-line-color;
+      color: $modus-input-border-color;
       margin: $rem-4px;
     }
   }
 
   .label-container {
     display: inline-block;
+    margin-bottom: 0.25rem;
 
     .required {
       bottom: $rem-1px;
@@ -39,14 +35,14 @@ textarea {
     align-items: center;
     background-color: $modus-input-bg;
     border: $rem-1px solid $modus-input-border-color;
-    border-bottom-color: $modus-input-bottom-line-color;
     border-radius: 4px;
     box-sizing: border-box;
     display: flex;
     flex-direction: row;
     margin: 0;
     min-height: 4.5rem;
-    padding: 0;
+    padding-bottom: 2px;
+    padding-top: 2px;
     position: relative;
     width: 100%;
 
@@ -62,9 +58,13 @@ textarea {
       background-color: transparent;
       border: none;
       color: $modus-input-color;
+      font-family: $primary-font;
       font-size: $rem-12px;
+      min-height: 4rem;
       outline: none;
       padding: 0 $rem-8px;
+      resize: none;
+      resize: vertical;
       width: 100%;
 
       &.has-left-icon {
@@ -108,44 +108,34 @@ textarea {
       cursor: text;
     }
 
-    &:focus-within,
-    &.error,
-    &.valid {
-      border-bottom-width: $rem-2px;
-      height: 2rem; // Counteract bottom border width.
-    }
-
     &:focus-within {
-      border-bottom-color: $modus-input-bottom-line-active-color;
+      border-color: $modus-input-border-active-color;
+      box-shadow: 0 0 0 1px $modus-input-border-active-color;
     }
 
     &.error {
-      border-bottom-color: $modus-input-validation-error-color;
+      border-color: $modus-input-validation-error-color;
+      box-shadow: 0 0 0 1px $modus-input-validation-error-color;
     }
 
     &.valid {
-      border-bottom-color: $modus-input-validation-success-color;
+      border-color: $modus-input-validation-success-color;
+      box-shadow: 0 0 0 1px $modus-input-validation-success-color;
     }
 
     &.large {
-      height: 3rem;
+      min-height: 5rem;
 
-      input {
+      textarea {
         font-size: $rem-14px;
         padding: 0 $rem-16px;
-      }
-
-      &:focus-within,
-      &.error,
-      &.valid {
-        height: 3rem; // Counteract bottom border width.
       }
     }
   }
 
   .input-container:has(input[readonly]) {
     background-color: $modus-input-readonly-bg;
-    border-bottom-color: $modus-input-disabled-bottom-line-color;
+    border-color: transparent;
   }
 
   .sub-text {
@@ -183,7 +173,7 @@ textarea {
     .input-container {
       background-color: $modus-input-disabled-bg;
       border: $rem-1px solid $modus-input-disabled-border-color;
-      border-bottom-color: $modus-input-disabled-bottom-line-color;
+      border-color: transparent;
 
       svg path {
         fill: $modus-input-disabled-color;

--- a/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.spec.tsx
+++ b/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.spec.tsx
@@ -11,8 +11,8 @@ describe('modus-textarea-input', () => {
       <modus-textarea-input>
         <mock:shadow-root>
             <div class="modus-textarea-input">
-                <div class="input-container medium" part="input-container" style="height: 6rem;">
-                    <textarea class="text-align-left" id="mwc_id_0_textarea_input" rows="5" tabindex="0">
+                <div class="input-container medium" part="input-container">
+                    <textarea class="text-align-left" id="mwc_id_0_textarea_input" rows="3" tabindex="0">
                     </textarea>
                 </div>
             </div>
@@ -30,8 +30,8 @@ describe('modus-textarea-input', () => {
       <modus-textarea-input autocapitalize="words">
         <mock:shadow-root>
             <div class="modus-textarea-input">
-                <div class="input-container medium" part="input-container" style="height: 6rem;">
-                  <textarea class="text-align-left" id="mwc_id_1_textarea_input" rows="5" tabindex="0" autocapitalize="words">
+                <div class="input-container medium" part="input-container">
+                  <textarea class="text-align-left" id="mwc_id_1_textarea_input" rows="3" tabindex="0" autocapitalize="words">
                   </textarea>
                 </div>
             </div>
@@ -49,8 +49,8 @@ describe('modus-textarea-input', () => {
       <modus-textarea-input autocorrect="on">
         <mock:shadow-root>
             <div class="modus-textarea-input">
-                <div class="input-container medium" part="input-container" style="height: 6rem;">
-                <textarea class="text-align-left" id="mwc_id_2_textarea_input" rows="5" tabindex="0" autocorrect="on">
+                <div class="input-container medium" part="input-container">
+                <textarea class="text-align-left" id="mwc_id_2_textarea_input" rows="3" tabindex="0" autocorrect="on">
                 </textarea>
                 </div>
             </div>
@@ -68,8 +68,8 @@ describe('modus-textarea-input', () => {
       <modus-textarea-input enterkeyhint="done">
         <mock:shadow-root>
             <div class="modus-textarea-input">
-                <div class="input-container medium" part="input-container" style="height: 6rem;">
-                <textarea class="text-align-left" id="mwc_id_3_textarea_input" rows="5" tabindex="0" enterkeyhint="done">
+                <div class="input-container medium" part="input-container">
+                <textarea class="text-align-left" id="mwc_id_3_textarea_input" rows="3" tabindex="0" enterkeyhint="done">
                 </textarea>
                 </div>
             </div>
@@ -87,8 +87,8 @@ describe('modus-textarea-input', () => {
       <modus-textarea-input spellcheck>
         <mock:shadow-root>
             <div class="modus-textarea-input">
-                <div class="input-container medium" part="input-container" style="height: 6rem;">
-                <textarea class="text-align-left" id="mwc_id_4_textarea_input" rows="5" tabindex="0" spellcheck>
+                <div class="input-container medium" part="input-container">
+                <textarea class="text-align-left" id="mwc_id_4_textarea_input" rows="3" tabindex="0" spellcheck>
                 </textarea>
                 </div>
             </div>

--- a/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.tsx
+++ b/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.tsx
@@ -52,7 +52,7 @@ export class ModusTextareaInput {
   @Prop() readOnly: boolean;
 
   /** (optional) Number of rows on textarea */
-  @Prop() rows = 5;
+  @Prop() rows = 3;
 
   /** (optional) Whether the input is required. */
   @Prop() required: boolean;
@@ -168,8 +168,7 @@ export class ModusTextareaInput {
             this.size
           )}`}
           onClick={() => this.textInput.focus()}
-          part="input-container"
-          style={{ height: this.rows + 1 + 'rem' }}>
+          part="input-container">
           <textarea
             id={this.inputId}
             aria-invalid={!!this.errorText}

--- a/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.vars.scss
+++ b/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.vars.scss
@@ -1,8 +1,7 @@
 $modus-input-bg: var(--modus-input-bg, #fff) !default;
 $modus-input-color: var(--modus-input-color, #252a2e) !default;
-$modus-input-border-color: var(--modus-input-border-color, #e0e1e9) !default;
-$modus-input-bottom-line-color: var(--modus-input-bottom-line-color, #6a6e79) !default;
-$modus-input-bottom-line-active-color: var(--modus-input-bottom-line-active-color, #217cbb) !default;
+$modus-input-border-color: var(--modus-input-border-color, #6a6e79) !default;
+$modus-input-border-active-color: var(--modus-input-border-active-color, #217cbb) !default;
 $modus-input-helper-icon-color: var(--modus-input-helper-icon-color, #6a6e79);
 $modus-input-hint-text-color: var(--modus-input-hint-text-color, #a3a6b1) !default;
 $modus-input-label-color: var(--modus-input-label-color, #464b52) !default;
@@ -13,8 +12,7 @@ $modus-input-validation-error-color: var(--modus-input-validation-error-color, #
 
 // Disabled
 $modus-input-disabled-bg: var(--modus-input-disabled-bg, #e0e1e9) !default;
-$modus-input-disabled-border-color: var(--modus-input-disabled-border-color, #e0e1e9) !default;
-$modus-input-disabled-bottom-line-color: var(--modus-input-disabled-bottom-line-color, #a3a6b1) !default;
+$modus-input-disabled-border-color: var(--modus-input-disabled-border-color, transparent) !default;
 $modus-input-disabled-color: var(--modus-input-disabled-color, #a3a6b1) !default;
 
 // Readonly

--- a/stencil-workspace/storybook/stories/components/modus-textarea-input/modus-textarea-input-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-textarea-input/modus-textarea-input-storybook-docs.mdx
@@ -20,8 +20,6 @@ This component is compatible with Angular reactive forms. This can be achieved t
 
 <modus-textarea-input label="Textarea Input (Large & Helper Text)" placeholder="Placeholder" value="Value" size="large" helper-text="Your username must be 8-20 characters long, contain letters and numbers, and must not contain spaces"></modus-textarea-input>
 
-<modus-textarea-input label="Textarea Input (Clearable)" placeholder="Placeholder" value="Value" clearable="true"></modus-textarea-input>
-
 ```html
 <modus-textarea-input
   label="Textarea Input"
@@ -52,11 +50,6 @@ This component is compatible with Angular reactive forms. This can be achieved t
   value="Value"
   size="large"
   helper-text="Your username must be 8-20 characters long, contain letters and numbers, and must not contain spaces"></modus-textarea-input>
-<modus-textarea-input
-  label="Textarea Input (Clearable)"
-  placeholder="Placeholder"
-  value="Value"
-  clearable="true"></modus-textarea-input>
 <modus-textarea-input
   label="Textarea Input (3 rows)"
   placeholder="Placeholder"

--- a/stencil-workspace/storybook/stories/components/modus-textarea-input/modus-textarea-input.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-textarea-input/modus-textarea-input.stories.tsx
@@ -281,7 +281,7 @@ Default.args = {
   placeholder: '',
   readOnly: false,
   required: false,
-  rows: 5,
+  rows: 3,
   size: 'medium',
   spellcheck: false,
   textAlign: 'left',


### PR DESCRIPTION
## Description

- Allows the textarea to be vertically resized
- Adds visible 2px border on focus and valid/invalid states
- Removes the clearable example (seemed unnecessary and looked bad)
- Removed hard-coded height of the inputs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally with Edge v125

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
