### PR TITLE
Potential fix for code scanning alert no. 31: Duplicate property

### DIFF
--- a/stencil-workspace/stylelint.config.mjs
+++ b/stencil-workspace/stylelint.config.mjs
@@ -7,7 +7,6 @@ export default {
     'color-function-notation': null,
     'declaration-property-value-keyword-no-deprecated': null,
     'declaration-block-no-redundant-longhand-properties': null,
-    'declaration-property-value-keyword-no-deprecated': null,
     'no-descending-specificity': null,
     'order/properties-alphabetical-order': true,
     'property-no-vendor-prefix': null,


### PR DESCRIPTION
Potential fix for [https://github.com/trimble-oss/modus-web-components/security/code-scanning/31](https://github.com/trimble-oss/modus-web-components/security/code-scanning/31)

To fix the issue, we need to remove the duplicate property `'declaration-property-value-keyword-no-deprecated'` from the `rules` object. Since both instances assign the same value (`null`), removing either one will not affect the functionality of the code. The best approach is to remove the second occurrence (line 10) to preserve the original order of properties in the object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
