### PR TITLE
Remove Google Fonts from Modus Variables CSS

### DIFF
--- a/stencil-workspace/src/global/modus-variables.scss
+++ b/stencil-workspace/src/global/modus-variables.scss
@@ -11,7 +11,6 @@
 $enable-deprecation-messages: false;
 
 // Fonts and Icons
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700');
 $primary-font:
   'Open Sans',
   -apple-system,


### PR DESCRIPTION
## Description

Remove Google Fonts from Modus Variables CSS

Fixes: #2955

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Font still loads from Google Fonts CDN:
https://deploy-preview-2956--moduswebcomponents.netlify.app/?path=/story/components-file-dropzone--default

You just need to include this in your HTML:

```html
<link href="https://fonts.gstatic.com" rel="preconnect" crossorigin>
<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=fallback">
```

![image](https://github.com/user-attachments/assets/3b7feb65-5d3a-4f67-bc0e-70165763ff7f)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
