### PR TITLE
Table: Set state when columns property changed

### DIFF
--- a/stencil-workspace/src/components/modus-table/modus-table.tsx
+++ b/stencil-workspace/src/components/modus-table/modus-table.tsx
@@ -90,6 +90,11 @@ export class ModusTable {
   @Prop({ mutable: true }) columns!: ModusTableColumn<unknown>[];
   @Watch('columns') onColumnsChange(newVal: ModusTableColumn<unknown>[]) {
     this.tableCore?.setOptions('columns', (newVal as ColumnDef<unknown>[]) ?? []);
+    this.tableCore?.setState(
+      'columnOrder',
+      newVal.map((column) => column.id as string)
+    );
+    this.tableState.columnOrder = newVal.map((column) => column.id as string);
   }
 
   /* (optional) To manage column resizing */


### PR DESCRIPTION
## Description

Set 'columnOrder' state when new `columns` array provided to modus table. This change support column reordering when new columns were added after table's initial render.

References #2811 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Ran all unit and e2e tests using `npm run test`
Exploratory testing locally in index.html file

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
