### PR TITLE
add ellipsis to the options content

### DIFF
--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.scss
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.scss
@@ -104,6 +104,13 @@
       font-size: $rem-12px;
       min-height: 2rem;
       padding: 0 8px;
+      .text-content {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        max-width: 95%; // Ensure the text does not exceed the text-option width and check icon is visible
+        display: inline-block;
+      }
 
       &.selected {
         background-color: $modus-autocomplete-selected-option-color;

--- a/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.tsx
+++ b/stencil-workspace/src/components/modus-autocomplete/modus-autocomplete.tsx
@@ -559,7 +559,7 @@ export class ModusAutocomplete {
                     role="option"
                     onClick={() => this.handleOptionClick(option)}
                     onKeyDown={(e) => this.handleOptionKeyDown(e, option)}>
-                    {option.value}
+                    <span class="text-content">{option.value}</span>
                     {isSelected && <IconCheck size="16" />}
                   </li>
                 );


### PR DESCRIPTION
## Description

Added styles to the options listing in the dropdown, such that when the content goes beyond the width, it gets truncated and ellipsis is added.

References #3059 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
