### PR TITLE
Datepicker: Add position property to control component placement relative to the wrapped item

### DIFF
--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.scss
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.scss
@@ -53,6 +53,11 @@
     position: absolute;
     z-index: 1;
 
+    &[data-popper-reference-hidden] {
+      pointer-events: none;
+      visibility: hidden;
+    }
+
     .calendar-header {
       align-items: center;
       background-color: $modus-date-picker-calendar-header-bg;

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.spec.tsx
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.spec.tsx
@@ -22,7 +22,7 @@ describe('modus-date-picker', () => {
        <div class="date-inputs" part="date-inputs">
          <slot></slot>
        </div>
-       <div style="display: inline-flex;"></div>
+       <div class="calendar" part="calendar" style="display: inline-flex;"></div>
      </div>
    </mock:shadow-root>
    <modus-date-input label="Start" show-calendar-icon="" type="start"></modus-date-input>

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.tsx
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.tsx
@@ -24,7 +24,7 @@ export class ModusDatePicker {
   @Prop() label: string;
 
   /** (optional) The placement of the calendar popup */
-  @Prop() calendarPlacement: Placement = 'bottom-start';
+  @Prop() position: Placement = 'bottom-start';
 
   /** Needed for a better control over the state and avoid re-renders */
   @State() _forceUpdate = {};
@@ -67,7 +67,7 @@ export class ModusDatePicker {
 
     if (referenceElement && popperElement && !this._popperInstance) {
       this._popperInstance = createPopper(referenceElement, popperElement, {
-        placement: this.calendarPlacement,
+        placement: this.position,
         modifiers: [
           {
             name: 'offset',

--- a/stencil-workspace/src/components/modus-date-picker/modus-date-picker.tsx
+++ b/stencil-workspace/src/components/modus-date-picker/modus-date-picker.tsx
@@ -10,6 +10,7 @@ import { ModusIconMap } from '../../icons/ModusIconMap';
 import ModusDatePickerCalendar from './utils/modus-date-picker.calendar';
 import ModusDatePickerState from './utils/modus-date-picker.state';
 import { ModusDateInputEventDetails } from '../modus-date-input/utils/modus-date-input.models';
+import { createPopper, Instance, Placement } from '@popperjs/core';
 
 @Component({
   tag: 'modus-date-picker',
@@ -22,6 +23,9 @@ export class ModusDatePicker {
   /** (optional) Label for the field. */
   @Prop() label: string;
 
+  /** (optional) The placement of the calendar popup */
+  @Prop() calendarPlacement: Placement = 'bottom-start';
+
   /** Needed for a better control over the state and avoid re-renders */
   @State() _forceUpdate = {};
 
@@ -31,6 +35,7 @@ export class ModusDatePicker {
   private _calendar: ModusDatePickerCalendar;
   private _dateInputs: { [key: string]: ModusDatePickerState } = {};
   private _locale = 'default';
+  private _popperInstance: Instance;
 
   private get _currentInput(): ModusDatePickerState {
     return Object.values(this._dateInputs).find((dt) => dt.isCalendarOpen());
@@ -38,6 +43,55 @@ export class ModusDatePicker {
 
   componentWillLoad() {
     this._calendar = new ModusDatePickerCalendar();
+  }
+
+  componentDidLoad() {
+    this.initializePopper();
+  }
+
+  componentDidUpdate() {
+    if (this._showCalendar) {
+      this.initializePopper();
+    } else {
+      this.destroyPopper();
+    }
+  }
+
+  disconnectedCallback() {
+    this.destroyPopper();
+  }
+
+  initializePopper() {
+    const referenceElement = this.element.parentElement as HTMLElement;
+    const popperElement = this.element.shadowRoot.querySelector('.calendar-container') as HTMLElement;
+
+    if (referenceElement && popperElement && !this._popperInstance) {
+      this._popperInstance = createPopper(referenceElement, popperElement, {
+        placement: this.calendarPlacement,
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [0.2, 0.2],
+              mainAxis: false,
+            },
+          },
+          {
+            name: 'preventOverflow',
+            options: {
+              boundary: 'viewport',
+            },
+          },
+        ],
+      });
+    }
+  }
+
+  destroyPopper() {
+    if (this._popperInstance) {
+      this._popperInstance.destroy();
+      this._popperInstance = null;
+    }
   }
 
   /** Handlers */
@@ -341,7 +395,7 @@ export class ModusDatePicker {
         <div class="date-inputs" part="date-inputs">
           <slot onSlotchange={() => this.handleSlotChange()}></slot>
         </div>
-        <div style={{ display: 'inline-flex' }}>
+        <div class="calendar" part="calendar" style={{ display: 'inline-flex' }}>
           {this._showCalendar && (
             <nav class="calendar-container" aria-label="Pick a Date">
               {this.renderCalendarHeader()}

--- a/stencil-workspace/src/components/modus-date-picker/readme.md
+++ b/stencil-workspace/src/components/modus-date-picker/readme.md
@@ -7,15 +7,17 @@
 
 ## Properties
 
-| Property | Attribute | Description                     | Type     | Default     |
-| -------- | --------- | ------------------------------- | -------- | ----------- |
-| `label`  | `label`   | (optional) Label for the field. | `string` | `undefined` |
+| Property            | Attribute            | Description                                    | Type                                                                                                                                                                                                         | Default          |
+| ------------------- | -------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `calendarPlacement` | `calendar-placement` | (optional) The placement of the calendar popup | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
+| `label`             | `label`              | (optional) Label for the field.                | `string`                                                                                                                                                                                                     | `undefined`      |
 
 
 ## Shadow Parts
 
 | Part            | Description |
 | --------------- | ----------- |
+| `"calendar"`    |             |
 | `"date-inputs"` |             |
 
 

--- a/stencil-workspace/src/components/modus-date-picker/readme.md
+++ b/stencil-workspace/src/components/modus-date-picker/readme.md
@@ -7,10 +7,10 @@
 
 ## Properties
 
-| Property            | Attribute            | Description                                    | Type                                                                                                                                                                                                         | Default          |
-| ------------------- | -------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
-| `calendarPlacement` | `calendar-placement` | (optional) The placement of the calendar popup | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
-| `label`             | `label`              | (optional) Label for the field.                | `string`                                                                                                                                                                                                     | `undefined`      |
+| Property   | Attribute  | Description                                    | Type                                                                                                                                                                                                         | Default          |
+| ---------- | ---------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `label`    | `label`    | (optional) Label for the field.                | `string`                                                                                                                                                                                                     | `undefined`      |
+| `position` | `position` | (optional) The placement of the calendar popup | `"auto" \| "auto-end" \| "auto-start" \| "bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'bottom-start'` |
 
 
 ## Shadow Parts

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.scss
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.scss
@@ -39,6 +39,11 @@ table.density-compact {
   justify-content: center;
 }
 
+.date-picker-container::part(calendar) {
+  position: fixed;
+  z-index: 99;
+}
+
 .editor::part(input-container) {
   border: 2px solid var(--modus-input-border-active-color, #217cbb);
   border-radius: unset;

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.tsx
@@ -218,7 +218,7 @@ export class ModusTableCellEditor {
     return (
       <modus-date-picker
         onBlur={this.handleBlur}
-        calendar-placement="auto"
+        position="auto"
         onClick={(e: MouseEvent) => e.stopPropagation()}
         class="date-picker-container">
         <modus-date-input

--- a/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.tsx
+++ b/stencil-workspace/src/components/modus-table/parts/cell/modus-table-cell-editor/modus-table-cell-editor.tsx
@@ -218,6 +218,7 @@ export class ModusTableCellEditor {
     return (
       <modus-date-picker
         onBlur={this.handleBlur}
+        calendar-placement="auto"
         onClick={(e: MouseEvent) => e.stopPropagation()}
         class="date-picker-container">
         <modus-date-input

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
@@ -126,9 +126,11 @@ Each character as shown in the table below can be used for representing the date
 
 ##### Modus Date Picker
 
-| Property | Attribute | Description                     | Type     | Default     |
-| -------- | --------- | ------------------------------- | -------- | ----------- |
-| `label`  | `label`   | (optional) Label for the field. | `string` | `undefined` |
+| Property            | Attribute            | Description                                     | Type                                                                                                                                                                                                        | Default        |
+| ------------------- | -------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `label`             | `label`              | (optional) Label for the field.                 | `string`                                                                                                                                                                                                    | `undefined`    |
+| `calendarPlacement` | `calendar-placement` | (optional) The placement of the calendar popup. | `"auto" \| "auto-start" \| "auto-end" \| "top-start" \| "top-end" \| "bottom-start" \| "bottom-end" \| "right-start" \| "right-end" \| "left-start" \| "left-end" \| "top" \| "left" \| "bottom" \| "right" | `bottom-start` |
+| `                   |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker-storybook-docs.mdx
@@ -129,7 +129,7 @@ Each character as shown in the table below can be used for representing the date
 | Property            | Attribute            | Description                                     | Type                                                                                                                                                                                                        | Default        |
 | ------------------- | -------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
 | `label`             | `label`              | (optional) Label for the field.                 | `string`                                                                                                                                                                                                    | `undefined`    |
-| `calendarPlacement` | `calendar-placement` | (optional) The placement of the calendar popup. | `"auto" \| "auto-start" \| "auto-end" \| "top-start" \| "top-end" \| "bottom-start" \| "bottom-end" \| "right-start" \| "right-end" \| "left-start" \| "left-end" \| "top" \| "left" \| "bottom" \| "right" | `bottom-start` |
+| `position` | `position` | (optional) The position  of the calendar popup. | `"auto" \| "auto-start" \| "auto-end" \| "top-start" \| "top-end" \| "bottom-start" \| "bottom-end" \| "right-start" \| "right-end" \| "left-start" \| "left-end" \| "top" \| "left" \| "bottom" \| "right" | `bottom-start` |
 | `                   |
 
 ### DOM Events

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
@@ -7,16 +7,14 @@ export default {
   argTypes: {
     allowedCharsRegex: {
       name: 'allowed-chars-regex',
-      description:
-        'Regular expression to allow characters while typing the input.',
+      description: 'Regular expression to allow characters while typing the input.',
       table: {
         type: { summary: 'string' },
       },
     },
     altFormats: {
       name: 'alt-formats',
-      description:
-        'Alternative formats string for the date input split by | separator.',
+      description: 'Alternative formats string for the date input split by | separator.',
       table: {
         type: { summary: 'string' },
       },
@@ -33,6 +31,37 @@ export default {
       description: 'Sets autofocus for the input',
       table: {
         type: { summary: 'boolean' },
+      },
+    },
+    calendarPlacement: {
+      name: 'calendar-placement',
+      control: {
+        options: [
+          'auto',
+          'auto-start',
+          'auto-end',
+          'top-start',
+          'top-end',
+          'bottom-start',
+          'bottom-end',
+          'right-start',
+          'right-end',
+          'left-start',
+          'left-end',
+          'top',
+          'left',
+          'bottom',
+          'right',
+        ],
+        type: 'select',
+      },
+      description: 'The placement of the calendar popup',
+      table: {
+        defaultValue: { summary: 'bottom-start' },
+        type: {
+          summary:
+            "'auto' | 'auto-start' | 'auto-end' | 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end' | 'right-start' | 'right-end' | 'left-start' | 'left-end' | 'top' | 'left' | 'bottom' | 'right'",
+        },
       },
     },
     disabled: {
@@ -81,13 +110,13 @@ export default {
       description: "The maximum date allowed. The input string should be ISO8601 'yyyy-mm-dd'.",
       table: {
         type: { summary: 'string' },
-      }
+      },
     },
     min: {
       description: "The minimum date allowed. The input string should be ISO8601 'yyyy-mm-dd'.",
       table: {
         type: { summary: 'string' },
-      }
+      },
     },
     placeholder: {
       description: "The input's placeholder text",
@@ -137,8 +166,7 @@ export default {
       },
     },
     value: {
-      description:
-        "A string representing the date entered in the input. The input string should be ISO8601 'yyyy-mm-dd'.",
+      description: "A string representing the date entered in the input. The input string should be ISO8601 'yyyy-mm-dd'.",
       table: {
         type: { summary: 'string' },
       },
@@ -310,27 +338,28 @@ DateRange.args = {
 };
 
 const DefaultWithPickerTemplate = ({
-    ariaLabel,
-    allowedCharsRegex,
-    altFormats,
-    autoFocusInput,
-    disableValidation,
-    disabled,
-    errorText,
-    format,
-    helperText,
-    label,
-    min,
-    max,
-    placeholder,
-    readOnly,
-    required,
-    showCalendarIcon,
-    size,
-    validText,
-    value,
-  }) => html`
-  <modus-date-picker>
+  ariaLabel,
+  allowedCharsRegex,
+  altFormats,
+  autoFocusInput,
+  calendarPlacement,
+  disableValidation,
+  disabled,
+  errorText,
+  format,
+  helperText,
+  label,
+  min,
+  max,
+  placeholder,
+  readOnly,
+  required,
+  showCalendarIcon,
+  size,
+  validText,
+  value,
+}) => html`
+  <modus-date-picker calendar-placement=${calendarPlacement}>
     <modus-date-input
       allowed-chars-regex=${allowedCharsRegex}
       aria-label=${ariaLabel}
@@ -357,6 +386,7 @@ const DefaultWithPickerTemplate = ({
 export const DefaultWithPicker = DefaultWithPickerTemplate.bind({});
 DefaultWithPicker.args = {
   ...defaultArgs,
+  calendarPlacement: 'bottom-start',
   showCalendarIcon: true,
   min: '2022-12-02',
   max: '2022-12-30',

--- a/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-date-picker/modus-date-picker.stories.tsx
@@ -33,8 +33,8 @@ export default {
         type: { summary: 'boolean' },
       },
     },
-    calendarPlacement: {
-      name: 'calendar-placement',
+    position: {
+      name: 'position',
       control: {
         options: [
           'auto',
@@ -342,7 +342,7 @@ const DefaultWithPickerTemplate = ({
   allowedCharsRegex,
   altFormats,
   autoFocusInput,
-  calendarPlacement,
+  position,
   disableValidation,
   disabled,
   errorText,
@@ -359,7 +359,7 @@ const DefaultWithPickerTemplate = ({
   validText,
   value,
 }) => html`
-  <modus-date-picker calendar-placement=${calendarPlacement}>
+  <modus-date-picker position=${position}>
     <modus-date-input
       allowed-chars-regex=${allowedCharsRegex}
       aria-label=${ariaLabel}
@@ -386,7 +386,7 @@ const DefaultWithPickerTemplate = ({
 export const DefaultWithPicker = DefaultWithPickerTemplate.bind({});
 DefaultWithPicker.args = {
   ...defaultArgs,
-  calendarPlacement: 'bottom-start',
+  position: 'bottom-start',
   showCalendarIcon: true,
   min: '2022-12-02',
   max: '2022-12-30',


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Added a prop called `calendar-placement` to set the position of the calendar 
- Added popper function to change position seamlessly while scrolling but the default position is set to bottom-start
References 
Fixes #2802 <!-- issue number -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
