### PR TITLE
Autocomplete: Improve disabled state CSS

### DIFF
--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.scss
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.scss
@@ -44,6 +44,11 @@
     position: relative;
     width: 100%;
 
+    &:focus-within {
+      border-color: $modus-autocomplete-container-border-active-color;
+      box-shadow: 0 0 0 1px $modus-autocomplete-container-border-active-color;
+    }
+
     .icon-search {
       margin-left: 4px;
       margin-right: 0;
@@ -178,7 +183,21 @@
   }
 }
 
-.autocomplete .chips-container:focus-within {
-  border-color: $modus-autocomplete-container-border-active-color;
-  box-shadow: 0 0 0 1px $modus-autocomplete-container-border-active-color;
+.autocomplete[aria-disabled='true'] {
+  .chips-container {
+    background-color: var(--modus-input-disabled-bg, #e0e1e9);
+    border-color: transparent;
+    pointer-events: none;
+    user-select: none;
+
+    .input {
+      &::part(input-container) {
+        background-color: var(--modus-input-disabled-bg, #e0e1e9);
+        border-color: transparent;
+        color: var(--modus-input-disabled-color, #a3a6b1);
+        pointer-events: none;
+        user-select: none;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description

This is a CSS-only fix to improve the disabled state by making border transparent, disabling text select and pointer-events.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-2690--moduswebcomponents.netlify.app/?path=/story/user-inputs-autocomplete--default&args=disabled:true

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
