### PR TITLE
File Dropzone: Make whole dropzone area clickable

### DIFF
--- a/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.scss
+++ b/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.scss
@@ -37,7 +37,7 @@
     justify-content: center;
     padding: $rem-12px $rem-16px;
 
-    .browse {
+    &.browse {
       color: $modus-file-upload-dropzone-browse-color;
 
       &:hover {
@@ -75,7 +75,7 @@
         fill: $modus-file-upload-dropzone-disabled-svg-color;
       }
 
-      .browse {
+      &.browse {
         color: $modus-file-upload-dropzone-disabled-color;
         cursor: not-allowed;
       }

--- a/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.tsx
+++ b/stencil-workspace/src/components/modus-file-dropzone/modus-file-dropzone.tsx
@@ -213,21 +213,16 @@ export class ModusFileDropzone {
               error: !!this.error,
               highlight: this.fileDraggedOver,
               disabled: this.disabled,
+              browse: !this.error && !this.fileDraggedOver,
             }}
             onDragLeave={(e) => this.onDragLeave(e)}
             onDragOver={(e) => this.onDragOver(e)}
             onDrop={(e) => this.onDrop(e)}
+            onClick={this.error ? undefined : this.openBrowse}
             style={{ height: this.dropzoneHeight, width: this.dropzoneWidth }}
             tabIndex={0}>
             {this.includeStateIcon && (this.error ? <IconCancel size={'36'} /> : <IconUploadCloud size={'36'} />)}
-            {!this.error &&
-              (this.fileDraggedOver ? (
-                this.fileDraggedOverInstructions
-              ) : (
-                <div class="browse" onClick={this.openBrowse}>
-                  {this.instructions}
-                </div>
-              ))}
+            {!this.error && (this.fileDraggedOver ? this.fileDraggedOverInstructions : this.instructions)}
             {this.error && (
               <div class="error-messages" role="alert">
                 {this.errorMessageTop && <span>{this.errorMessageTop}</span>}


### PR DESCRIPTION
## Description

Make the whole area clickable, opening the browse window, since just the text is a small & unintuitive target (and tailwind CSS makes the whole thing use the pointer cursor since it has role=button)

Fixes https://github.com/trimble-oss/modus-web-components/issues/3406

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

*It might be a breaking change, in that the resulting component will accept clicks where it previously wouldn't*

## How Has This Been Tested?

Story book manual tests:
- Normal state:
  - Hovering anywhere over field: Pointer
  - Clicking anywhere: Opens browse
  - Dropping a file: Works, and doesn't open browse
- Error state:
  - Hovering anywhere: Default cursor
    - Hovering over button: Pointer
  - Clicking anywhere: No action
    - Clicking button: Clears error, and doesn't open browse
- Disabled state:
  - Hovering anywhere: not-allowed cursor
  - Clicking: No action

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
