### PR TITLE
Table: Exposed the placeholder for the select type cells

### DIFF
--- a/stencil-workspace/src/components/modus-table/models/modus-table.models.ts
+++ b/stencil-workspace/src/components/modus-table/models/modus-table.models.ts
@@ -50,7 +50,7 @@ export type ModusTableCellEditorType =
   | typeof CELL_EDIT_TYPE_DATE;
 
 export type ModusTableCellDateEditorArgs = { format: string };
-export type ModusTableCellSelectEditorArgs = { options: unknown[]; optionsDisplayProp?: string };
+export type ModusTableCellSelectEditorArgs = { options: unknown[]; optionsDisplayProp?: string; placeholder?: string };
 export type ModusTableCellAutocompleteEditorArgs = {
   options: ModusAutocompleteOption[];
   noResultsFoundText: string;

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.tsx
@@ -176,6 +176,7 @@ export class ModusTableCellEditor {
     const args = this.args as ModusTableCellSelectEditorArgs;
     const options = args?.options || [];
     const optionsDisplayProp = args?.optionsDisplayProp || valueKey;
+    const placeholder = args?.placeholder;
     const selectedOption = options.find((option) => option[optionsDisplayProp] === this.value) as unknown;
 
     function handleEnter(e: KeyboardEvent, callback: (e: KeyboardEvent) => void) {
@@ -193,6 +194,7 @@ export class ModusTableCellEditor {
           options-display-prop={optionsDisplayProp}
           size="large"
           options={options}
+          placeholder={placeholder}
           onInputBlur={this.handleBlur}
           onKeyDown={(e) => handleEnter(e, this.handleKeyDown)}
           onValueChange={(e: CustomEvent<unknown>) => {

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/readme.md
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/readme.md
@@ -7,14 +7,14 @@
 
 ## Properties
 
-| Property      | Attribute   | Description | Type                                                                          | Default     |
-| ------------- | ----------- | ----------- | ----------------------------------------------------------------------------- | ----------- |
-| `args`        | --          |             | `{ format: string; } \| { options: unknown[]; optionsDisplayProp?: string; }` | `undefined` |
-| `dataType`    | `data-type` |             | `string`                                                                      | `undefined` |
-| `keyDown`     | --          |             | `(e: KeyboardEvent, newValue: string) => void`                                | `undefined` |
-| `type`        | `type`      |             | `string`                                                                      | `undefined` |
-| `value`       | --          |             | `unknown`                                                                     | `undefined` |
-| `valueChange` | --          |             | `(newValue: string) => void`                                                  | `undefined` |
+| Property      | Attribute   | Description | Type                                                                                                | Default     |
+| ------------- | ----------- | ----------- | --------------------------------------------------------------------------------------------------- | ----------- |
+| `args`        | --          |             | `{ format: string; } \| { options: unknown[]; optionsDisplayProp?: string; placeholder?: string; }` | `undefined` |
+| `dataType`    | `data-type` |             | `string`                                                                                            | `undefined` |
+| `keyDown`     | --          |             | `(e: KeyboardEvent, newValue: string) => void`                                                      | `undefined` |
+| `type`        | `type`      |             | `string`                                                                                            | `undefined` |
+| `value`       | --          |             | `unknown`                                                                                           | `undefined` |
+| `valueChange` | --          |             | `(newValue: string) => void`                                                                        | `undefined` |
 
 
 ## Dependencies


### PR DESCRIPTION
## Description

I added the placeholder option in the `ModusTableCellSelectEditorArgs` type to send a custom placeholder alongside the options and the display option for the select type cells.

References #2656 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
