### PR TITLE
Content Tree: Fix text being selected when expanding a section

### DIFF
--- a/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item/modus-tree-view-item.scss
+++ b/stencil-workspace/src/components/modus-content-tree/modus-tree-view-item/modus-tree-view-item.scss
@@ -13,6 +13,7 @@
   font-size: $rem-16px;
   justify-content: space-between;
   min-height: $list-group-item-height;
+  user-select: none;
   width: 100%;
 
   svg path {


### PR DESCRIPTION
Fixes the text being selected when expanding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-2973--moduswebcomponents.netlify.app/?path=/story/components-content-tree--multi-selection

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
