### PR TITLE
Toolbar: Icon only buttons do not have aria-labels

### DIFF
--- a/stencil-workspace/src/components/modus-toolbar/modus-toolbar.spec.ts
+++ b/stencil-workspace/src/components/modus-toolbar/modus-toolbar.spec.ts
@@ -13,7 +13,7 @@ describe('modus-toolbar', () => {
     expect(root).toEqualHtml(`
       <modus-toolbar role="toolbar">
         <mock:shadow-root>
-          <modus-button button-style="borderless" class="modus-button" color="secondary">
+          <modus-button arialabel="button" button-style="borderless" class="modus-button" color="secondary">
             Button
           </modus-button>
         </mock:shadow-root>
@@ -52,7 +52,7 @@ describe('modus-toolbar', () => {
     expect(root).toEqualHtml(`
       <modus-toolbar role="toolbar">
         <mock:shadow-root>
-          <modus-button button-style="borderless" class="modus-button" color="secondary" icon-only="close">
+          <modus-button arialabel="button" button-style="borderless" class="modus-button" color="secondary" icon-only="close">
             Button
           </modus-button>
         </mock:shadow-root>
@@ -73,7 +73,7 @@ describe('modus-toolbar', () => {
     expect(root).toEqualHtml(`
       <modus-toolbar role="toolbar">
         <mock:shadow-root>
-          <modus-button button-style="borderless" class="modus-button" color="secondary" icon-only="close">
+          <modus-button arialabel="button" button-style="borderless" class="modus-button" color="secondary" icon-only="close">
             Button
           </modus-button>
         </mock:shadow-root>
@@ -94,7 +94,7 @@ describe('modus-toolbar', () => {
     expect(root).toEqualHtml(`
       <modus-toolbar role="toolbar">
         <mock:shadow-root>
-          <modus-button button-style="borderless" class="modus-button" color="secondary">
+          <modus-button arialabel="button" button-style="borderless" class="modus-button" color="secondary">
             Button
           </modus-button>
         </mock:shadow-root>

--- a/stencil-workspace/src/components/modus-toolbar/modus-toolbar.tsx
+++ b/stencil-workspace/src/components/modus-toolbar/modus-toolbar.tsx
@@ -19,12 +19,12 @@ export class ModusToolbar {
   createButton(child: Element) {
     const className = 'modus-button';
     const iconOnly = child.getAttribute('icon-only');
-    const ariaLabel = child.getAttribute('aria-label');
+    const ariaLabel = child.getAttribute('aria-label') || 'button';
     const label = child.textContent ? child.textContent.trim() : '';
 
     return (
       <modus-button
-        aria-label={ariaLabel}
+        ariaLabel={ariaLabel}
         button-style="borderless"
         color="secondary"
         class={className}

--- a/stencil-workspace/src/components/modus-toolbar/modus-toolbar.tsx
+++ b/stencil-workspace/src/components/modus-toolbar/modus-toolbar.tsx
@@ -19,10 +19,12 @@ export class ModusToolbar {
   createButton(child: Element) {
     const className = 'modus-button';
     const iconOnly = child.getAttribute('icon-only');
+    const ariaLabel = child.getAttribute('aria-label');
     const label = child.textContent ? child.textContent.trim() : '';
 
     return (
       <modus-button
+        aria-label={ariaLabel}
         button-style="borderless"
         color="secondary"
         class={className}

--- a/stencil-workspace/storybook/stories/components/modus-toolbar/modus-toolbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-toolbar/modus-toolbar-storybook-docs.mdx
@@ -52,3 +52,4 @@ The `modus-toolbar` component provides a customizable Toolbar that can be positi
 
 - Toolbar gets role="toolbar"
 - Toolbar gets an `aria-label` provided by the `aria-label` property input.
+- Toolbar button gets an `aria-label` provided by the `aria-label` property input.


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


- Added aria labels for toolbar buttons 
- Updated the storybook documentation

References 

Fixes #2619  <!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
