### PR TITLE
Table: Number 0 is visible in the table cells

### DIFF
--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -177,7 +177,7 @@ export class ModusTableCellMain {
     const { row, getValue } = this.cell;
     const cellValue = getValue();
 
-    if (cellValue !== null && cellValue !== undefined) return null;
+    if (cellValue === null || cellValue === undefined) return null;
 
     const { cellLinkClick, wrapText } = this.context;
     const cellDataType = cellValue['_type'] ?? this.cell.column.columnDef[COLUMN_DEF_DATATYPE_KEY];

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-main/modus-table-cell-main.tsx
@@ -177,7 +177,7 @@ export class ModusTableCellMain {
     const { row, getValue } = this.cell;
     const cellValue = getValue();
 
-    if (!cellValue) return null;
+    if (cellValue !== null && cellValue !== undefined) return null;
 
     const { cellLinkClick, wrapText } = this.context;
     const cellDataType = cellValue['_type'] ?? this.cell.column.columnDef[COLUMN_DEF_DATATYPE_KEY];


### PR DESCRIPTION
## Description

I've changed the cell value validation to only `null` and `undefined` so as not to stop the number 0 from being shown in the table.

References #2647

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
