### PR TITLE
Utility Panel: Add custom css property to configure padding

### DIFF
--- a/stencil-workspace/src/components/modus-utility-panel/modus-utility-panel.scss
+++ b/stencil-workspace/src/components/modus-utility-panel/modus-utility-panel.scss
@@ -1,5 +1,9 @@
 @import './modus-utility-panel.vars';
 
+:host {
+  --panel-padding: 1rem;
+}
+
 .utility-panel {
   background-color: $modus-utility-panel-bg;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
@@ -34,13 +38,13 @@
       align-items: center;
       display: flex;
       height: 50px;
-      padding: 0 1rem;
+      padding: 0 var(--panel-padding);
     }
 
     .panel-body {
       flex: 1;
       overflow: auto;
-      padding: 1rem;
+      padding: var(--panel-padding);
     }
 
     hr {

--- a/stencil-workspace/storybook/stories/components/modus-utility-panel/modus-utility-panel-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-utility-panel/modus-utility-panel-storybook-docs.mdx
@@ -72,6 +72,7 @@ It has header, body, and footer slots for adding content. It supports both overl
 | `targetContent` | Specifies the selector for the page's content that will be affected by the utility panel based on the `pushContent` property. | `string`  |         |
 
 ## CSS Custom Properties
+More info on CSS Custom Properties: [Customizing Components with Custom Properties](https://stenciljs.com/docs/styling#customizing-components-with-custom-properties)
 
 | Property                  | Description                                                                                   |
 | ------------------------- | --------------------------------------------------------------------------------------------- |

--- a/stencil-workspace/storybook/stories/components/modus-utility-panel/modus-utility-panel-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-utility-panel/modus-utility-panel-storybook-docs.mdx
@@ -70,3 +70,9 @@ It has header, body, and footer slots for adding content. It supports both overl
 | `expanded`      | Controls the expanded state of the utility panel. When `true`, the panel is visible.                                          | `boolean` | false   |
 | `pushContent`   | Determines whether the utility panel should push the main content to the right (`true`) or overlay the content (`false`).     | `boolean` | false   |
 | `targetContent` | Specifies the selector for the page's content that will be affected by the utility panel based on the `pushContent` property. | `string`  |         |
+
+## CSS Custom Properties
+
+| Property                  | Description                                                                                   |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `--panel-padding`         | Padding of the utility panel, defaults to 1rem                                                                 |


### PR DESCRIPTION
## Description

Add a custom css property to allow user of utility panel to specify custom padding.

References #2699 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested usage of property in storybook.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
