### PR TITLE
feat: allow consumer to control modus navbar dropdown item selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,42 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=16.20.2"
       }
-    },
-    "node_modules/@stencil/angular-output-target": {
-      "version": "0.6.1-dev.11657573317.16e0205c",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.6.1-dev.11657573317.16e0205c.tgz",
-      "integrity": "sha512-dSD2d8itnD8xa5vRRoOFjWiSd813L+/vuulolDl22k7urBWdH8pGDlBu5uhatEjZD12d6C0blFBlWpy25YFjBw==",
-      "peerDependencies": {
-        "@stencil/core": "^2.9.0"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA==",
-      "peer": true,
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@stencil/angular-output-target": {
-      "version": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.6.1-dev.11657573317.16e0205c.tgz",
-      "integrity": "sha512-dSD2d8itnD8xa5vRRoOFjWiSd813L+/vuulolDl22k7urBWdH8pGDlBu5uhatEjZD12d6C0blFBlWpy25YFjBw==",
-      "requires": {}
-    },
-    "@stencil/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA==",
-      "peer": true
     }
   }
 }

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -15,7 +15,7 @@ import { ModusDataTableCellLink, ModusDataTableDisplayOptions, ModusDataTableRow
 import { ModusDateInputEventDetails, ModusDateInputType } from "./components/modus-date-input/utils/modus-date-input.models";
 import { ModusIconName } from "./icons/ModusIconUtilities";
 import { ModusNavbarApp } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
-import { ModusNavbarButton, ModusNavbarDropdownItem, ModusNavbarDropdownOptions, ModusNavbarLogoOptions, ModusNavbarProfileMenuLink, ModusNavbarTooltip, ModusProfileMenuOptions } from "./components/modus-navbar/modus-navbar.models";
+import { ModusNavbarButton, ModusNavbarDropdownItemSelectEvent, ModusNavbarDropdownOptions, ModusNavbarLogoOptions, ModusNavbarProfileMenuLink, ModusNavbarTooltip, ModusProfileMenuOptions } from "./components/modus-navbar/modus-navbar.models";
 import { ModusNavbarApp as ModusNavbarApp1 } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
 import { RadioButton } from "./components/modus-radio-group/modus-radio-button";
 import { ModusSentimentScaleType } from "./components/modus-sentiment-scale/modus-sentiment-scale.models";
@@ -38,7 +38,7 @@ export { ModusDataTableCellLink, ModusDataTableDisplayOptions, ModusDataTableRow
 export { ModusDateInputEventDetails, ModusDateInputType } from "./components/modus-date-input/utils/modus-date-input.models";
 export { ModusIconName } from "./icons/ModusIconUtilities";
 export { ModusNavbarApp } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
-export { ModusNavbarButton, ModusNavbarDropdownItem, ModusNavbarDropdownOptions, ModusNavbarLogoOptions, ModusNavbarProfileMenuLink, ModusNavbarTooltip, ModusProfileMenuOptions } from "./components/modus-navbar/modus-navbar.models";
+export { ModusNavbarButton, ModusNavbarDropdownItemSelectEvent, ModusNavbarDropdownOptions, ModusNavbarLogoOptions, ModusNavbarProfileMenuLink, ModusNavbarTooltip, ModusProfileMenuOptions } from "./components/modus-navbar/modus-navbar.models";
 export { ModusNavbarApp as ModusNavbarApp1 } from "./components/modus-navbar/apps-menu/modus-navbar-apps-menu";
 export { RadioButton } from "./components/modus-radio-group/modus-radio-button";
 export { ModusSentimentScaleType } from "./components/modus-sentiment-scale/modus-sentiment-scale.models";
@@ -2309,7 +2309,7 @@ declare global {
         "appsMenuAppOpen": ModusNavbarApp;
         "buttonClick": string;
         "helpOpen": void;
-        "dropdownItemSelect": ModusNavbarDropdownItem;
+        "dropdownItemSelect": ModusNavbarDropdownItemSelectEvent;
         "mainMenuClick": KeyboardEvent | MouseEvent;
         "notificationsMenuOpen": void;
         "productLogoClick": MouseEvent;
@@ -3746,7 +3746,7 @@ declare namespace LocalJSX {
         /**
           * An event that fires when a dropdown item is selected *
          */
-        "onDropdownItemSelect"?: (event: ModusNavbarCustomEvent<ModusNavbarDropdownItem>) => void;
+        "onDropdownItemSelect"?: (event: ModusNavbarCustomEvent<ModusNavbarDropdownItemSelectEvent>) => void;
         /**
           * An event that fires when the help link opens.
          */

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.models.ts
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.models.ts
@@ -41,6 +41,13 @@ export interface ModusNavbarDropdownItem {
 
 export interface ModusNavbarDropdownOptions {
   ariaLabel: string;
-  defaultValue: string;
+  defaultValue?: string;
   items: ModusNavbarDropdownItem[];
+  useItemSelectPromise?: boolean;
+}
+
+export interface ModusNavbarDropdownItemSelectEvent {
+  item: ModusNavbarDropdownItem;
+  resolve?: (value: ModusNavbarDropdownItem) => void;
+  reject?: (reason?: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -17,7 +17,45 @@
 
   <body data-mwc-theme="light">
     <main>
-      <!-- Test components -->
+      <modus-navbar id="with-optional-features" show-apps-menu show-help show-main-menu show-notifications>
+        <div slot="main" style="height:300px;">Render your own main menu.</div>
+        <div slot="notifications">Render your own notifications.</div>
+      </modus-navbar>
+
+      <script>
+        const element = document.querySelector('modus-navbar');
+        element.apps = [
+          {
+            description: 'The One Trimble Design System',
+            logoUrl: 'https://modus.trimble.com/favicon.svg',
+            name: 'Trimble Modus',
+            url: 'https://modus.trimble.com/',
+          },
+        ];
+        element.logoOptions = {
+          primary: {
+            url: 'https://modus-bootstrap.trimble.com/img/trimble-logo-rev.svg',
+            height: 24,
+          },
+          secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
+        };
+        element.dropdownOptions = {
+          ariaLabel: 'Project dropdown',
+          defaultValue: '2',
+          items: [
+            { text: 'Project 1', value: '1' },
+            { text: 'Project 2', value: '2' },
+            { text: 'Project 3', value: '3' },
+          ],
+        };
+        element.profileMenuOptions = {
+          avatarUrl: 'https://avatar.example.com/broken-image-link.png',
+          email: 'modus_user@trimble.com',
+          initials: 'MU',
+          signOutText: 'Sign out',
+          username: 'Modus User',
+        };
+      </script>
     </main>
   </body>
 </html>

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -39,6 +39,11 @@
           },
           secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
         };
+
+        element.addEventListener('dropdownItemSelect', (props) => {
+          const { item, resolve, reject } = props.detail;
+          resolve(item);
+        });
         element.dropdownOptions = {
           ariaLabel: 'Project dropdown',
           defaultValue: '2',
@@ -47,7 +52,9 @@
             { text: 'Project 2', value: '2' },
             { text: 'Project 3', value: '3' },
           ],
+          useItemSelectPromise: true,
         };
+
         element.profileMenuOptions = {
           avatarUrl: 'https://avatar.example.com/broken-image-link.png',
           email: 'modus_user@trimble.com',

--- a/stencil-workspace/src/index.html
+++ b/stencil-workspace/src/index.html
@@ -17,52 +17,7 @@
 
   <body data-mwc-theme="light">
     <main>
-      <modus-navbar id="with-optional-features" show-apps-menu show-help show-main-menu show-notifications>
-        <div slot="main" style="height:300px;">Render your own main menu.</div>
-        <div slot="notifications">Render your own notifications.</div>
-      </modus-navbar>
-
-      <script>
-        const element = document.querySelector('modus-navbar');
-        element.apps = [
-          {
-            description: 'The One Trimble Design System',
-            logoUrl: 'https://modus.trimble.com/favicon.svg',
-            name: 'Trimble Modus',
-            url: 'https://modus.trimble.com/',
-          },
-        ];
-        element.logoOptions = {
-          primary: {
-            url: 'https://modus-bootstrap.trimble.com/img/trimble-logo-rev.svg',
-            height: 24,
-          },
-          secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
-        };
-
-        element.addEventListener('dropdownItemSelect', (props) => {
-          const { item, resolve, reject } = props.detail;
-          resolve(item);
-        });
-        element.dropdownOptions = {
-          ariaLabel: 'Project dropdown',
-          defaultValue: '2',
-          items: [
-            { text: 'Project 1', value: '1' },
-            { text: 'Project 2', value: '2' },
-            { text: 'Project 3', value: '3' },
-          ],
-          useItemSelectPromise: true,
-        };
-
-        element.profileMenuOptions = {
-          avatarUrl: 'https://avatar.example.com/broken-image-link.png',
-          email: 'modus_user@trimble.com',
-          initials: 'MU',
-          signOutText: 'Sign out',
-          username: 'Modus User',
-        };
-      </script>
+      <!-- Test components -->
     </main>
   </body>
 </html>

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -18,6 +18,7 @@ This component utilizes the slot element, allowing you to render your own HTML i
   - The `slot` allows rendering custom HTML on button click by linking the slot name with button id.
 - If a `show-search` with `enable-search-overlay` set as true then search overly will open on search button click, if enable-search-overlay set to false then search button emit the event for client.
 - The `slot` allows rendering custom HTML by linking the slot name with `profileMenu` id under the links.
+- Dropdown item selection can be handled by the consumer using promises by setting `dropdownOptions.useItemSelectPromise` to true (see the "Types" section for more details).
 
 ### Default
 
@@ -273,6 +274,24 @@ interface ModusNavbarButton {
   hideMenu?: boolean;
   tooltip?: ModusNavbarTooltip;
 }
+
+export interface ModusNavbarDropdownItem {
+  text: string;
+  value: string;
+}
+
+export interface ModusNavbarDropdownOptions {
+  ariaLabel: string;
+  defaultValue?: string;
+  items: ModusNavbarDropdownItem[];
+  useItemSelectPromise?: boolean;
+}
+
+export interface ModusNavbarDropdownItemSelectEvent {
+  item: ModusNavbarDropdownItem;
+  resolve?: (value: ModusNavbarDropdownItem) => void;
+  reject?: (reason?: any) => void;
+}
 ```
 
 ### Properties
@@ -308,7 +327,7 @@ interface ModusNavbarButton {
 | `appsMenuAppOpen`         | An event that fires when an apps menu app opens.                        | `CustomEvent<ModusNavbarApp>`                             |
 | `appsMenuOpen`            | An event that fires when the apps menu opens.                           | `CustomEvent<void>`                                       |
 | `buttonClick`             | An event that fires when a button in the custom button list is clicked. | `CustomEvent<string>`                                     |
-| `dropdownItemSelect`      | An event that fires when a dropdown item is selected.                   | `CustomEvent<ModusNavbarDropdownItem>`                    |
+| `dropdownItemSelect`      | An event that fires when a dropdown item is selected.                   | `CustomEvent<ModusNavbarDropdownItemSelectEvent>`         |
 | `helpOpen`                | An event that fires when the help link opens.                           | `CustomEvent<void>`                                       |
 | `mainMenuClick`           | An event that fires on main menu click.                                 | `CustomEvent<KeyboardEvent>` or `CustomEvent<MouseEvent>` |
 | `notificationsMenuOpen`   | An event that fires when the notifications menu opens.                  | `CustomEvent<void>`                                       |


### PR DESCRIPTION
> [!IMPORTANT]
> There are 2 competing PRs with different ways of solving this. Only merge one.

## Description

This PR adds an optional boolean value to the Modus Navbar `dropdownOptions` input named `useItemSelectPromise`.

If falsy, the navbar continues to function as originally designed. Setting internal state for the `selectedDropdownItem` and emitting the selected item.

If truthy, the navbar creates a new promise and emits the selected item along with resolve and reject functions (from the promise). The consumer is now responsible for calling resolve or reject accordingly along with the item. In our case, we need to open a new tab on selection and leave the old one as is. This means that we won't call resolve or reject on selection.

This is technically a breaking change as it updates the shape of the emitted value from `item` to `{ item, resolve, reject }`. While I don't think anyone else is using this feature yet, we can't be 100% certain.

A small change to make `dropdownOptions.defaultValue` optional was included, this was intended in the original design. This has been tested.

References #2682

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Manually through the stencil index.html and Storybook.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
