### PR TITLE
Utility Panel: Content is not pushed in the default expanded state

### DIFF
--- a/stencil-workspace/src/components/modus-utility-panel/modus-utility-panel.spec.ts
+++ b/stencil-workspace/src/components/modus-utility-panel/modus-utility-panel.spec.ts
@@ -10,7 +10,7 @@ describe('modus-utility-panel', () => {
     expect(root).toEqualHtml(`
       <modus-utility-panel>
         <mock:shadow-root>
-          <div class="overlay utility-panel">
+          <div class="utility-panel">
             <div class="panel-content">
               <div aria-labelledby="body" class="panel-body">
                 <slot name="body"></slot>
@@ -31,7 +31,7 @@ describe('modus-utility-panel', () => {
     expect(root).toEqualHtml(`
       <modus-utility-panel expanded="true">
         <mock:shadow-root>
-          <div class="open overlay utility-panel">
+          <div class="open utility-panel">
             <div class="panel-content">
               <div aria-labelledby="body" class="panel-body">
                 <slot name="body"></slot>

--- a/stencil-workspace/src/components/modus-utility-panel/modus-utility-panel.tsx
+++ b/stencil-workspace/src/components/modus-utility-panel/modus-utility-panel.tsx
@@ -11,7 +11,7 @@ export class ModusUtilityPanel {
   @Prop() expanded = false;
 
   /** Determines if the panel pushes content or displays an overlay. */
-  @Prop() pushContent = false;
+  @Prop() pushContent = true;
 
   @Prop() targetContent: string;
 
@@ -22,6 +22,12 @@ export class ModusUtilityPanel {
   @Event() panelClosed: EventEmitter<void>;
 
   @Element() el: HTMLElement;
+
+  componentDidLoad() {
+    if (this.pushContent) {
+      this.adjustContent();
+    }
+  }
 
   @Watch('expanded')
   handleExpandedChange(newValue: boolean) {


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

References

- push content feature not working in the initial stage  

Fixes #3061  <!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
