### PR TITLE
feat: modus navbar dropdown selection is manually controlled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,42 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=16.20.2"
       }
-    },
-    "node_modules/@stencil/angular-output-target": {
-      "version": "0.6.1-dev.11657573317.16e0205c",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.6.1-dev.11657573317.16e0205c.tgz",
-      "integrity": "sha512-dSD2d8itnD8xa5vRRoOFjWiSd813L+/vuulolDl22k7urBWdH8pGDlBu5uhatEjZD12d6C0blFBlWpy25YFjBw==",
-      "peerDependencies": {
-        "@stencil/core": "^2.9.0"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA==",
-      "peer": true,
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@stencil/angular-output-target": {
-      "version": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.6.1-dev.11657573317.16e0205c.tgz",
-      "integrity": "sha512-dSD2d8itnD8xa5vRRoOFjWiSd813L+/vuulolDl22k7urBWdH8pGDlBu5uhatEjZD12d6C0blFBlWpy25YFjBw==",
-      "requires": {}
-    },
-    "@stencil/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA==",
-      "peer": true
     }
   }
 }

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -825,7 +825,7 @@ export namespace Components {
          */
         "searchTooltip": ModusNavbarTooltip;
         /**
-          * (optional) The selected dropdown item value.
+          * (optional) The selected dropdown item object.
          */
         "selectedDropdownItem": ModusNavbarDropdownItem;
         /**
@@ -3800,7 +3800,7 @@ declare namespace LocalJSX {
          */
         "searchTooltip"?: ModusNavbarTooltip;
         /**
-          * (optional) The selected dropdown item value.
+          * (optional) The selected dropdown item object.
          */
         "selectedDropdownItem"?: ModusNavbarDropdownItem;
         /**

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -825,6 +825,10 @@ export namespace Components {
          */
         "searchTooltip": ModusNavbarTooltip;
         /**
+          * (optional) The selected dropdown item value.
+         */
+        "selectedDropdownItem": ModusNavbarDropdownItem;
+        /**
           * (optional) Whether to show the apps menu.
          */
         "showAppsMenu": boolean;
@@ -3795,6 +3799,10 @@ declare namespace LocalJSX {
           * (optional) Search tooltip.
          */
         "searchTooltip"?: ModusNavbarTooltip;
+        /**
+          * (optional) The selected dropdown item value.
+         */
+        "selectedDropdownItem"?: ModusNavbarDropdownItem;
         /**
           * (optional) Whether to show the apps menu.
          */

--- a/stencil-workspace/src/components/modus-navbar/dropdown/modus-navbar-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-navbar/dropdown/modus-navbar-dropdown.tsx
@@ -8,7 +8,7 @@ interface Props {
   itemSelect: (item: ModusNavbarDropdownItem) => void;
   options: ModusNavbarDropdownOptions;
   reverse: boolean;
-  selectedItem: ModusNavbarDropdownItem;
+  selectedItem?: ModusNavbarDropdownItem;
 }
 
 export const ModusNavbarDropdown: FunctionalComponent<Props> = ({ itemSelect, options, reverse, selectedItem }) => {
@@ -28,14 +28,14 @@ export const ModusNavbarDropdown: FunctionalComponent<Props> = ({ itemSelect, op
         id={toggleElementId}
         slot={'dropdownToggle'}
         show-caret={true}>
-        {selectedItem.text}
+        {selectedItem?.text}
       </modus-button>
       <modus-list dir={direction} slot={'dropdownList'}>
         {options.items.map((item) => (
           <modus-list-item
             key={item.value}
             onItemClick={() => itemSelectHandler(item)}
-            selected={item.value !== '' && item.value === selectedItem.value}>
+            selected={item.value !== '' && item.value === selectedItem?.value}>
             {item.text}
           </modus-list-item>
         ))}

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.models.ts
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.models.ts
@@ -41,6 +41,5 @@ export interface ModusNavbarDropdownItem {
 
 export interface ModusNavbarDropdownOptions {
   ariaLabel: string;
-  defaultValue: string;
   items: ModusNavbarDropdownItem[];
 }

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
@@ -61,7 +61,7 @@ export class ModusNavbar {
   /** (optional) Dropdown options. */
   @Prop() dropdownOptions: ModusNavbarDropdownOptions;
 
-  /** (optional) The selected dropdown item value. */
+  /** (optional) The selected dropdown item object. */
   @Prop() selectedDropdownItem: ModusNavbarDropdownItem;
 
   /** (required) Profile menu options. */

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
@@ -61,6 +61,9 @@ export class ModusNavbar {
   /** (optional) Dropdown options. */
   @Prop() dropdownOptions: ModusNavbarDropdownOptions;
 
+  /** (optional) The selected dropdown item value. */
+  @Prop() selectedDropdownItem: ModusNavbarDropdownItem;
+
   /** (required) Profile menu options. */
   @Prop({ mutable: true }) profileMenuOptions: ModusProfileMenuOptions;
 
@@ -158,7 +161,6 @@ export class ModusNavbar {
   @State() componentId = createGuid();
   @State() searchOverlayVisible: boolean;
   @State() openButtonMenuId: string;
-  @State() selectedDropdownItem: ModusNavbarDropdownItem;
 
   readonly SLOT_MAIN = 'main';
   readonly SLOT_NOTIFICATIONS = 'notifications';
@@ -185,12 +187,6 @@ export class ModusNavbar {
   @Listen('signOutClick')
   signOutClickHandler(event: KeyboardEvent | MouseEvent): void {
     this.profileMenuSignOutClick.emit(event);
-  }
-
-  componentWillLoad(): void {
-    this.selectedDropdownItem = this.dropdownOptions?.items.find(
-      (item) => item.value === this.dropdownOptions.defaultValue
-    ) ?? { text: '', value: '' };
   }
 
   componentDidRender(): void {
@@ -383,7 +379,6 @@ export class ModusNavbar {
   }
 
   dropdownItemSelectHandler(item: ModusNavbarDropdownItem): void {
-    this.selectedDropdownItem = item;
     this.dropdownItemSelect.emit(item);
   }
 

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -279,6 +279,16 @@ interface ModusNavbarButton {
   hideMenu?: boolean;
   tooltip?: ModusNavbarTooltip;
 }
+
+export interface ModusNavbarDropdownItem {
+  text: string;
+  value: string;
+}
+
+export interface ModusNavbarDropdownOptions {
+  ariaLabel: string;
+  items: ModusNavbarDropdownItem[];
+}
 ```
 
 ### Properties

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -159,15 +159,21 @@ Add optional features to the navbar.
     },
     secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
   };
+
+  const defaultItem = { text: 'Project 1', value: '1' };
   element.dropdownOptions = {
     ariaLabel: 'Project dropdown',
-    defaultValue: '2',
     items: [
-      { text: 'Project 1', value: '1' },
+      defaultItem,
       { text: 'Project 2', value: '2' },
       { text: 'Project 3', value: '3' },
     ],
   };
+  element.selectedDropdownItem = defaultItem;
+  element.addEventListener('dropdownItemSelect', ({ detail }) => {
+    element.selectedDropdownItem = detail;
+  });
+
   element.profileMenuOptions = {
     avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -309,14 +309,14 @@ BlueNavbar.args = {
   notificationCount: 0,
 };
 
+const defaultItem = { text: 'Project 1', value: '1' };
 const dropdownOptions = {
   ariaLabel: 'Project dropdown',
-  defaultValue: '2',
-  items: [
-    { text: 'Project 1', value: '1' },
-    { text: 'Project 2', value: '2' },
-    { text: 'Project 3', value: '3' },
-  ],
+  items: [defaultItem, { text: 'Project 2', value: '2' }, { text: 'Project 3', value: '3' }],
+};
+let selectedDropdownItem = defaultItem;
+const dropdownItemSelectHandler = ({ detail }) => {
+  selectedDropdownItem = detail;
 };
 
 const WithOptionalFeaturesTemplate = ({
@@ -332,6 +332,7 @@ const WithOptionalFeaturesTemplate = ({
   showSearch,
 }) => html`
   <modus-navbar
+    with-optional-features
     enable-search-overlay=${enableSearchOverlay}
     nav-aria-label=${navAriaLabel}
     show-apps-menu
@@ -346,6 +347,7 @@ const WithOptionalFeaturesTemplate = ({
     .helpTooltip=${helpTooltip}
     .logoOptions=${defaultLogo}
     .dropdownOptions=${dropdownOptions}
+    .selectedDropdownItem=${selectedDropdownItem}
     .profileMenuOptions=${profileMenuOptions}
     .searchTooltip=${searchTooltip}>
     <div slot="main" style="height:300px;">Render your own main menu.</div>
@@ -393,3 +395,15 @@ WithOptionalFeatures.args = {
   showSearch: false,
   notificationCount: 0,
 };
+
+document.addEventListener('DOMContentLoaded', () => {
+  setTimeout(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const navbar = document.querySelector('modus-navbar[with-optional-features]') as any;
+    if (navbar) {
+      navbar.addEventListener('dropdownItemSelect', (event) => {
+        navbar.selectedDropdownItem = event.detail;
+      });
+    }
+  }, 500);
+});

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -397,6 +397,7 @@ WithOptionalFeatures.args = {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Ensure that Storybook has rendered before accessing the modus-navbar
   setTimeout(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const navbar = document.querySelector('modus-navbar[with-optional-features]') as any;

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -314,10 +314,7 @@ const dropdownOptions = {
   ariaLabel: 'Project dropdown',
   items: [defaultItem, { text: 'Project 2', value: '2' }, { text: 'Project 3', value: '3' }],
 };
-let selectedDropdownItem = defaultItem;
-const dropdownItemSelectHandler = ({ detail }) => {
-  selectedDropdownItem = detail;
-};
+const selectedDropdownItem = defaultItem;
 
 const WithOptionalFeaturesTemplate = ({
   buttons,


### PR DESCRIPTION
> [!IMPORTANT]
> There are 2 competing PRs with different ways of solving this. Only merge one.
> This is the simpler implementation but moves state management responsibility to the consumer.

## Description

This PR moves control of the Modus Navbar dropdown selected item to the consumer. The state value `selectedDropdownItem` has been updated to be an input prop.

This adds complete flexibility to the feature by allowing the user to set their own default item and handle selection as they see fit. This is valuable for the use case when a user selects an item and we want to leave the current tab unchanged but open a new tab in the context of the selected value.

This is a breaking change as it updates the input prop models. Though it is unlikely that anyone else is using the dropdown feature yet, but we can't be 100% sure.

References #2682

![chrome_xl1gSQ2sV0](https://github.com/trimble-oss/modus-web-components/assets/83187108/3330e1bc-003f-4456-8e0c-2791f31f58b1)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Manually through the stencil index.html and Storybook.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
