### PR TITLE
Side-Navigation: Don't animate if user prefers reduced animation

### DIFF
--- a/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.scss
+++ b/stencil-workspace/src/components/modus-side-navigation/modus-side-navigation.scss
@@ -120,3 +120,15 @@
     }
   }
 }
+
+@media (prefers-reduced-motion) {
+  .side-nav-level,
+  .side-nav-menu,
+  .side-nav-panel {
+    transition-duration: 0s !important;
+
+    &.expanded {
+      transition-duration: 0s !important;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes: #2355 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

In Dev Tools you can set `Rendering > Prefers-Reduced-Animation: Reduce`.
Then expanding and collapsing the menu has no animation.

![image](https://github.com/user-attachments/assets/6876d592-912b-46fc-bfcc-0606c5becd1d)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
