### PR TITLE
Time Picker: Fix only emitting 00 or 12 for hours when ampm property is set to true

### DIFF
--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.formatter.spec.tsx
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.formatter.spec.tsx
@@ -1,0 +1,106 @@
+import TimeInputFormatter from './modus-time-picker.formatter';
+
+describe('TimeInputFormatter', () => {
+  let formatter: TimeInputFormatter;
+  beforeEach(() => {
+    formatter = new TimeInputFormatter(false);
+  });
+  describe('parseTimeDisplay', () => {
+    describe('hasAmPm is false', () => {
+      it('should return null when input is empty', () => {
+        const result = formatter.parseTimeDisplay('');
+        expect(result).toBeNull();
+      });
+      it('should return time string when input is valid', () => {
+        const result = formatter.parseTimeDisplay('12:30');
+        expect(result).toBe('12:30');
+      });
+      it('should return time string when input is 0:00', () => {
+        const result = formatter.parseTimeDisplay('0:00');
+        expect(result).toBe('0:00');
+      });
+      it('should return time string when input is 00:59', () => {
+        const result = formatter.parseTimeDisplay('00:59');
+        expect(result).toBe('00:59');
+      });
+      it('should return time string when input is before noon', () => {
+        const result = formatter.parseTimeDisplay('11:30');
+        expect(result).toBe('11:30');
+      });
+      it('should return time string when input is 11:59', () => {
+        const result = formatter.parseTimeDisplay('11:59');
+        expect(result).toBe('11:59');
+      });
+      it('should return time string when input is noon', () => {
+        const result = formatter.parseTimeDisplay('12:00');
+        expect(result).toBe('12:00');
+      });
+      it('should return time string when input is after noon', () => {
+        const result = formatter.parseTimeDisplay('13:30');
+        expect(result).toBe('13:30');
+      });
+      it('should return time string when input is 12:59', () => {
+        const result = formatter.parseTimeDisplay('12:59');
+        expect(result).toBe('12:59');
+      });
+      it('should return time string when input is 13:00', () => {
+        const result = formatter.parseTimeDisplay('13:00');
+        expect(result).toBe('13:00');
+      });
+      it('should return time string when input is 23:59', () => {
+        const result = formatter.parseTimeDisplay('23:59');
+        expect(result).toBe('23:59');
+      });
+    });
+
+    describe('hasAmPm is true', () => {
+      beforeEach(() => {
+        formatter = new TimeInputFormatter(true);
+      });
+      it('should return null when input is empty', () => {
+        const result = formatter.parseTimeDisplay('');
+        expect(result).toBeNull();
+      });
+      it('should return time string when input is valid', () => {
+        const result = formatter.parseTimeDisplay('12:30 PM');
+        expect(result).toBe('12:30');
+      });
+      it('should return time string when input is 12:00 AM', () => {
+        const result = formatter.parseTimeDisplay('12:00 AM');
+        expect(result).toBe('00:00');
+      });
+      it('should return time string when input is 12:59 AM', () => {
+        const result = formatter.parseTimeDisplay('12:59 AM');
+        expect(result).toBe('00:59');
+      });
+      it('should return time string when input is before noon', () => {
+        const result = formatter.parseTimeDisplay('11:30 AM');
+        expect(result).toBe('11:30');
+      });
+      it('should return time string when input is 11:59 AM', () => {
+        const result = formatter.parseTimeDisplay('11:59 AM');
+        expect(result).toBe('11:59');
+      });
+      it('should return time string when input is noon', () => {
+        const result = formatter.parseTimeDisplay('12:00 PM');
+        expect(result).toBe('12:00');
+      });
+      it('should return time string when input is after noon', () => {
+        const result = formatter.parseTimeDisplay('1:30 PM');
+        expect(result).toBe('13:30');
+      });
+      it('should return time string when input is 12:59 PM', () => {
+        const result = formatter.parseTimeDisplay('12:59 PM');
+        expect(result).toBe('12:59');
+      });
+      it('should return time string when input is 1:00 PM', () => {
+        const result = formatter.parseTimeDisplay('1:00 PM');
+        expect(result).toBe('13:00');
+      });
+      it('should return time string when input is 11:59 PM', () => {
+        const result = formatter.parseTimeDisplay('11:59 PM');
+        expect(result).toBe('23:59');
+      });
+    });
+  });
+});

--- a/stencil-workspace/src/components/modus-time-picker/modus-time-picker.formatter.tsx
+++ b/stencil-workspace/src/components/modus-time-picker/modus-time-picker.formatter.tsx
@@ -102,11 +102,11 @@ export default class TimeInputFormatter {
 
     // Subtract 12 hours for 12:00 AM or midnight to 12:59 AM
     if (ampm === 'AM') {
-      editedHours = hours - hours === 12 ? 12 : 0;
+      editedHours = hours - (hours === 12 ? 12 : 0);
     }
     // Add 12 hours for 1:00 PM to 11:59 PM
     else if (ampm === 'PM') {
-      editedHours = hours + hours !== 12 ? 12 : 0;
+      editedHours = hours + (hours !== 12 ? 12 : 0);
     }
     if (editedHours >= 0 && editedHours <= 23 && (minutes === 0 || minutes > 0))
       return `${this.pad(editedHours)}:${this.pad(minutes)}`;


### PR DESCRIPTION

## Description

Fix time picker valueChange event only emitting 00 or 12 for hours when ampm property is set to true. The parseTimeDisplay was always returning a string with 00 or 12 hours regardless of the hour value.

References #3179 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added unit tests for TimeInputFormatter's parseTimeDisplay method. Tested time picker in storybook.

1. Go to https://modus-web-components.trimble.com/?path=/story/user-inputs-time-picker--time-format
2. Change the value in the time picker input
3. Verify that the valueChange event detail.value is correct on the Actions tab
4. Set the amPm property to 'false' on the Controls tab
5. Change the value in the time picker input
6. Verify that the valueChange event detail.value is correct on the Actions tab

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
