### PR TITLE
Stencil Config Update: Add `externalRuntime: false`

### DIFF
--- a/stencil-workspace/stencil.config.ts
+++ b/stencil-workspace/stencil.config.ts
@@ -20,6 +20,7 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements',
+      externalRuntime: false,
       generateTypeDeclarations: false,
     },
     {


### PR DESCRIPTION
this is required for React v19... and MWC v2 has it
https://github.com/trimble-oss/modus-wc-2.0/blob/main/stencil.config.ts#L34

GitHub Copilot says this:

> The externalRuntime: false setting in your StencilJS configuration is important and should be kept.
> 
> This setting controls how the Stencil runtime is handled in your custom elements output. When set to false (as it currently is), it bundles the necessary runtime code with each component, making them more self-contained and independently usable. This means:
> 
> Each custom element will work on its own without requiring separate loading of the Stencil runtime.
> Components can be used directly in any web project without additional dependencies.
> It provides better compatibility across different environments.
> If you were to remove this setting or change it to true, you would need to separately load the Stencil runtime in projects using these components, which could complicate implementation for consumers of your library.
> 
> For a web components library like Modus Web Components that's meant to be widely usable across different projects, keeping externalRuntime: false is generally the recommended approach as it prioritizes ease of use and compatibility.