### PR TITLE
Improve Windows Forced-Colors High Contrast Theme Support

### DIFF
--- a/stencil-workspace/src/components.d.ts
+++ b/stencil-workspace/src/components.d.ts
@@ -85,6 +85,10 @@ export namespace Components {
           * (optional) The size of accordion item.
          */
         "size": 'condensed' | 'standard';
+        /**
+          * (optional) The supportingLabel of the accordion.
+         */
+        "supportingLabel": string;
     }
     interface ModusActionBar {
         /**
@@ -3001,6 +3005,10 @@ declare namespace LocalJSX {
           * (optional) The size of accordion item.
          */
         "size"?: 'condensed' | 'standard';
+        /**
+          * (optional) The supportingLabel of the accordion.
+         */
+        "supportingLabel"?: string;
     }
     interface ModusActionBar {
         /**

--- a/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
+++ b/stencil-workspace/src/components/modus-list-item/modus-list-item.scss
@@ -98,3 +98,10 @@ li {
     fill: $modus-list-item-color;
   }
 }
+
+@media screen and (forced-colors: active) {
+  li.disabled {
+    border-color: GrayText;
+    color: GrayText;
+  }
+}

--- a/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
+++ b/stencil-workspace/src/components/modus-navbar/modus-navbar.scss
@@ -273,3 +273,9 @@ nav {
     }
   }
 }
+
+@media screen and (forced-colors: active) {
+  nav {
+    border-bottom: 1px solid transparent;
+  }
+}

--- a/stencil-workspace/src/components/modus-table/modus-table.scss
+++ b/stencil-workspace/src/components/modus-table/modus-table.scss
@@ -135,6 +135,7 @@ table {
 
       th {
         background-color: $modus-table-header-bg;
+        border-bottom: 1px solid transparent; // Windows High Contrast Mode fix
         border-right: $rem-1px $modus-table-border-color solid;
         box-shadow: inset 0 -0.5px 0 $modus-table-border-color;
         font-weight: $font-weight-semi-bold;


### PR DESCRIPTION
## Description

Follow on PR from: #2601

Improves Modus Lists, Navbars and Tables using Windows Forced Colors High Contrast themes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Tested with Edge and Chrome on Windows 11 Pro by using the forced-colors: active option in Dev Tools - both light and dark mode.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
