### PR TITLE
Button Group: Add default selected property

### DIFF
--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
@@ -97,6 +97,7 @@ export class ModusButtonGroup {
 
   renderButtons(buttons: NodeListOf<HTMLModusButtonElement>, reset: boolean) {
     const buttonType = this.determineButtonType();
+    let foundSelected = false;
     buttons.forEach((button: HTMLModusButtonElement) => {
       if (reset) {
         button.ariaDisabled = this.ariaDisabled;
@@ -110,6 +111,11 @@ export class ModusButtonGroup {
       button.color = this.color;
       button.size = this.size;
       button.type = buttonType;
+      if (button.hasAttribute('selected') && !foundSelected && this.selectionType == DEFAULT_SELECTION_TYPE) {
+        button.setActive(true);
+        this.selectedButtons.push(button);
+        foundSelected = true;
+      }
     });
   }
 

--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
@@ -111,7 +111,7 @@ export class ModusButtonGroup {
       button.color = this.color;
       button.size = this.size;
       button.type = buttonType;
-      if (button.hasAttribute('selected') && !foundSelected && this.selectionType == DEFAULT_SELECTION_TYPE) {
+      if (button.hasAttribute('selected') && !foundSelected && this.selectionType == SINGLE_SELECTION_TYPE) {
         button.setActive(true);
         this.selectedButtons.push(button);
         foundSelected = true;

--- a/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
+++ b/stencil-workspace/src/components/modus-button-group/modus-button-group.tsx
@@ -115,6 +115,11 @@ export class ModusButtonGroup {
         button.setActive(true);
         this.selectedButtons.push(button);
         foundSelected = true;
+      } else if (button.hasAttribute('selected') && this.selectionType == MULTIPLE_SELECTION_TYPE) {
+        button.setActive(true);
+        if (!this.selectedButtons.includes(button)) {
+          this.selectedButtons.push(button);
+        }
       }
     });
   }

--- a/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group-storybook-docs.mdx
@@ -60,15 +60,15 @@ For Icon only Buttons,
 ## Multiple Selection
 
 <modus-button-group selection-type="multiple">
-  <modus-button>Button 1</modus-button>
-  <modus-button>Button 2</modus-button>
+  <modus-button selected>Button 1</modus-button>
+  <modus-button selected>Button 2</modus-button>
   <modus-button>Button 3</modus-button>
 </modus-button-group>
 
 ```html
 <modus-button-group selection-type="multiple">
-  <modus-button>Button 1</modus-button>
-  <modus-button>Button 2</modus-button>
+  <modus-button selected>Button 1</modus-button>
+  <modus-button selected>Button 2</modus-button>
   <modus-button>Button 3</modus-button>
 </modus-button-group>
 ```

--- a/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group-storybook-docs.mdx
@@ -42,14 +42,14 @@ For Icon only Buttons,
 ## Single Selection
 
 <modus-button-group selection-type="single">
-  <modus-button>Button 1</modus-button>
+  <modus-button selected>Button 1</modus-button>
   <modus-button>Button 2</modus-button>
   <modus-button>Button 3</modus-button>
 </modus-button-group>
 
 ```html
 <modus-button-group selection-type="single">
-  <modus-button>Button 1</modus-button>
+  <modus-button selected>Button 1</modus-button>
   <modus-button>Button 2</modus-button>
   <modus-button>Button 3</modus-button>
 </modus-button-group>
@@ -93,6 +93,7 @@ interface ModusButtonGroupButtonClickEvent {
 | `buttonStyle`   | `button-style`   | (optional) The style of the buttons in group                     | `"borderless" , "fill" , "outline"`              | `'outline'` |
 | `color`         | `color`          | (optional) The color of the buttons in group                     | `"danger" ,"primary" , "secondary" , "tertiary"` | `'primary'` |
 | `disabled`      | `disabled`       | (optional) If `true`, the button group is disabled               | `boolean`                                        | `false`     |
+| `selected`      | `selected`       | (optional) The default selected button in the group              | `HTMLModusButtonElement`                         | `undefined` |
 | `selectionType` | `selection-type` | (optional) The selection type (`none`, `single`, `multiple`)     | `ButtonGroupSelectionType`                       | `none`      |
 | `size`          | `size`           | (optional) The size of the buttons. (`small`, `medium`, `large`) | `ButtonSize`                                     | `medium`    |
 

--- a/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group.stories.tsx
@@ -2,10 +2,9 @@ import { html } from 'lit-html';
 // @ts-ignore: JSX/MDX with Stencil
 import docs from './modus-button-group-storybook-docs.mdx';
 
-
 export default {
   title: 'Components/Button Group',
-  argTypes:{
+  argTypes: {
     ariaDisabled: {
       name: 'aria-disabled',
       description: "The button group's aria-disabled state",
@@ -73,12 +72,12 @@ export default {
         defaultValue: { summary: `'medium'` },
         type: { summary: `'small' | 'medium' | 'large'` },
       },
-    }
+    },
   },
 
   parameters: {
     controls: { expanded: true, sort: 'alpha' },
-    actions:{
+    actions: {
       handles: ['buttonGroupClick', 'buttonSelectionChange'],
     },
     docs: {
@@ -90,8 +89,27 @@ export default {
   },
 };
 const Template = ({ ariaLabel, buttonStyle, color, disabled, selectionType, size }) => html`
-  <modus-button-group aria-label=${ariaLabel} button-style=${buttonStyle} color=${color} .disabled=${disabled} selection-type=${selectionType} size=${size}>
+  <modus-button-group
+    aria-label=${ariaLabel}
+    button-style=${buttonStyle}
+    color=${color}
+    .disabled=${disabled}
+    selection-type=${selectionType}
+    size=${size}>
     <modus-button>Button 1</modus-button>
+    <modus-button>Button 2</modus-button>
+    <modus-button>Button 3</modus-button>
+  </modus-button-group>
+`;
+const SingleSelectionTemplate = ({ ariaLabel, buttonStyle, color, disabled, selectionType, size }) => html`
+  <modus-button-group
+    aria-label=${ariaLabel}
+    button-style=${buttonStyle}
+    color=${color}
+    .disabled=${disabled}
+    selection-type=${selectionType}
+    size=${size}>
+    <modus-button selected>Button 1</modus-button>
     <modus-button>Button 2</modus-button>
     <modus-button>Button 3</modus-button>
   </modus-button-group>
@@ -108,10 +126,8 @@ const DefaultArgs = {
 export const Default = Template.bind({});
 Default.args = { ...DefaultArgs };
 
-export const SingleSelection = Template.bind({});
+export const SingleSelection = SingleSelectionTemplate.bind({});
 SingleSelection.args = { ...DefaultArgs, selectionType: 'single' };
 
 export const MultipleSelection = Template.bind({});
 MultipleSelection.args = { ...DefaultArgs, selectionType: 'multiple' };
-
-

--- a/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-button-group/modus-button-group.stories.tsx
@@ -88,7 +88,7 @@ export default {
     },
   },
 };
-const Template = ({ ariaLabel, buttonStyle, color, disabled, selectionType, size }) => html`
+const DefaultTemplate = ({ ariaLabel, buttonStyle, color, disabled, selectionType, size }) => html`
   <modus-button-group
     aria-label=${ariaLabel}
     button-style=${buttonStyle}
@@ -114,6 +114,19 @@ const SingleSelectionTemplate = ({ ariaLabel, buttonStyle, color, disabled, sele
     <modus-button>Button 3</modus-button>
   </modus-button-group>
 `;
+const MultipleSelectionTemplate = ({ ariaLabel, buttonStyle, color, disabled, selectionType, size }) => html`
+  <modus-button-group
+    aria-label=${ariaLabel}
+    button-style=${buttonStyle}
+    color=${color}
+    .disabled=${disabled}
+    selection-type=${selectionType}
+    size=${size}>
+    <modus-button selected>Button 1</modus-button>
+    <modus-button selected>Button 2</modus-button>
+    <modus-button>Button 3</modus-button>
+  </modus-button-group>
+`;
 const DefaultArgs = {
   ariaDisabled: '',
   ariaLabel: '',
@@ -123,11 +136,11 @@ const DefaultArgs = {
   color: 'primary',
   buttonStyle: 'outline',
 };
-export const Default = Template.bind({});
+export const Default = DefaultTemplate.bind({});
 Default.args = { ...DefaultArgs };
 
 export const SingleSelection = SingleSelectionTemplate.bind({});
 SingleSelection.args = { ...DefaultArgs, selectionType: 'single' };
 
-export const MultipleSelection = Template.bind({});
+export const MultipleSelection = MultipleSelectionTemplate.bind({});
 MultipleSelection.args = { ...DefaultArgs, selectionType: 'multiple' };


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Added selected property to modus button for default selection in single selection type

References 
Fixes #2642 <!-- issue number -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-2678--moduswebcomponents.netlify.app/?path=/docs/components-button-group--single-selection#single-selection

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
