### PR TITLE
Textarea: readonly state CSS fix

### DIFF
--- a/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.scss
+++ b/stencil-workspace/src/components/modus-textarea-input/modus-textarea-input.scss
@@ -46,14 +46,6 @@
     position: relative;
     width: 100%;
 
-    svg {
-      padding: 0 $rem-6px;
-
-      path {
-        fill: $modus-input-helper-icon-color;
-      }
-    }
-
     textarea {
       background-color: transparent;
       border: none;
@@ -67,40 +59,8 @@
       resize: vertical;
       width: 100%;
 
-      &.has-left-icon {
-        padding-left: 0;
-      }
-
-      &.has-right-icon {
-        padding-right: 0;
-      }
-
-      &.text-align-right {
-        text-align: right;
-      }
-
       &::placeholder {
         color: $modus-input-hint-text-color;
-      }
-    }
-
-    .icons {
-      align-items: center;
-      color: $modus-input-helper-icon-color;
-      cursor: pointer;
-      display: flex;
-      font-size: $rem-16px;
-      height: 100%;
-      justify-content: center;
-      width: 2rem;
-
-      &.clear {
-        cursor: pointer;
-        min-height: 1.5rem;
-
-        &:hover svg path {
-          opacity: 0.75;
-        }
       }
     }
 
@@ -133,7 +93,7 @@
     }
   }
 
-  .input-container:has(input[readonly]) {
+  .input-container:has(textarea[readonly]) {
     background-color: $modus-input-readonly-bg;
     border-color: transparent;
   }
@@ -172,56 +132,7 @@
 
     .input-container {
       background-color: $modus-input-disabled-bg;
-      border: $rem-1px solid $modus-input-disabled-border-color;
-      border-color: transparent;
-
-      svg path {
-        fill: $modus-input-disabled-color;
-      }
-
-      .icons {
-        background-color: $modus-input-disabled-bg;
-        cursor: default;
-
-        &.clear {
-          visibility: hidden;
-        }
-      }
-
-      input {
-        background-color: transparent;
-        border-radius: 0;
-        color: $modus-input-disabled-color;
-        height: 100%;
-      }
+      border: $rem-1px solid transparent;
     }
-  }
-
-  .toggle-password {
-    svg.visibility,
-    svg.visibility-off {
-      display: none;
-    }
-  }
-
-  input {
-    background-position: right calc(0.375em + 0.1875rem) center;
-    background-repeat: no-repeat;
-    background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
-    padding-right: calc(1.5em + 0.75rem);
-  }
-
-  input[type='password'] + .toggle-password > svg.visibility {
-    display: inline;
-  }
-
-  input[type='text'] + .toggle-password > svg.visibility-off {
-    display: inline;
-  }
-
-  input[type='search']::-webkit-search-cancel-button,
-  input[type='search']::-webkit-search-decoration {
-    -webkit-appearance: none;
-    appearance: none;
   }
 }


### PR DESCRIPTION
## Description

- Add readonly state CSS
- Remove unused icons CSS

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Preview:
https://deploy-preview-2631--moduswebcomponents.netlify.app/?path=/story/user-inputs-textarea-input--default&args=readOnly:true

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
