### PR TITLE
Navbar: dropdown allows manual selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,42 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=16.20.2"
       }
-    },
-    "node_modules/@stencil/angular-output-target": {
-      "version": "0.6.1-dev.11657573317.16e0205c",
-      "resolved": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.6.1-dev.11657573317.16e0205c.tgz",
-      "integrity": "sha512-dSD2d8itnD8xa5vRRoOFjWiSd813L+/vuulolDl22k7urBWdH8pGDlBu5uhatEjZD12d6C0blFBlWpy25YFjBw==",
-      "peerDependencies": {
-        "@stencil/core": "^2.9.0"
-      }
-    },
-    "node_modules/@stencil/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA==",
-      "peer": true,
-      "bin": {
-        "stencil": "bin/stencil"
-      },
-      "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@stencil/angular-output-target": {
-      "version": "https://registry.npmjs.org/@stencil/angular-output-target/-/angular-output-target-0.6.1-dev.11657573317.16e0205c.tgz",
-      "integrity": "sha512-dSD2d8itnD8xa5vRRoOFjWiSd813L+/vuulolDl22k7urBWdH8pGDlBu5uhatEjZD12d6C0blFBlWpy25YFjBw==",
-      "requires": {}
-    },
-    "@stencil/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-EEKHOHgYpg3/iFUKMXTZJjUayRul7sXDwNw0OGgkEOe4t7JWiibDkzUHuruvpbqEydX+z1+ez5K2bMMY76c2wA==",
-      "peer": true
     }
   }
 }

--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -738,6 +738,10 @@ export namespace Components {
          */
         "close": () => Promise<void>;
         /**
+          * (optional) The modal's full screen view
+         */
+        "fullscreen": boolean;
+        /**
           * (optional) The modal's primary button text.
          */
         "headerText": string;
@@ -824,6 +828,10 @@ export namespace Components {
           * (optional) Search tooltip.
          */
         "searchTooltip": ModusNavbarTooltip;
+        /**
+          * (optional) The selected dropdown item.
+         */
+        "selectedDropdownItem": ModusNavbarDropdownItem;
         /**
           * (optional) Whether to show the apps menu.
          */
@@ -3646,6 +3654,10 @@ declare namespace LocalJSX {
          */
         "backdrop"?: 'default' | 'static';
         /**
+          * (optional) The modal's full screen view
+         */
+        "fullscreen"?: boolean;
+        /**
           * (optional) The modal's primary button text.
          */
         "headerText"?: string;
@@ -3795,6 +3807,10 @@ declare namespace LocalJSX {
           * (optional) Search tooltip.
          */
         "searchTooltip"?: ModusNavbarTooltip;
+        /**
+          * (optional) The selected dropdown item.
+         */
+        "selectedDropdownItem"?: ModusNavbarDropdownItem;
         /**
           * (optional) Whether to show the apps menu.
          */

--- a/stencil-workspace/src/components/modus-navbar/dropdown/modus-navbar-dropdown.tsx
+++ b/stencil-workspace/src/components/modus-navbar/dropdown/modus-navbar-dropdown.tsx
@@ -8,7 +8,7 @@ interface Props {
   itemSelect: (item: ModusNavbarDropdownItem) => void;
   options: ModusNavbarDropdownOptions;
   reverse: boolean;
-  selectedItem: ModusNavbarDropdownItem;
+  selectedItem?: ModusNavbarDropdownItem;
 }
 
 export const ModusNavbarDropdown: FunctionalComponent<Props> = ({ itemSelect, options, reverse, selectedItem }) => {
@@ -28,14 +28,11 @@ export const ModusNavbarDropdown: FunctionalComponent<Props> = ({ itemSelect, op
         id={toggleElementId}
         slot={'dropdownToggle'}
         show-caret={true}>
-        {selectedItem.text}
+        {selectedItem?.text}
       </modus-button>
       <modus-list dir={direction} slot={'dropdownList'}>
         {options.items.map((item) => (
-          <modus-list-item
-            key={item.value}
-            onItemClick={() => itemSelectHandler(item)}
-            selected={item.value !== '' && item.value === selectedItem.value}>
+          <modus-list-item key={item.value} onItemClick={() => itemSelectHandler(item)} selected={item === selectedItem}>
             {item.text}
           </modus-list-item>
         ))}

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.models.ts
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.models.ts
@@ -41,6 +41,5 @@ export interface ModusNavbarDropdownItem {
 
 export interface ModusNavbarDropdownOptions {
   ariaLabel: string;
-  defaultValue: string;
   items: ModusNavbarDropdownItem[];
 }

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.tsx
@@ -61,6 +61,9 @@ export class ModusNavbar {
   /** (optional) Dropdown options. */
   @Prop() dropdownOptions: ModusNavbarDropdownOptions;
 
+  /** (optional) The selected dropdown item. */
+  @Prop() selectedDropdownItem: ModusNavbarDropdownItem;
+
   /** (required) Profile menu options. */
   @Prop({ mutable: true }) profileMenuOptions: ModusProfileMenuOptions;
 
@@ -158,7 +161,6 @@ export class ModusNavbar {
   @State() componentId = createGuid();
   @State() searchOverlayVisible: boolean;
   @State() openButtonMenuId: string;
-  @State() selectedDropdownItem: ModusNavbarDropdownItem;
 
   readonly SLOT_MAIN = 'main';
   readonly SLOT_NOTIFICATIONS = 'notifications';
@@ -185,12 +187,6 @@ export class ModusNavbar {
   @Listen('signOutClick')
   signOutClickHandler(event: KeyboardEvent | MouseEvent): void {
     this.profileMenuSignOutClick.emit(event);
-  }
-
-  componentWillLoad(): void {
-    this.selectedDropdownItem = this.dropdownOptions?.items.find(
-      (item) => item.value === this.dropdownOptions.defaultValue
-    ) ?? { text: '', value: '' };
   }
 
   componentDidRender(): void {

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar-storybook-docs.mdx
@@ -159,15 +159,18 @@ Add optional features to the navbar.
     },
     secondary: { url: 'https://modus.trimble.com/favicon.svg', height: 24 },
   };
+
+  const items = [
+    { text: 'Project 1', value: '1' },
+    { text: 'Project 2', value: '2' },
+    { text: 'Project 3', value: '3' },
+  ];
   element.dropdownOptions = {
     ariaLabel: 'Project dropdown',
-    defaultValue: '2',
-    items: [
-      { text: 'Project 1', value: '1' },
-      { text: 'Project 2', value: '2' },
-      { text: 'Project 3', value: '3' },
-    ],
+    items,
   };
+  element.selectedDropdownItem = items[1];
+
   element.profileMenuOptions = {
     avatarUrl: 'https://avatar.example.com/broken-image-link.png',
     email: 'modus_user@trimble.com',
@@ -273,6 +276,16 @@ interface ModusNavbarButton {
   hideMenu?: boolean;
   tooltip?: ModusNavbarTooltip;
 }
+
+export interface ModusNavbarDropdownItem {
+  text: string;
+  value: string;
+}
+
+export interface ModusNavbarDropdownOptions {
+  ariaLabel: string;
+  items: ModusNavbarDropdownItem[];
+}
 ```
 
 ### Properties
@@ -288,6 +301,7 @@ interface ModusNavbarButton {
 | `helpUrl`              | `help-url`               | (optional) Help URL.                                                                                                                                                                    | `string`                     | `undefined` |
 | `logoOptions`          | --                       | (optional) Set the primary logo to display when the screen size is greater than 576 pixels, and the secondary logo to display when the screen size is less than or equal to 576 pixels. | `ModusNavbarLogoOptions`     | `undefined` |
 | `dropdownOptions`      | --                       | (optional) Renders a modus dropdown in the Navbar.                                                                                                                                      | `ModusNavbarDropdownOptions` | `undefined` |
+| `selectedDropdownItem` | --                       | (optional) The selected dropdown item.                                                                                                                                                  | `ModusNavbarDropdownItem`    | `undefined` |
 | `profileMenuOptions`   | --                       | (required) Profile menu options.                                                                                                                                                        | `ModusProfileMenuOptions`    | `undefined` |
 | `reverse`              | `reverse`                | (optional) Whether to display the navbar items in reverse order.                                                                                                                        | `boolean`                    | `undefined` |
 | `searchTooltip`        | --                       | (optional) Search tooltip.                                                                                                                                                              | `ModusNavbarTooltip`         | `undefined` |

--- a/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-navbar/modus-navbar.stories.tsx
@@ -309,14 +309,14 @@ BlueNavbar.args = {
   notificationCount: 0,
 };
 
+const items = [
+  { text: 'Project 1', value: '1' },
+  { text: 'Project 2', value: '2' },
+  { text: 'Project 3', value: '3' },
+];
 const dropdownOptions = {
   ariaLabel: 'Project dropdown',
-  defaultValue: '2',
-  items: [
-    { text: 'Project 1', value: '1' },
-    { text: 'Project 2', value: '2' },
-    { text: 'Project 3', value: '3' },
-  ],
+  items,
 };
 
 const WithOptionalFeaturesTemplate = ({
@@ -346,6 +346,7 @@ const WithOptionalFeaturesTemplate = ({
     .helpTooltip=${helpTooltip}
     .logoOptions=${defaultLogo}
     .dropdownOptions=${dropdownOptions}
+    .selectedDropdownItem=${items[1]}
     .profileMenuOptions=${profileMenuOptions}
     .searchTooltip=${searchTooltip}>
     <div slot="main" style="height:300px;">Render your own main menu.</div>


### PR DESCRIPTION
## Description

This PR adds a way for the consumer to manually set the Navbar `selectedDropdownItem`. This allows the web component to track changes and emit events. But also allows the user to set it back to a previous value (or whatever they want).

This is a breaking change as it changes the interfaces for the Modus Navbar props.

References #2682

![image](https://github.com/trimble-oss/modus-web-components/assets/83187108/78f61a31-be75-4f58-bc61-f92f60e6a1e6)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

Manually tested and in Storybook.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
