### PR TITLE
Chip: Prevent event emit on keydown in disabled state

### DIFF
--- a/stencil-workspace/src/components/modus-chip/modus-chip.e2e.ts
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.e2e.ts
@@ -204,7 +204,7 @@ describe('modus-chip', () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-chip aria-label="test label"></modus-chip>');
-    let element = await page.find('modus-chip >>> button');
+    const element = await page.find('modus-chip >>> button');
     expect(element).toBeDefined();
     expect(element).toHaveAttribute('aria-label');
     expect(element.getAttribute('aria-label')).toEqual('test label');
@@ -214,7 +214,7 @@ describe('modus-chip', () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-chip></modus-chip>');
-    let element = await page.find('modus-chip >>> button');
+    const element = await page.find('modus-chip >>> button');
     expect(element).toBeDefined();
     expect(element).not.toHaveAttribute('aria-label');
   });
@@ -223,7 +223,7 @@ describe('modus-chip', () => {
     const page = await newE2EPage();
 
     await page.setContent('<modus-chip aria-label=""></modus-chip>');
-    let element = await page.find('modus-chip >>> button');
+    const element = await page.find('modus-chip >>> button');
     expect(element).toBeDefined();
     expect(element).not.toHaveAttribute('aria-label');
   });
@@ -236,5 +236,27 @@ describe('modus-chip', () => {
 
     const shadowContainer = await page.find('modus-chip >>> .modus-chip');
     expect(shadowContainer.classList.contains('active'));
+  });
+
+  it('should not emit chipClick event on Click when disabled', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-chip disabled></modus-chip>');
+    const chipClick = await page.spyOnEvent('chipClick');
+
+    const shadowContainer = await page.find('modus-chip >>> .modus-chip');
+    await shadowContainer.click();
+    await page.waitForChanges();
+    expect(chipClick).not.toHaveReceivedEvent();
+  });
+
+  it('should not emit chipClick event on keydown when disabled', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<modus-chip disabled></modus-chip>');
+    const chipClick = await page.spyOnEvent('chipClick');
+
+    const shadowContainer = await page.find('modus-chip >>> .modus-chip');
+    await shadowContainer.press('Enter');
+    await page.waitForChanges();
+    expect(chipClick).not.toHaveReceivedEvent();
   });
 });

--- a/stencil-workspace/src/components/modus-chip/modus-chip.tsx
+++ b/stencil-workspace/src/components/modus-chip/modus-chip.tsx
@@ -75,10 +75,9 @@ export class ModusChip {
 
   @Listen('keydown')
   elementKeydownHandler(event: KeyboardEvent): void {
-    switch (event.code) {
-      case 'Enter':
-        this.chipClick.emit(event);
-        break;
+    if (event.code === 'Enter' || event.code === 'Space') {
+      event.preventDefault();
+      this.chipClick.emit(event);
     }
   }
 
@@ -116,8 +115,9 @@ export class ModusChip {
         aria-label={this.ariaLabel || undefined}
         id={this.chipId || undefined}
         class={chipClass}
-        onClick={this.disabled ? null : (event) => this.onChipClick(event)}
-        tabIndex={0}
+        disabled={this.disabled}
+        onClick={(event) => this.onChipClick(event)}
+        tabIndex={this.disabled ? -1 : 0}
         type="button">
         {this.imageUrl ? (
           <img src={this.imageUrl} alt="" />


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

References 

This PR fixes 

1. prevents event emit / focus  on keyboard navigation
2. prevents duplicate event emission on pressing enter
3. adding event emission for space key

Fixes #3105 <!-- issue number -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

https://deploy-preview-3106--moduswebcomponents.netlify.app/

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
