### PR TITLE
fix autocomplete drop down scrolling issue

### DIFF
--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.tsx
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.tsx
@@ -557,7 +557,7 @@ export class ModusAutocomplete {
                     class={className}
                     tabindex="-1"
                     role="option"
-                    onClick={() => this.handleOptionClick(option)}
+                    onMouseDown={() => this.handleOptionClick(option)}
                     onKeyDown={(e) => this.handleOptionKeyDown(e, option)}>
                     {option.value}
                     {isSelected && <IconCheck size="16" />}
@@ -579,7 +579,7 @@ export class ModusAutocomplete {
                     class={className}
                     tabindex="-1"
                     role="option"
-                    onClick={() => this.handleCustomOptionClick(option)}
+                    onMouseDown={() => this.handleCustomOptionClick(option)}
                     onKeyDown={(e) => this.handleOptionKeyDown(e, option, true)}
                     innerHTML={option.outerHTML}
                   />


### PR DESCRIPTION
## Description

Autocomplete Dropdown Scrolls to Previously Selected Item, Preventing Selection of Desired Product
Unable to select a product from the autocomplete dropdown list. When trying to select a product at the 10th position, the dropdown scrolls back to the currently selected product at the 50th position, making it impossible to choose the desired product from the list.


References #3034 

