### PR TITLE
Alerts: Fix Warning / Error BG color CSS

### DIFF
--- a/stencil-workspace/src/components/modus-alert/modus-alert.vars.scss
+++ b/stencil-workspace/src/components/modus-alert/modus-alert.vars.scss
@@ -1,8 +1,8 @@
 // Background color
 $modus-alert-primary-bg: var(--modus-alert-primary-bg, rgba(220, 237, 249, 0.5)) !default;
 $modus-alert-success-bg: var(--modus-alert-success-bg, rgba(224, 236, 207, 0.5)) !default;
-$modus-alert-danger-bg: var(--modus-alert-danger-bg, rgba(255, 245, 228, 0.5)) !default;
-$modus-alert-warning-bg: var(--modus-alert-warning-bg, rgba(251, 212, 215, 0.5)) !default;
+$modus-alert-danger-bg: var(--modus-alert-danger-bg, rgba(251, 212, 215, 0.5)) !default;
+$modus-alert-warning-bg: var(--modus-alert-warning-bg, rgba(255, 245, 228, 0.5)) !default;
 
 // Text color
 $modus-alert-primary-color: var(--modus-alert-primary-color, #252a2e) !default;


### PR DESCRIPTION
## Description

Fixes the alerts background color for web components when the CSS is NOT used. This fix isn't testable via Storybook because the CSS is loaded.

Fixes: #2913 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Locally.

![image](https://github.com/user-attachments/assets/8eac772a-672f-462f-9e08-56589500e32f)


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
