### PR TITLE
Tooltip: Set max-width to 250px

### DIFF
--- a/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
+++ b/stencil-workspace/src/components/modus-tooltip/modus-tooltip.scss
@@ -7,9 +7,8 @@
   display: none;
   font-family: $primary-font;
   font-size: $rem-12px;
-  max-width: none;
+  max-width: 250px;
   padding: $rem-4px $rem-8px;
-  white-space: nowrap;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Description

Tooltips do not currently wrap lines which can result in very wide tooltips that don't always fit in their container.

We should set `max-width: 250px` in CSS to allow for line-wrap.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Before:
https://modus-web-components.trimble.com/?path=/story/components-tooltip--default&args=text:Tooltip+text+can+be+very+annoying+if+its+too+long+and+not+wrapped

After:
https://deploy-preview-2597--moduswebcomponents.netlify.app/?path=/story/components-tooltip--default&args=text:Tooltip+text+can+be+very+annoying+if+its+too+long+and+not+wrapped

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
