### PR TITLE
Toast: Add prop to retain element on dismiss

### DIFF
--- a/stencil-workspace/src/components/modus-toast/modus-toast.e2e.ts
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.e2e.ts
@@ -111,7 +111,7 @@ describe('modus-toast', () => {
     expect(dismissClick).toHaveReceivedEvent();
   });
 
-  it('removes the element from the DOM when retainElement is true', async () => {
+  it('retains the element from the DOM when retainElement is true', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-toast retainElement="true" delay="1000"></modus-toast>');
@@ -124,7 +124,7 @@ describe('modus-toast', () => {
     expect(element).toBeDefined();
   });
 
-  it('retains the element in the DOM when retainElement is false', async () => {
+  it('removes the element in the DOM when retainElement is false', async () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-toast retainElement="false" delay="1000"></modus-toast>');

--- a/stencil-workspace/src/components/modus-toast/modus-toast.e2e.ts
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.e2e.ts
@@ -67,7 +67,7 @@ describe('modus-toast', () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-toast aria-label="test label"></modus-toast>');
-    let element = await page.find('modus-toast >>> .modus-toast');
+    const element = await page.find('modus-toast >>> .modus-toast');
     expect(element).toBeDefined();
     expect(element).toHaveAttribute('aria-label');
     expect(element.getAttribute('aria-label')).toEqual('test label');
@@ -77,7 +77,7 @@ describe('modus-toast', () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-toast></modus-toast>');
-    let element = await page.find('modus-toast >>> .modus-toast');
+    const element = await page.find('modus-toast >>> .modus-toast');
     expect(element).toBeDefined();
     expect(element).not.toHaveAttribute('aria-label');
   });
@@ -86,7 +86,7 @@ describe('modus-toast', () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-toast aria-label=""></modus-toast>');
-    let element = await page.find('modus-toast >>> .modus-toast');
+    const element = await page.find('modus-toast >>> .modus-toast');
     expect(element).toBeDefined();
     expect(element).not.toHaveAttribute('aria-label');
   });
@@ -109,5 +109,31 @@ describe('modus-toast', () => {
 
     await page.waitForTimeout(10000);
     expect(dismissClick).toHaveReceivedEvent();
+  });
+
+  it('removes the element from the DOM when retainElement is true', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-toast retainElement="true" delay="1000"></modus-toast>');
+    const dismissClick = await page.spyOnEvent('dismissClick');
+
+    await page.waitForTimeout(1000);
+    expect(dismissClick).toHaveReceivedEvent();
+
+    const element = await page.find('modus-toast >>> .modus-toast');
+    expect(element).toBeDefined();
+  });
+
+  it('retains the element in the DOM when retainElement is false', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent('<modus-toast retainElement="false" delay="1000"></modus-toast>');
+    const dismissClick = await page.spyOnEvent('dismissClick');
+
+    await page.waitForTimeout(1000);
+    expect(dismissClick).toHaveReceivedEvent();
+
+    const element = await page.find('modus-toast >>> .modus-toast');
+    expect(element).toBeNull();
   });
 });

--- a/stencil-workspace/src/components/modus-toast/modus-toast.tsx
+++ b/stencil-workspace/src/components/modus-toast/modus-toast.tsx
@@ -22,6 +22,9 @@ export class ModusToast {
   /** (optional) Time taken to dismiss the toast */
   @Prop() delay = 15000;
 
+  /** (optional) Whether to retain the element in the DOM after it has been dismissed. */
+  @Prop() retainElement = false;
+
   /** (optional) Role taken by the toast.  Defaults to 'status'. */
   @Prop() role: string | null = 'status';
 
@@ -70,7 +73,9 @@ export class ModusToast {
 
   dismissElement() {
     this.dismissClick.emit();
-    this.el.remove();
+    if (!this.retainElement) {
+      this.el.remove();
+    }
   }
   componentDidLoad(): void {
     if (this.delay > 0) {

--- a/stencil-workspace/src/components/modus-toast/readme.md
+++ b/stencil-workspace/src/components/modus-toast/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property      | Attribute     | Description                                                | Type                                                                                    | Default     |
-| ------------- | ------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------- |
-| `ariaLabel`   | `aria-label`  | (optional) The toast's aria-label.                         | `string`                                                                                | `undefined` |
-| `delay`       | `delay`       | (optional) Time taken to dismiss the toast                 | `number`                                                                                | `15000`     |
-| `dismissible` | `dismissible` | (optional) Whether the toast has a dismiss button.         | `boolean`                                                                               | `undefined` |
-| `role`        | `role`        | (optional) Role taken by the toast.  Defaults to 'status'. | `string`                                                                                | `'status'`  |
-| `showIcon`    | `show-icon`   | (optional) Whether to show the toasts' icon.               | `boolean`                                                                               | `true`      |
-| `type`        | `type`        | (optional) The toasts' type.                               | `"danger" \| "dark" \| "default" \| "primary" \| "secondary" \| "success" \| "warning"` | `'default'` |
+| Property        | Attribute        | Description                                                                      | Type                                                                                    | Default     |
+| --------------- | ---------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ----------- |
+| `ariaLabel`     | `aria-label`     | (optional) The toast's aria-label.                                               | `string`                                                                                | `undefined` |
+| `delay`         | `delay`          | (optional) Time taken to dismiss the toast                                       | `number`                                                                                | `15000`     |
+| `dismissible`   | `dismissible`    | (optional) Whether the toast has a dismiss button.                               | `boolean`                                                                               | `undefined` |
+| `retainElement` | `retain-element` | (optional) Whether to retain the element in the DOM after it has been dismissed. | `boolean`                                                                               | `false`     |
+| `role`          | `role`           | (optional) Role taken by the toast.  Defaults to 'status'.                       | `string`                                                                                | `'status'`  |
+| `showIcon`      | `show-icon`      | (optional) Whether to show the toasts' icon.                                     | `boolean`                                                                               | `true`      |
+| `type`          | `type`           | (optional) The toasts' type.                                                     | `"danger" \| "dark" \| "default" \| "primary" \| "secondary" \| "success" \| "warning"` | `'default'` |
 
 
 ## Events

--- a/stencil-workspace/storybook/stories/components/modus-toast/modus-toast-storybook-docs.mdx
+++ b/stencil-workspace/storybook/stories/components/modus-toast/modus-toast-storybook-docs.mdx
@@ -30,23 +30,31 @@ import { Anchor } from '@storybook/addon-docs';
 
 <Anchor storyId="components-toast--danger" />
 
+### Retained Toast
+
+<modus-toast type="primary" retain-element="true">Retained Toast</modus-toast>
+
+<Anchor storyId="components-toast--retained-toast" />
+
 ```html
 <modus-toast type="primary">Primary</modus-toast>
 <modus-toast type="secondary">Secondary</modus-toast>
 <modus-toast type="success">Success</modus-toast>
 <modus-toast type="danger">Danger</modus-toast>
+<modus-toast type="primary" retain-element="true">Retained Toast</modus-toast>
 ```
 
 ### Properties
 
-| Name          | Description                      | Type      | Options                                      | Default Value |
-| ------------- | -------------------------------- | --------- | -------------------------------------------- | ------------- |
-| `aria-label`  | The toast's aria-label           | `string`  |                                              |               |
-| `delay`       | Time taken to dismiss the toast  | `number`  |                                              | 15000         |
-| `dismissible` | Whether the toast is dismissible | `boolean` |                                              | false         |
-| `role`        | Role taken by the toast          | `string`  | 'alert', 'log', 'marquee', 'status', 'timer' | 'status'      |
-| `show-icon`   | Whether to show the toast's      | `boolean` |                                              | false         |
-| `type`        | The toast's type                 | `string`  | 'danger', 'primary', 'secondary', 'success', | 'primary'     |
+| Name             | Description                                                            | Type      | Options                                      | Default Value |
+| ---------------- | ---------------------------------------------------------------------- | --------- | -------------------------------------------- | ------------- |
+| `aria-label`     | The toast's aria-label                                                 | `string`  |                                              |               |
+| `delay`          | Time taken to dismiss the toast                                        | `number`  |                                              | 15000         |
+| `dismissible`    | Whether the toast is dismissible                                       | `boolean` |                                              | false         |
+| `retain-element` | Whether to retain the toast's element in the DOM after it is dismissed | `boolean` |                                              | false         |
+| `role`           | Role taken by the toast                                                | `string`  | 'alert', 'log', 'marquee', 'status', 'timer' | 'status'      |
+| `show-icon`      | Whether to show the toast's                                            | `boolean` |                                              | false         |
+| `type`           | The toast's type                                                       | `string`  | 'danger', 'primary', 'secondary', 'success', | 'primary'     |
 
 ### DOM Events
 

--- a/stencil-workspace/storybook/stories/components/modus-toast/modus-toast.stories.tsx
+++ b/stencil-workspace/storybook/stories/components/modus-toast/modus-toast.stories.tsx
@@ -26,6 +26,14 @@ export default {
         type: { summary: 'boolean' },
       },
     },
+    retainElement: {
+      name: 'retain-element',
+      description: 'Whether to retain the element in the DOM after it has been dismissed',
+      table: {
+        defaultValue: { summary: false },
+        type: { summary: 'boolean' },
+      },
+    },
     role: {
       control: {
         options: ['alert', 'log', 'marquee', 'status', 'timer'],
@@ -73,12 +81,13 @@ export default {
   },
 };
 
-const Template = ({ ariaLabel, dismissible, showIcon, role, type, delay }) => html`
+const Template = ({ ariaLabel, dismissible, showIcon, retainElement, role, type, delay }) => html`
   <modus-toast
     aria-label=${ariaLabel}
     delay=${delay}
     dismissible=${dismissible}
     show-icon=${showIcon}
+    retain-element=${retainElement}
     role=${role}
     type=${type}
     >Toast!</modus-toast
@@ -90,6 +99,7 @@ Primary.args = {
   ariaLabel: '',
   delay: 0,
   dismissible: false,
+  retainElement: false,
   role: 'status',
   showIcon: true,
   type: 'primary',
@@ -100,6 +110,7 @@ Secondary.args = {
   ariaLabel: '',
   delay: 0,
   dismissible: false,
+  retainElement: false,
   role: 'status',
   showIcon: true,
   type: 'secondary',
@@ -110,6 +121,7 @@ Success.args = {
   ariaLabel: '',
   delay: 0,
   dismissible: false,
+  retainElement: false,
   role: 'status',
   showIcon: true,
   type: 'success',
@@ -120,7 +132,19 @@ Danger.args = {
   ariaLabel: '',
   delay: 0,
   dismissible: false,
+  retainElement: false,
   role: 'status',
   showIcon: true,
   type: 'danger',
+};
+
+export const RetainedToast = Template.bind({});
+RetainedToast.args = {
+  ariaLabel: '',
+  delay: 2000,
+  dismissible: false,
+  retainElement: true,
+  role: 'status',
+  showIcon: true,
+  type: 'primary',
 };


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Add `retainELement ` prop to not stop the toast component from getting removed from the dom
References 
Fixes #2835 <!-- issue number -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
